### PR TITLE
Fix `intel/llm-scaler-omni` docker image to correct version

### DIFF
--- a/omni/README.md
+++ b/omni/README.md
@@ -22,7 +22,7 @@ bash build.sh
 Run docker image:
 
 ```bash
-export DOCKER_IMAGE=intel/llm-scaler-omni:0.1-b1
+export DOCKER_IMAGE=intel/llm-scaler-omni:0.1.0-b1
 export CONTAINER_NAME=comfyui
 export MODEL_DIR=<your_model_dir>
 export COMFYUI_MODEL_DIR=<your_comfyui_model_dir>


### PR DESCRIPTION
`intel/llm-scaler-omni:0.1-b1` does not exist, only `intel/llm-scaler-omni:0.1.0-b1 `