### PR TITLE
vLLM: Add ESIMD kernels and update docker/patches for b8.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+*.egg
+dist/
+build/
+
+# Compiled extensions
+*.so
+*.o
+*.obj
+*.a
+*.lib
+*.dll
+*.dylib
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db

--- a/vllm/custom-esimd-kernels-vllm/csrc/eagle/eagle.kernels.bf16.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/eagle/eagle.kernels.bf16.h
@@ -1,0 +1,469 @@
+
+ESIMD_INLINE void causalConv1dUpdateBf16(
+  uint8_t* qkvzState,
+  uint8_t* zOut,
+  uint8_t* convW,
+  uint8_t* convB,
+  uint8_t* convState,
+  uint32_t* convStateIdx,
+  uint32_t* acceptedTokens,
+  uint32_t nTokens,
+  uint32_t headQk,
+  uint32_t headV,
+  uint32_t headDim,
+  uint32_t hiddenDim,
+  uint32_t conv_stride0,
+  sycl::nd_item<2>& ndi) {
+  constexpr uint32_t baseOffsetInc16[16] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+  constexpr int32_t convKernelSize = 4;
+  constexpr float inv128 = 1.0f / 128.0f;
+  constexpr float eps = 1e-6;
+  uint32_t totalHeads = headQk * 2 + headV;
+  uint32_t convDim = totalHeads * headDim;
+  uint32_t cachedConvStates = convKernelSize - 1 + nTokens - 1;
+  uint32_t qkDim = headDim * headQk;
+  uint32_t vzDim = headDim * headV;
+  uint32_t hsPerBatchSz = hiddenDim * nTokens;
+  uint32_t csPerBatchSz = conv_stride0;
+  uint32_t headIdx = ndi.get_group(0);
+  constexpr uint32_t tokenIdx = 0;
+  uint32_t batchIdx = ndi.get_group(1);
+  uint32_t convStateOffset = convStateIdx[batchIdx * nTokens];
+  uint32_t updateTokens = acceptedTokens[batchIdx];
+  uint32_t offsetB;
+  uint32_t offsetW;
+  uint32_t blockAddress = headIdx >> 2;
+  uint32_t whereAmI = headIdx & 0x3; // 0: q, 1: k, 2~3: v
+  uint32_t qkvBase = tokenIdx * hiddenDim + blockAddress * 6 * headDim + whereAmI * headDim + batchIdx * nTokens * hiddenDim;
+  uint32_t zBase = qkvBase + 2 * headDim;
+  uint32_t offsetCs = csPerBatchSz * convStateOffset + tokenIdx * convDim;
+  uint32_t flatHead;
+
+  if (whereAmI < 2) {
+    flatHead = whereAmI * headQk;
+    flatHead = flatHead + blockAddress;
+  }
+  else {
+    flatHead = whereAmI - 2;
+    flatHead = flatHead + blockAddress * 2;
+    flatHead = flatHead + 2 * headQk;
+  }
+
+  offsetCs = offsetCs + flatHead * headDim;
+  offsetB = flatHead * headDim;
+  offsetW = convKernelSize * flatHead * headDim;
+
+  simd<bf16, 6 * 128> fp16InputHistoric;
+  simd<bf16, 7 * 128> fp16InputCurrent;
+  simd<bf16, 4 * 128> fp16Weight;
+  simd<float, 4 * 128> fp32Output;
+  simd<float, 128> fp32W;
+  simd<float, 128> fp32In;
+  {
+    simd<bf16, 128> fp16Bias = 0;
+    if (nullptr != convB) {
+      fp16Bias.select<128, 1>(0) = block_load<bf16, 128>((bf16*)convB + offsetB);
+    }
+#pragma unroll
+    for (int32_t kk = 0; kk < 4; kk++) {
+      fp32Output.select<128, 1>(128 * kk) = fp16Bias;
+    }
+  }
+  fp16Weight = block_load<bf16, 512>((bf16*)convW + offsetW);
+#pragma unroll
+  for (int32_t kk = 0; kk < 6; kk++) {
+    if (kk < cachedConvStates) {
+      fp16InputHistoric.select<128, 1>(128 * kk) = block_load<bf16, 128>((bf16*)convState + offsetCs + convDim * kk);
+    }
+    else {
+      fp16InputHistoric.select<128, 1>(128 * kk) = 0;
+    }
+  }
+#pragma unroll
+  for (int32_t kk = 0; kk < 4; kk++) {
+    if (kk < nTokens) {
+      fp16InputCurrent.select<128, 1>(128 * kk + 128 * 3) = block_load<bf16, 128>((bf16*)qkvzState + qkvBase + hiddenDim * kk);
+    }
+    else {
+      fp16InputCurrent.select<128, 1>(128 * kk + 128 * 3) = 0;
+    }
+  }
+
+  if (updateTokens == 1) {
+    fp16InputCurrent.select<128 * 3, 1>(0) = fp16InputHistoric.select<128 * 3, 1>(0 * 128);
+  }
+  else if (updateTokens == 2) {
+    fp16InputCurrent.select<128 * 3, 1>(0) = fp16InputHistoric.select<128 * 3, 1>(1 * 128);
+  }
+  else if (updateTokens == 3) {
+    fp16InputCurrent.select<128 * 3, 1>(0) = fp16InputHistoric.select<128 * 3, 1>(2 * 128);
+  }
+  else if (updateTokens == 4) {
+    fp16InputCurrent.select<128 * 3, 1>(0) = fp16InputHistoric.select<128 * 3, 1>(3 * 128);
+  }
+
+#pragma unroll
+  for (int32_t cc = 0; cc < convKernelSize; cc++) {
+    fp32W = fp16Weight.select<128, 4>(cc);
+#pragma unroll
+    for (int32_t kk = 0; kk < 4; kk++) {
+      fp32In = fp16InputCurrent.select<128, 1>(128 * (cc + kk));
+      fp32Output.select<128, 1>(128 * kk) = fp32Output.select<128, 1>(128 * kk) + fp32In * fp32W;
+    }
+  }
+
+  // The rolling of conv state:
+  //
+  // Before forward, the conv_state is:
+  // [history1, history2, ..., historyM].
+  //
+  // After forward, the conv_state becomes:
+  // [history2, ..., historyM, draft1, draft2, ..., draftN].
+  //
+  // After acceptance, it becomes:
+  //
+  // - accept 1 tokens: [history2, ..., historyM, draft1]
+  // - accept 2 tokens: [history3, ..., historyM, draft1, draft2]
+  // - accept 3 tokens: [history4, ..., historyM, draft1, draft2, draft3]
+  // - accept 4 tokens: [history5, ..., historyM, draft1, draft2, draft3, draft4]
+  // - and so on.
+  if (updateTokens == 1) {
+#pragma unroll
+    for (int32_t kk = 0; kk < convKernelSize - 2; kk++) {
+      fp16InputHistoric.select<128, 1>(128 * kk) = fp16InputHistoric.select<128, 1>(128 * kk + 128);
+    }
+  }
+  else if (updateTokens == 2) {
+#pragma unroll
+    for (int32_t kk = 0; kk < convKernelSize - 2; kk++) {
+      fp16InputHistoric.select<128, 1>(128 * kk) = fp16InputHistoric.select<128, 1>(128 * kk + 128 * 2);
+    }
+  }
+  else if (updateTokens == 3) {
+#pragma unroll
+    for (int32_t kk = 0; kk < convKernelSize - 2; kk++) {
+      fp16InputHistoric.select<128, 1>(128 * kk) = fp16InputHistoric.select<128, 1>(128 * kk + 128 * 3);
+    }
+  }
+  else if (updateTokens == 4) {
+#pragma unroll
+    for (int32_t kk = 0; kk < convKernelSize - 2; kk++) {
+      fp16InputHistoric.select<128, 1>(128 * kk) = fp16InputHistoric.select<128, 1>(128 * kk + 128 * 4);
+    }
+  }
+
+  fp16InputHistoric.select<128 * 4, 1>(128 * 2) = fp16InputCurrent.select<128 * 4, 1>(128 * 3);
+#pragma unroll
+  for (int32_t kk = 0; kk < 6; kk++) {
+    if (kk < cachedConvStates) {
+      block_store<bf16, 128>((bf16*)convState + offsetCs + convDim * kk, fp16InputHistoric.select<128, 1>(128 * kk));
+    }
+  }
+
+  // silu
+#pragma unroll
+  for (int32_t kk = 0; kk < 4; kk++) {
+    simd<float, 128> siluT = fp32Output.select<128, 1>(128 * kk) * (-1.0f);
+    siluT = exp(siluT);
+    siluT = siluT + 1.0f;
+    siluT = 1.0f / siluT;
+    fp32Output.select<128, 1>(128 * kk) = fp32Output.select<128, 1>(128 * kk) * siluT;
+  }
+
+  // norm QK
+  if (whereAmI < 2) {
+#pragma unroll
+    for (int32_t bb = 0; bb < 4; bb++) {
+      fp32In = fp32Output.select<128, 1>(128 * bb) * fp32Output.select<128, 1>(128 * bb);
+      float acc = sycl::ext::intel::esimd::detail::sum<float, float, 128>(fp32In);
+      float scale = __ESIMD_NS::rsqrt(acc + eps);
+      fp32Output.select<128, 1>(128 * bb) = fp32Output.select<128, 1>(128 * bb) * scale;
+    }
+  }
+  else { // copy z
+#pragma unroll
+    for (int32_t kk = 0; kk < 4; kk++) {
+      if (kk < nTokens) {
+        fp16Weight.select<128, 1>(128 * kk) = block_load<bf16, 128>((bf16*)qkvzState + zBase + hiddenDim * kk);
+      }
+    }
+  }
+
+  simd<bf16, 4 * 128> fp16Output;
+  fp16Output = fp32Output;
+#pragma unroll
+  for (int32_t bb = 0; bb < 4; bb++) {
+    if (bb < nTokens) {
+      block_store<bf16, 128>((bf16*)qkvzState + qkvBase + bb * hiddenDim, fp16Output.select<128, 1>(128 * bb));
+    }
+  }
+  if (whereAmI >= 2) {
+    uint32_t zvDim = headV * headDim;
+    zBase = tokenIdx * zvDim + blockAddress * 2 * headDim + (whereAmI - 2) * headDim + batchIdx * nTokens * zvDim;
+    for (int32_t kk = 0; kk < 4; kk++) {
+      if (kk < nTokens) {
+        block_store<bf16, 128>((bf16*)zOut + zBase + kk * zvDim, fp16Weight.select<128, 1>(128 * kk));
+      }
+    }
+  }
+}
+
+ESIMD_INLINE void gdnRecurBf16(
+  uint8_t* qkvzState,
+  uint8_t* baState,
+  bf16* aLogW,
+  bf16* dtBias,
+  uint32_t* acceptedTokens,
+  uint32_t* ssmStateIdx,
+  uint8_t* lastRecurState,
+  uint8_t* outState,
+  uint32_t nTokens,
+  uint32_t headQk,
+  uint32_t headV,
+  uint32_t headDim,
+  uint32_t qkvz_stride0,
+  uint32_t ssm_stride0,
+  sycl::nd_item<2>& ndi) {
+  constexpr uint32_t baseOffsetInc16[16] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+  constexpr float softPlusBeta = 1.0f;
+  constexpr float softPlusInvBeta = 1.0f / softPlusBeta;
+  constexpr float softPlusThr = 20.0f;
+  constexpr float rsqrt128 = 0.08838834764831844f; // 1.0f / sqrt(128.0f);
+  constexpr uint32_t slmSize = 16 * 128 * sizeof(float) + 128 * sizeof(float);
+  constexpr uint32_t slmOffsetDelta = 16 * 128 * sizeof(float);
+  __ESIMD_NS::slm_init(slmSize);
+
+  uint32_t qkDim = headDim * headQk;
+  uint32_t vzDim = headDim * headV;
+  uint32_t hiddenDim = qkDim * 2 + vzDim * 2;
+  uint32_t headIdx = ndi.get_group(0);
+  uint32_t hh = ndi.get_local_id(0);
+  uint32_t bs = ndi.get_group(1);
+  uint32_t headGroup = headIdx >> 1;
+  uint32_t headSubGroup = headIdx & 0x1;
+  uint32_t acceptedId = acceptedTokens[bs];
+  uint32_t* ssmIdxPtr = ssmStateIdx + bs * nTokens;
+  simd<uint32_t, 16> simdOffsetsQk(baseOffsetInc16);
+  simd<uint32_t, 32> simdOffsetsRecur;
+  simd<uint32_t, 16> simdOffsetsV;
+  simd<uint32_t, 16> simdOffsetsBa;
+  simd<uint32_t, 16> simdOffsetsOut;
+  if (acceptedId < 1) {
+    return;
+  }
+  acceptedId = acceptedId - 1;
+  uint32_t initRecurState = ssmIdxPtr[acceptedId];
+  uint32_t offsetRecurStateBase;
+
+  simd<bf16, 8 * 4> fp16Q;
+  simd<bf16, 8 * 4> fp16K;
+  simd<float, 8 * 4> fp32Gk;
+  simd<float, 8 * 4> fp32K;
+  simd<float, 8 * 4> fp32Q;
+
+  simd<bf16, 128 * 4> fp16V;
+  simd<bf16, 128 * 8> fp16InS;
+  simd_mask<16> mask;
+  simd<bf16, 16> fp16A;
+  simd<bf16, 16>  fp16B;
+  simd<float, 16> fp32A;
+  simd<float, 16> fp32B;
+
+  bf16 fp16Alog = aLogW[headIdx];
+  bf16 fp16DtBias = dtBias[headIdx];
+  float fp32Alog;
+  float fp32DtBias;
+
+  mask = simdOffsetsQk < nTokens;
+  simdOffsetsRecur.select<16, 1>(0) = simdOffsetsQk;
+  simdOffsetsRecur.select<16, 1>(16) = simdOffsetsQk + 16;
+  simdOffsetsQk.merge(0, simdOffsetsQk >= nTokens);
+  simdOffsetsV = simdOffsetsQk;
+  simdOffsetsBa = simdOffsetsQk;
+  simdOffsetsOut = simdOffsetsQk;
+  simdOffsetsQk = simdOffsetsQk * hiddenDim + headGroup * 6 * headDim + bs * nTokens * hiddenDim;
+  simdOffsetsV = simdOffsetsV * hiddenDim + headGroup * 6 * headDim + headSubGroup * headDim + 2 * headDim + bs * nTokens * hiddenDim;
+  simdOffsetsBa = simdOffsetsBa * 2 * headV * sizeof(bf16) + headGroup * 4 * sizeof(bf16) + headSubGroup * sizeof(bf16) + bs * nTokens * 2 * headV * sizeof(bf16);
+  simdOffsetsOut = simdOffsetsOut * vzDim + headIdx * headDim + bs * nTokens * vzDim;
+  offsetRecurStateBase = headIdx * headDim * headDim * sizeof(bf16) + hh * 8 * sizeof(bf16) + initRecurState * ssm_stride0 * sizeof(bf16);
+  simdOffsetsRecur.select<32, 1>(0) = simdOffsetsRecur.select<32, 1>(0) * 128 * sizeof(bf16);
+  fp16A =
+    __ESIMD_ENS::lsc_gather<
+    bf16,
+    1,
+    __ESIMD_ENS::lsc_data_size::u16,
+    __ESIMD_ENS::cache_hint::cached,
+    __ESIMD_ENS::cache_hint::cached,
+    16,
+    uint32_t
+    >((bf16*)baState, simdOffsetsBa + 2 * sizeof(bf16));
+
+  if (hh == 0) {
+#pragma unroll
+    for (int32_t nn = 0; nn < 4; nn++) {
+      fp16V.select<128, 1>(128 * nn) = block_load<bf16, 128>((bf16*)qkvzState + simdOffsetsV[nn]);
+    }
+    fp16B =
+      __ESIMD_ENS::lsc_gather<
+      bf16,
+      1,
+      __ESIMD_ENS::lsc_data_size::u16,
+      __ESIMD_ENS::cache_hint::cached,
+      __ESIMD_ENS::cache_hint::cached,
+      16,
+      uint32_t
+      >((bf16*)baState, simdOffsetsBa);
+  }
+
+#pragma unroll
+  for (int32_t kk = 0; kk < 4; kk++) {
+    fp16InS.template bit_cast_view<uint32_t>().select<128, 1>(128 * kk) =
+      __ESIMD_ENS::lsc_gather<
+      uint32_t,
+      4,
+      __ESIMD_ENS::lsc_data_size::u32,
+      __ESIMD_ENS::cache_hint::cached,
+      __ESIMD_ENS::cache_hint::cached,
+      32,
+      uint32_t
+      >((uint32_t*)lastRecurState, simdOffsetsRecur + offsetRecurStateBase + kk * 32 * 128 * sizeof(bf16));
+  }
+
+#pragma unroll
+  for (int32_t nn = 0; nn < 4; nn++) {
+    fp16Q.select<8, 1>(8 * nn) = block_load<bf16, 8>((bf16*)qkvzState + simdOffsetsQk[nn] + hh * 8);
+    fp16K.select<8, 1>(8 * nn) = block_load<bf16, 8>((bf16*)qkvzState + simdOffsetsQk[nn] + headDim + hh * 8);
+  }
+
+  {
+    simd<float, 16> softPlusTemp;
+    fp32A = fp16A;
+    fp32DtBias = fp16DtBias;
+    fp32A.select<16, 1>(0) = fp32A.select<16, 1>(0) + fp32DtBias;
+
+    softPlusTemp = exp(fp32A * softPlusBeta);
+    softPlusTemp = softPlusInvBeta * __ESIMD_NS::log(softPlusTemp + 1.0f);
+    fp32A.merge(softPlusTemp, fp32A <= softPlusThr);
+
+    fp32Alog = fp16Alog;
+    fp32Alog = exp(fp32Alog) * (-1.0f);
+    fp32A.select<16, 1>(0) = fp32A.select<16, 1>(0) * fp32Alog;
+    fp32A = exp(fp32A);
+  }
+
+  {
+    fp32B = fp16B;
+    fp32B = fp32B * (-1.0f);
+    fp32B = exp(fp32B) + 1.0f;
+    fp32B = 1.0f / fp32B;
+  }
+
+  fp32Gk = fp16K;
+  fp32K = fp32Gk;
+  fp32Q = fp16Q;
+  fp32Q.select<32, 1>(0) = fp32Q.select<32, 1>(0) * rsqrt128;
+
+#pragma unroll
+  for (int32_t nn = 0; nn < 4; nn++) {
+    fp32Gk.select<8, 1>(8 * nn) = fp32Gk.select<8, 1>(8 * nn) * fp32A[nn];
+  }
+
+#pragma unroll
+  for (int32_t nn = 0; nn < 4; nn++) {
+    if (nn < nTokens) {
+      uint32_t storeRecurStateOffset = ssmIdxPtr[nn];
+      simd<float, 128> kvMemTemp = 0.0f;
+#pragma unroll
+      for (int32_t kk = 0; kk < 4; kk++) {
+#pragma unroll
+        for (int32_t kkk = 0; kkk < 2; kkk++) {
+          simd<float, 128> tempState1;
+          tempState1.select<32, 1>(0 * 32) = fp16InS.select<32, 2>(64 * kk + 256 * 0 + kkk);
+          tempState1.select<32, 1>(1 * 32) = fp16InS.select<32, 2>(64 * kk + 256 * 1 + kkk);
+          tempState1.select<32, 1>(2 * 32) = fp16InS.select<32, 2>(64 * kk + 256 * 2 + kkk);
+          tempState1.select<32, 1>(3 * 32) = fp16InS.select<32, 2>(64 * kk + 256 * 3 + kkk);
+          kvMemTemp.select<128, 1>(0) = kvMemTemp.select<128, 1>(0) + tempState1.select<128, 1>(0) * fp32Gk[nn * 8 + 2 * kk + kkk];
+        }
+      }
+      slm_block_store<float, 128>(hh * 128 * sizeof(float), kvMemTemp);
+      barrier();
+
+      if (hh == 0) {
+        simd<float, 128> tempState1;
+        simd<float, 128> kvMemTemp;
+
+        kvMemTemp = slm_block_load<float, 128>(0 * 128 * sizeof(float));
+#pragma unroll
+        for (int32_t kk = 1; kk < 16; kk++) {
+          tempState1 = slm_block_load<float, 128>(kk * 128 * sizeof(float));
+          kvMemTemp = kvMemTemp + tempState1;
+        }
+
+        tempState1 = fp16V.select<128, 1>(128 * nn);
+        tempState1 = tempState1 - kvMemTemp;
+
+        tempState1.select<128, 1>(0) = tempState1.select<128, 1>(0) * fp32B[nn];
+        slm_block_store<float, 128>(slmOffsetDelta, tempState1);
+      }
+
+      barrier();
+      {
+        simd<float, 128> fp32Delta;
+        simd<float, 128> fp32CurrSum = 0.0f;
+        fp32Delta = slm_block_load<float, 128>(slmOffsetDelta);
+        uint32_t outputOffset = simdOffsetsOut[nn];
+
+#pragma unroll
+        for (int32_t kk = 0; kk < 4; kk++) {
+#pragma unroll
+          for (int32_t kkk = 0; kkk < 2; kkk++) {
+            simd<float, 128> tempState1;
+            tempState1.select<32, 1>(0 * 32) = fp16InS.select<32, 2>(64 * kk + 256 * 0 + kkk);
+            tempState1.select<32, 1>(1 * 32) = fp16InS.select<32, 2>(64 * kk + 256 * 1 + kkk);
+            tempState1.select<32, 1>(2 * 32) = fp16InS.select<32, 2>(64 * kk + 256 * 2 + kkk);
+            tempState1.select<32, 1>(3 * 32) = fp16InS.select<32, 2>(64 * kk + 256 * 3 + kkk);
+            tempState1.select<128, 1>(0) = tempState1.select<128, 1>(0) * fp32A[nn];
+            tempState1.select<128, 1>(0) = tempState1.select<128, 1>(0) + fp32Delta.select<128, 1>(0) * fp32K[8 * nn + 2 * kk + kkk];
+            fp16InS.select<32, 2>(64 * kk + 256 * 0 + kkk) = tempState1.select<32, 1>(0 * 32);
+            fp16InS.select<32, 2>(64 * kk + 256 * 1 + kkk) = tempState1.select<32, 1>(1 * 32);
+            fp16InS.select<32, 2>(64 * kk + 256 * 2 + kkk) = tempState1.select<32, 1>(2 * 32);
+            fp16InS.select<32, 2>(64 * kk + 256 * 3 + kkk) = tempState1.select<32, 1>(3 * 32);
+            fp32CurrSum.select<128, 1>(0) = fp32CurrSum.select<128, 1>(0) + tempState1.select<128, 1>(0) * fp32Q[nn * 8 + 2 * kk + kkk];
+          }
+        }
+
+        slm_block_store<float, 128>(hh * 128 * sizeof(float), fp32CurrSum);
+      }
+      barrier();
+      if (hh == 0) {
+        simd<float, 128> fp32OutTemp;
+        simd<float, 128> tempState1;
+
+        fp32OutTemp = slm_block_load<float, 128>(0 * 128 * sizeof(float));
+#pragma unroll
+        for (int32_t kk = 1; kk < 16; kk++) {
+          tempState1 = slm_block_load<float, 128>(kk * 128 * sizeof(float));
+          fp32OutTemp = fp32OutTemp + tempState1;
+        }
+        simd<bf16, 128> fp16Out = fp32OutTemp;
+        block_store<bf16, 128>((bf16*)outState + simdOffsetsOut[nn], fp16Out);
+      }
+      barrier();
+
+      storeRecurStateOffset = storeRecurStateOffset * ssm_stride0;
+      storeRecurStateOffset = storeRecurStateOffset * sizeof(bf16) + headIdx * headDim * headDim * sizeof(bf16) + hh * 8 * sizeof(bf16);
+#pragma unroll
+      for (int32_t kk = 0; kk < 4; kk++) {
+        __ESIMD_ENS::lsc_scatter<
+          uint32_t,
+          4,
+          __ESIMD_ENS::lsc_data_size::u32,
+          __ESIMD_ENS::cache_hint::write_back,
+          __ESIMD_ENS::cache_hint::write_back,
+          32,
+          uint32_t
+        >((uint32_t*)lastRecurState, simdOffsetsRecur + storeRecurStateOffset + kk * 32 * 128 * sizeof(bf16), fp16InS.bit_cast_view<uint32_t>().select<128, 1>(128 * kk));
+      }
+    }
+  }
+}

--- a/vllm/custom-esimd-kernels-vllm/csrc/eagle/eagle.kernels.fp16.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/eagle/eagle.kernels.fp16.h
@@ -1,0 +1,469 @@
+
+ESIMD_INLINE void causalConv1dUpdateFp16(
+  uint8_t* qkvzState,
+  uint8_t* zOut,
+  uint8_t* convW,
+  uint8_t* convB,
+  uint8_t* convState,
+  uint32_t* convStateIdx,
+  uint32_t* acceptedTokens,
+  uint32_t nTokens,
+  uint32_t headQk,
+  uint32_t headV,
+  uint32_t headDim,
+  uint32_t hiddenDim,
+  uint32_t conv_stride0,
+  sycl::nd_item<2>& ndi) {
+  constexpr uint32_t baseOffsetInc16[16] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+  constexpr int32_t convKernelSize = 4;
+  constexpr float inv128 = 1.0f / 128.0f;
+  constexpr float eps = 1e-6;
+  uint32_t totalHeads = headQk * 2 + headV;
+  uint32_t convDim = totalHeads * headDim;
+  uint32_t cachedConvStates = convKernelSize - 1 + nTokens - 1;
+  uint32_t qkDim = headDim * headQk;
+  uint32_t vzDim = headDim * headV;
+  uint32_t hsPerBatchSz = hiddenDim * nTokens;
+  uint32_t csPerBatchSz = conv_stride0;
+  uint32_t headIdx = ndi.get_group(0);
+  constexpr uint32_t tokenIdx = 0;
+  uint32_t batchIdx = ndi.get_group(1);
+  uint32_t convStateOffset = convStateIdx[batchIdx * nTokens];
+  uint32_t updateTokens = acceptedTokens[batchIdx];
+  uint32_t offsetB;
+  uint32_t offsetW;
+  uint32_t blockAddress = headIdx >> 2;
+  uint32_t whereAmI = headIdx & 0x3; // 0: q, 1: k, 2~3: v
+  uint32_t qkvBase = tokenIdx * hiddenDim + blockAddress * 6 * headDim + whereAmI * headDim + batchIdx * nTokens * hiddenDim;
+  uint32_t zBase = qkvBase + 2 * headDim;
+  uint32_t offsetCs = csPerBatchSz * convStateOffset + tokenIdx * convDim;
+  uint32_t flatHead;
+
+  if (whereAmI < 2) {
+    flatHead = whereAmI * headQk;
+    flatHead = flatHead + blockAddress;
+  }
+  else {
+    flatHead = whereAmI - 2;
+    flatHead = flatHead + blockAddress * 2;
+    flatHead = flatHead + 2 * headQk;
+  }
+
+  offsetCs = offsetCs + flatHead * headDim;
+  offsetB = flatHead * headDim;
+  offsetW = convKernelSize * flatHead * headDim;
+
+  simd<fp16, 6 * 128> fp16InputHistoric;
+  simd<fp16, 7 * 128> fp16InputCurrent;
+  simd<fp16, 4 * 128> fp16Weight;
+  simd<float, 4 * 128> fp32Output;
+  simd<float, 128> fp32W;
+  simd<float, 128> fp32In;
+  {
+    simd<fp16, 128> fp16Bias = 0;
+    if (nullptr != convB) {
+      fp16Bias.select<128, 1>(0) = block_load<fp16, 128>((fp16*)convB + offsetB);
+    }
+#pragma unroll
+    for (int32_t kk = 0; kk < 4; kk++) {
+      fp32Output.select<128, 1>(128 * kk) = fp16Bias;
+    }
+  }
+  fp16Weight = block_load<fp16, 512>((fp16*)convW + offsetW);
+#pragma unroll
+  for (int32_t kk = 0; kk < 6; kk++) {
+    if (kk < cachedConvStates) {
+      fp16InputHistoric.select<128, 1>(128 * kk) = block_load<fp16, 128>((fp16*)convState + offsetCs + convDim * kk);
+    }
+    else {
+      fp16InputHistoric.select<128, 1>(128 * kk) = 0;
+    }
+  }
+#pragma unroll
+  for (int32_t kk = 0; kk < 4; kk++) {
+    if (kk < nTokens) {
+      fp16InputCurrent.select<128, 1>(128 * kk + 128 * 3) = block_load<fp16, 128>((fp16*)qkvzState + qkvBase + hiddenDim * kk);
+    }
+    else {
+      fp16InputCurrent.select<128, 1>(128 * kk + 128 * 3) = 0;
+    }
+  }
+
+  if (updateTokens == 1) {
+    fp16InputCurrent.select<128 * 3, 1>(0) = fp16InputHistoric.select<128 * 3, 1>(0 * 128);
+  }
+  else if (updateTokens == 2) {
+    fp16InputCurrent.select<128 * 3, 1>(0) = fp16InputHistoric.select<128 * 3, 1>(1 * 128);
+  }
+  else if (updateTokens == 3) {
+    fp16InputCurrent.select<128 * 3, 1>(0) = fp16InputHistoric.select<128 * 3, 1>(2 * 128);
+  }
+  else if (updateTokens == 4) {
+    fp16InputCurrent.select<128 * 3, 1>(0) = fp16InputHistoric.select<128 * 3, 1>(3 * 128);
+  }
+
+#pragma unroll
+  for (int32_t cc = 0; cc < convKernelSize; cc++) {
+    fp32W = fp16Weight.select<128, 4>(cc);
+#pragma unroll
+    for (int32_t kk = 0; kk < 4; kk++) {
+      fp32In = fp16InputCurrent.select<128, 1>(128 * (cc + kk));
+      fp32Output.select<128, 1>(128 * kk) = fp32Output.select<128, 1>(128 * kk) + fp32In * fp32W;
+    }
+  }
+
+  // The rolling of conv state:
+  //
+  // Before forward, the conv_state is:
+  // [history1, history2, ..., historyM].
+  //
+  // After forward, the conv_state becomes:
+  // [history2, ..., historyM, draft1, draft2, ..., draftN].
+  //
+  // After acceptance, it becomes:
+  //
+  // - accept 1 tokens: [history2, ..., historyM, draft1]
+  // - accept 2 tokens: [history3, ..., historyM, draft1, draft2]
+  // - accept 3 tokens: [history4, ..., historyM, draft1, draft2, draft3]
+  // - accept 4 tokens: [history5, ..., historyM, draft1, draft2, draft3, draft4]
+  // - and so on.
+  if (updateTokens == 1) {
+#pragma unroll
+    for (int32_t kk = 0; kk < convKernelSize - 2; kk++) {
+      fp16InputHistoric.select<128, 1>(128 * kk) = fp16InputHistoric.select<128, 1>(128 * kk + 128);
+    }
+  }
+  else if (updateTokens == 2) {
+#pragma unroll
+    for (int32_t kk = 0; kk < convKernelSize - 2; kk++) {
+      fp16InputHistoric.select<128, 1>(128 * kk) = fp16InputHistoric.select<128, 1>(128 * kk + 128 * 2);
+    }
+  }
+  else if (updateTokens == 3) {
+#pragma unroll
+    for (int32_t kk = 0; kk < convKernelSize - 2; kk++) {
+      fp16InputHistoric.select<128, 1>(128 * kk) = fp16InputHistoric.select<128, 1>(128 * kk + 128 * 3);
+    }
+  }
+  else if (updateTokens == 4) {
+#pragma unroll
+    for (int32_t kk = 0; kk < convKernelSize - 2; kk++) {
+      fp16InputHistoric.select<128, 1>(128 * kk) = fp16InputHistoric.select<128, 1>(128 * kk + 128 * 4);
+    }
+  }
+
+  fp16InputHistoric.select<128 * 4, 1>(128 * 2) = fp16InputCurrent.select<128 * 4, 1>(128 * 3);
+#pragma unroll
+  for (int32_t kk = 0; kk < 6; kk++) {
+    if (kk < cachedConvStates) {
+      block_store<fp16, 128>((fp16*)convState + offsetCs + convDim * kk, fp16InputHistoric.select<128, 1>(128 * kk));
+    }
+  }
+
+  // silu
+#pragma unroll
+  for (int32_t kk = 0; kk < 4; kk++) {
+    simd<float, 128> siluT = fp32Output.select<128, 1>(128 * kk) * (-1.0f);
+    siluT = exp(siluT);
+    siluT = siluT + 1.0f;
+    siluT = 1.0f / siluT;
+    fp32Output.select<128, 1>(128 * kk) = fp32Output.select<128, 1>(128 * kk) * siluT;
+  }
+
+  // norm QK
+  if (whereAmI < 2) {
+#pragma unroll
+    for (int32_t bb = 0; bb < 4; bb++) {
+      fp32In = fp32Output.select<128, 1>(128 * bb) * fp32Output.select<128, 1>(128 * bb);
+      float acc = sycl::ext::intel::esimd::detail::sum<float, float, 128>(fp32In);
+      float scale = __ESIMD_NS::rsqrt(acc + eps);
+      fp32Output.select<128, 1>(128 * bb) = fp32Output.select<128, 1>(128 * bb) * scale;
+    }
+  }
+  else { // copy z
+#pragma unroll
+    for (int32_t kk = 0; kk < 4; kk++) {
+      if (kk < nTokens) {
+        fp16Weight.select<128, 1>(128 * kk) = block_load<fp16, 128>((fp16*)qkvzState + zBase + hiddenDim * kk);
+      }
+    }
+  }
+
+  simd<fp16, 4 * 128> fp16Output;
+  fp16Output = fp32Output;
+#pragma unroll
+  for (int32_t bb = 0; bb < 4; bb++) {
+    if (bb < nTokens) {
+      block_store<fp16, 128>((fp16*)qkvzState + qkvBase + bb * hiddenDim, fp16Output.select<128, 1>(128 * bb));
+    }
+  }
+  if (whereAmI >= 2) {
+    uint32_t zvDim = headV * headDim;
+    zBase = tokenIdx * zvDim + blockAddress * 2 * headDim + (whereAmI - 2) * headDim + batchIdx * nTokens * zvDim;
+    for (int32_t kk = 0; kk < 4; kk++) {
+      if (kk < nTokens) {
+        block_store<fp16, 128>((fp16*)zOut + zBase + kk * zvDim, fp16Weight.select<128, 1>(128 * kk));
+      }
+    }
+  }
+}
+
+ESIMD_INLINE void gdnRecurFp16(
+  uint8_t* qkvzState,
+  uint8_t* baState,
+  fp16* aLogW,
+  fp16* dtBias,
+  uint32_t* acceptedTokens,
+  uint32_t* ssmStateIdx,
+  uint8_t* lastRecurState,
+  uint8_t* outState,
+  uint32_t nTokens,
+  uint32_t headQk,
+  uint32_t headV,
+  uint32_t headDim,
+  uint32_t qkvz_stride0,
+  uint32_t ssm_stride0,
+  sycl::nd_item<2>& ndi) {
+  constexpr uint32_t baseOffsetInc16[16] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+  constexpr float softPlusBeta = 1.0f;
+  constexpr float softPlusInvBeta = 1.0f / softPlusBeta;
+  constexpr float softPlusThr = 20.0f;
+  constexpr float rsqrt128 = 0.08838834764831844f; // 1.0f / sqrt(128.0f);
+  constexpr uint32_t slmSize = 16 * 128 * sizeof(float) + 128 * sizeof(float);
+  constexpr uint32_t slmOffsetDelta = 16 * 128 * sizeof(float);
+  __ESIMD_NS::slm_init(slmSize);
+
+  uint32_t qkDim = headDim * headQk;
+  uint32_t vzDim = headDim * headV;
+  uint32_t hiddenDim = qkDim * 2 + vzDim * 2;
+  uint32_t headIdx = ndi.get_group(0);
+  uint32_t hh = ndi.get_local_id(0);
+  uint32_t bs = ndi.get_group(1);
+  uint32_t headGroup = headIdx >> 1;
+  uint32_t headSubGroup = headIdx & 0x1;
+  uint32_t acceptedId = acceptedTokens[bs];
+  uint32_t* ssmIdxPtr = ssmStateIdx + bs * nTokens;
+  simd<uint32_t, 16> simdOffsetsQk(baseOffsetInc16);
+  simd<uint32_t, 32> simdOffsetsRecur;
+  simd<uint32_t, 16> simdOffsetsV;
+  simd<uint32_t, 16> simdOffsetsBa;
+  simd<uint32_t, 16> simdOffsetsOut;
+  if (acceptedId < 1) {
+    return;
+  }
+  acceptedId = acceptedId - 1;
+  uint32_t initRecurState = ssmIdxPtr[acceptedId];
+  uint32_t offsetRecurStateBase;
+
+  simd<fp16, 8 * 4> fp16Q;
+  simd<fp16, 8 * 4> fp16K;
+  simd<float, 8 * 4> fp32Gk;
+  simd<float, 8 * 4> fp32K;
+  simd<float, 8 * 4> fp32Q;
+
+  simd<fp16, 128 * 4> fp16V;
+  simd<fp16, 128 * 8> fp16InS;
+  simd_mask<16> mask;
+  simd<fp16, 16> fp16A;
+  simd<fp16, 16>  fp16B;
+  simd<float, 16> fp32A;
+  simd<float, 16> fp32B;
+
+  fp16 fp16Alog = aLogW[headIdx];
+  fp16 fp16DtBias = dtBias[headIdx];
+  float fp32Alog;
+  float fp32DtBias;
+
+  mask = simdOffsetsQk < nTokens;
+  simdOffsetsRecur.select<16, 1>(0) = simdOffsetsQk;
+  simdOffsetsRecur.select<16, 1>(16) = simdOffsetsQk + 16;
+  simdOffsetsQk.merge(0, simdOffsetsQk >= nTokens);
+  simdOffsetsV = simdOffsetsQk;
+  simdOffsetsBa = simdOffsetsQk;
+  simdOffsetsOut = simdOffsetsQk;
+  simdOffsetsQk = simdOffsetsQk * hiddenDim + headGroup * 6 * headDim + bs * nTokens * hiddenDim;
+  simdOffsetsV = simdOffsetsV * hiddenDim + headGroup * 6 * headDim + headSubGroup * headDim + 2 * headDim + bs * nTokens * hiddenDim;
+  simdOffsetsBa = simdOffsetsBa * 2 * headV * sizeof(fp16) + headGroup * 4 * sizeof(fp16) + headSubGroup * sizeof(fp16) + bs * nTokens * 2 * headV * sizeof(fp16);
+  simdOffsetsOut = simdOffsetsOut * vzDim + headIdx * headDim + bs * nTokens * vzDim;
+  offsetRecurStateBase = headIdx * headDim * headDim * sizeof(fp16) + hh * 8 * sizeof(fp16) + initRecurState * ssm_stride0 * sizeof(fp16);
+  simdOffsetsRecur.select<32, 1>(0) = simdOffsetsRecur.select<32, 1>(0) * 128 * sizeof(fp16);
+  fp16A =
+    __ESIMD_ENS::lsc_gather<
+    fp16,
+    1,
+    __ESIMD_ENS::lsc_data_size::u16,
+    __ESIMD_ENS::cache_hint::cached,
+    __ESIMD_ENS::cache_hint::cached,
+    16,
+    uint32_t
+    >((fp16*)baState, simdOffsetsBa + 2 * sizeof(fp16));
+
+  if (hh == 0) {
+#pragma unroll
+    for (int32_t nn = 0; nn < 4; nn++) {
+      fp16V.select<128, 1>(128 * nn) = block_load<fp16, 128>((fp16*)qkvzState + simdOffsetsV[nn]);
+    }
+    fp16B =
+      __ESIMD_ENS::lsc_gather<
+      fp16,
+      1,
+      __ESIMD_ENS::lsc_data_size::u16,
+      __ESIMD_ENS::cache_hint::cached,
+      __ESIMD_ENS::cache_hint::cached,
+      16,
+      uint32_t
+      >((fp16*)baState, simdOffsetsBa);
+  }
+
+#pragma unroll
+  for (int32_t kk = 0; kk < 4; kk++) {
+    fp16InS.template bit_cast_view<uint32_t>().select<128, 1>(128 * kk) =
+      __ESIMD_ENS::lsc_gather<
+      uint32_t,
+      4,
+      __ESIMD_ENS::lsc_data_size::u32,
+      __ESIMD_ENS::cache_hint::cached,
+      __ESIMD_ENS::cache_hint::cached,
+      32,
+      uint32_t
+      >((uint32_t*)lastRecurState, simdOffsetsRecur + offsetRecurStateBase + kk * 32 * 128 * sizeof(fp16));
+  }
+
+#pragma unroll
+  for (int32_t nn = 0; nn < 4; nn++) {
+    fp16Q.select<8, 1>(8 * nn) = block_load<fp16, 8>((fp16*)qkvzState + simdOffsetsQk[nn] + hh * 8);
+    fp16K.select<8, 1>(8 * nn) = block_load<fp16, 8>((fp16*)qkvzState + simdOffsetsQk[nn] + headDim + hh * 8);
+  }
+
+  {
+    simd<float, 16> softPlusTemp;
+    fp32A = fp16A;
+    fp32DtBias = fp16DtBias;
+    fp32A.select<16, 1>(0) = fp32A.select<16, 1>(0) + fp32DtBias;
+
+    softPlusTemp = exp(fp32A * softPlusBeta);
+    softPlusTemp = softPlusInvBeta * __ESIMD_NS::log(softPlusTemp + 1.0f);
+    fp32A.merge(softPlusTemp, fp32A <= softPlusThr);
+
+    fp32Alog = fp16Alog;
+    fp32Alog = exp(fp32Alog) * (-1.0f);
+    fp32A.select<16, 1>(0) = fp32A.select<16, 1>(0) * fp32Alog;
+    fp32A = exp(fp32A);
+  }
+
+  {
+    fp32B = fp16B;
+    fp32B = fp32B * (-1.0f);
+    fp32B = exp(fp32B) + 1.0f;
+    fp32B = 1.0f / fp32B;
+  }
+
+  fp32Gk = fp16K;
+  fp32K = fp32Gk;
+  fp32Q = fp16Q;
+  fp32Q.select<32, 1>(0) = fp32Q.select<32, 1>(0) * rsqrt128;
+
+#pragma unroll
+  for (int32_t nn = 0; nn < 4; nn++) {
+    fp32Gk.select<8, 1>(8 * nn) = fp32Gk.select<8, 1>(8 * nn) * fp32A[nn];
+  }
+
+#pragma unroll
+  for (int32_t nn = 0; nn < 4; nn++) {
+    if (nn < nTokens) {
+      uint32_t storeRecurStateOffset = ssmIdxPtr[nn];
+      simd<float, 128> kvMemTemp = 0.0f;
+#pragma unroll
+      for (int32_t kk = 0; kk < 4; kk++) {
+#pragma unroll
+        for (int32_t kkk = 0; kkk < 2; kkk++) {
+          simd<float, 128> tempState1;
+          tempState1.select<32, 1>(0 * 32) = fp16InS.select<32, 2>(64 * kk + 256 * 0 + kkk);
+          tempState1.select<32, 1>(1 * 32) = fp16InS.select<32, 2>(64 * kk + 256 * 1 + kkk);
+          tempState1.select<32, 1>(2 * 32) = fp16InS.select<32, 2>(64 * kk + 256 * 2 + kkk);
+          tempState1.select<32, 1>(3 * 32) = fp16InS.select<32, 2>(64 * kk + 256 * 3 + kkk);
+          kvMemTemp.select<128, 1>(0) = kvMemTemp.select<128, 1>(0) + tempState1.select<128, 1>(0) * fp32Gk[nn * 8 + 2 * kk + kkk];
+        }
+      }
+      slm_block_store<float, 128>(hh * 128 * sizeof(float), kvMemTemp);
+      barrier();
+
+      if (hh == 0) {
+        simd<float, 128> tempState1;
+        simd<float, 128> kvMemTemp;
+
+        kvMemTemp = slm_block_load<float, 128>(0 * 128 * sizeof(float));
+#pragma unroll
+        for (int32_t kk = 1; kk < 16; kk++) {
+          tempState1 = slm_block_load<float, 128>(kk * 128 * sizeof(float));
+          kvMemTemp = kvMemTemp + tempState1;
+        }
+
+        tempState1 = fp16V.select<128, 1>(128 * nn);
+        tempState1 = tempState1 - kvMemTemp;
+
+        tempState1.select<128, 1>(0) = tempState1.select<128, 1>(0) * fp32B[nn];
+        slm_block_store<float, 128>(slmOffsetDelta, tempState1);
+      }
+
+      barrier();
+      {
+        simd<float, 128> fp32Delta;
+        simd<float, 128> fp32CurrSum = 0.0f;
+        fp32Delta = slm_block_load<float, 128>(slmOffsetDelta);
+        uint32_t outputOffset = simdOffsetsOut[nn];
+
+#pragma unroll
+        for (int32_t kk = 0; kk < 4; kk++) {
+#pragma unroll
+          for (int32_t kkk = 0; kkk < 2; kkk++) {
+            simd<float, 128> tempState1;
+            tempState1.select<32, 1>(0 * 32) = fp16InS.select<32, 2>(64 * kk + 256 * 0 + kkk);
+            tempState1.select<32, 1>(1 * 32) = fp16InS.select<32, 2>(64 * kk + 256 * 1 + kkk);
+            tempState1.select<32, 1>(2 * 32) = fp16InS.select<32, 2>(64 * kk + 256 * 2 + kkk);
+            tempState1.select<32, 1>(3 * 32) = fp16InS.select<32, 2>(64 * kk + 256 * 3 + kkk);
+            tempState1.select<128, 1>(0) = tempState1.select<128, 1>(0) * fp32A[nn];
+            tempState1.select<128, 1>(0) = tempState1.select<128, 1>(0) + fp32Delta.select<128, 1>(0) * fp32K[8 * nn + 2 * kk + kkk];
+            fp16InS.select<32, 2>(64 * kk + 256 * 0 + kkk) = tempState1.select<32, 1>(0 * 32);
+            fp16InS.select<32, 2>(64 * kk + 256 * 1 + kkk) = tempState1.select<32, 1>(1 * 32);
+            fp16InS.select<32, 2>(64 * kk + 256 * 2 + kkk) = tempState1.select<32, 1>(2 * 32);
+            fp16InS.select<32, 2>(64 * kk + 256 * 3 + kkk) = tempState1.select<32, 1>(3 * 32);
+            fp32CurrSum.select<128, 1>(0) = fp32CurrSum.select<128, 1>(0) + tempState1.select<128, 1>(0) * fp32Q[nn * 8 + 2 * kk + kkk];
+          }
+        }
+
+        slm_block_store<float, 128>(hh * 128 * sizeof(float), fp32CurrSum);
+      }
+      barrier();
+      if (hh == 0) {
+        simd<float, 128> fp32OutTemp;
+        simd<float, 128> tempState1;
+
+        fp32OutTemp = slm_block_load<float, 128>(0 * 128 * sizeof(float));
+#pragma unroll
+        for (int32_t kk = 1; kk < 16; kk++) {
+          tempState1 = slm_block_load<float, 128>(kk * 128 * sizeof(float));
+          fp32OutTemp = fp32OutTemp + tempState1;
+        }
+        simd<fp16, 128> fp16Out = fp32OutTemp;
+        block_store<fp16, 128>((fp16*)outState + simdOffsetsOut[nn], fp16Out);
+      }
+      barrier();
+
+      storeRecurStateOffset = storeRecurStateOffset * ssm_stride0;
+      storeRecurStateOffset = storeRecurStateOffset * sizeof(fp16) + headIdx * headDim * headDim * sizeof(fp16) + hh * 8 * sizeof(fp16);
+#pragma unroll
+      for (int32_t kk = 0; kk < 4; kk++) {
+        __ESIMD_ENS::lsc_scatter<
+          uint32_t,
+          4,
+          __ESIMD_ENS::lsc_data_size::u32,
+          __ESIMD_ENS::cache_hint::write_back,
+          __ESIMD_ENS::cache_hint::write_back,
+          32,
+          uint32_t
+        >((uint32_t*)lastRecurState, simdOffsetsRecur + storeRecurStateOffset + kk * 32 * 128 * sizeof(fp16), fp16InS.bit_cast_view<uint32_t>().select<128, 1>(128 * kk));
+      }
+    }
+  }
+}

--- a/vllm/custom-esimd-kernels-vllm/csrc/eagle/eagle.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/eagle/eagle.sycl
@@ -1,0 +1,369 @@
+#include <torch/extension.h>
+#include <c10/xpu/XPUStream.h>
+#include <sycl/ext/intel/esimd.hpp>
+#include <sycl/ext/intel/experimental/esimd/memory.hpp>
+#include <random>
+#include <sstream>
+#include <fstream>
+using fp16 = sycl::half;
+using namespace sycl::ext::intel::esimd;
+using namespace sycl::ext::intel::esimd::xmx;
+namespace xesimd = sycl::ext::intel::experimental::esimd;
+using bf16 = sycl::ext::oneapi::bfloat16;
+
+static inline sycl::event submit_kernel(
+    std::function<void(sycl::handler&)> kernel,
+    const torch::Device& device,
+    const char* desc) {
+    sycl::queue& queue = c10::xpu::getCurrentXPUStream(device.index()).queue();
+    return queue.submit(kernel);
+}
+
+static inline uint32_t getHighestBit(uint32_t in) {
+  uint32_t ret = 0;
+  uint32_t temp = in - 1;
+  while (temp != 0) {
+    temp = temp >> 1;
+    ret++;
+  }
+  return ret;
+}
+
+#include "eagle.kernels.fp16.h"
+#include "eagle.kernels.bf16.h"
+#include "page.attn.h"
+
+// ── Kernel 1: MTP causal conv1d update kernel ───────────────────────────────
+void conv1d_forward_kernel(
+  uint8_t* qkvzState,
+  uint8_t* zOut,
+  uint8_t* convW,
+  uint8_t* convB,
+  uint8_t* convState,
+  uint32_t* convStateIdx,
+  uint32_t* acceptedTokens,
+  torch::ScalarType fpType,
+  uint32_t batches,
+  uint32_t nTokens,
+  uint32_t headQk,
+  uint32_t headV,
+  uint32_t headDim,
+  uint32_t qkvzStride,
+  uint32_t conv_stride0,
+  const torch::Device& device) {
+  uint32_t totalHeads = headQk * 2 + headV;
+  uint32_t convDim = totalHeads * headDim;
+  uint32_t hiddenDim = qkvzStride; // (headQk * 2 + headV * 2) * headDim;
+  uint32_t groupH = convDim >> 7;
+  uint32_t groupV = batches;
+  sycl::range<2> globalConv1d(groupH, groupV);
+  sycl::range<2> localConv1d(1, 1);
+  sycl::nd_range<2> rangeConv1d(globalConv1d, localConv1d);
+
+  std::function<void(sycl::handler&)> kernel;
+  switch (fpType) {
+    case torch::kBFloat16:
+      kernel = [&](sycl::handler& cgh) {
+        cgh.parallel_for<class eagleConv1dBf16Forward>(rangeConv1d, [=](sycl::nd_item<2> idx) SYCL_ESIMD_KERNEL{
+            causalConv1dUpdateBf16(
+              qkvzState, zOut, convW, convB, convState, convStateIdx, acceptedTokens,
+              nTokens, headQk, headV, headDim, qkvzStride, conv_stride0, idx
+            );
+          });
+        };
+
+      submit_kernel(kernel, device, "causal_conv1d_update forward");
+    break;
+    case torch::kHalf:
+      kernel = [&](sycl::handler& cgh) {
+        cgh.parallel_for<class eagleConv1dFp16Forward>(rangeConv1d, [=](sycl::nd_item<2> idx) SYCL_ESIMD_KERNEL{
+            causalConv1dUpdateFp16(
+              qkvzState, zOut, convW, convB, convState, convStateIdx, acceptedTokens,
+              nTokens, headQk, headV, headDim, qkvzStride, conv_stride0, idx
+            );
+          });
+        };
+
+      submit_kernel(kernel, device, "causal_conv1d_update forward");
+      break;
+    default:
+      break;
+  }
+}
+
+// ── Kernel 2: GDN eagle kernel ───────────────────────────────
+void gdn_eagle_forward_kernel(
+  uint8_t* qkvzState,
+  uint8_t* baState,
+  uint8_t* aLogW,
+  uint8_t* dtBias,
+  uint32_t* acceptedTokens,
+  uint32_t* ssmStateIdx,
+  uint8_t* lastRecurState,
+  uint8_t* outState,
+  torch::ScalarType fpType,
+  uint32_t batches,
+  uint32_t nTokens,
+  uint32_t headQk,
+  uint32_t headV,
+  uint32_t headDim,
+  uint32_t qkvzStride,
+  uint32_t ssm_stride0,
+  const torch::Device& device) {
+
+  sycl::range<2> globalGdnRecur(headV * 16, batches);
+  sycl::range<2> localGdnRecur(16, 1);
+  sycl::nd_range<2> rangeGdnRecur(globalGdnRecur, localGdnRecur);
+  std::function<void(sycl::handler&)> kernel;
+
+  switch (fpType) {
+  case torch::kBFloat16:
+    kernel = [&](sycl::handler& cgh) {
+      cgh.parallel_for<class eagleGdnRecurBf16Forward>(
+        rangeGdnRecur, [=](sycl::nd_item<2> idx) SYCL_ESIMD_KERNEL{
+          gdnRecurBf16(qkvzState, baState, (bf16*)aLogW, (bf16*)dtBias, acceptedTokens, ssmStateIdx, lastRecurState, outState,
+            nTokens, headQk, headV, headDim, qkvzStride, ssm_stride0, idx);
+        });
+      };
+
+    submit_kernel(kernel, device, "gdn_eagle forward");
+    break;
+  case torch::kHalf:
+    kernel = [&](sycl::handler& cgh) {
+      cgh.parallel_for<class eagleGdnRecurFp16Forward>(
+        rangeGdnRecur, [=](sycl::nd_item<2> idx) SYCL_ESIMD_KERNEL{
+          gdnRecurFp16(qkvzState, baState, (fp16*)aLogW, (fp16*)dtBias, acceptedTokens, ssmStateIdx, lastRecurState, outState,
+            nTokens, headQk, headV, headDim, qkvzStride, ssm_stride0, idx);
+        });
+      };
+
+    submit_kernel(kernel, device, "gdn_eagle forward");
+    break;
+  default:
+    break;
+  }
+}
+
+inline void dumpDeviceMem(sycl::queue& debugDumpQueue, void* deviceMem, size_t sizeDump, std::stringstream& fileDirectory) {
+  uint8_t* sysMem = (uint8_t*)malloc(sizeDump);
+  debugDumpQueue.wait();
+  debugDumpQueue.memcpy(sysMem, deviceMem, sizeDump).wait();
+  std::ofstream outFile;
+  fileDirectory << "." << sizeDump << ".dat";
+  outFile.open(fileDirectory.str().c_str(), std::ios::binary);
+  outFile.write((char*)sysMem, sizeDump);
+  outFile.close();
+  free(sysMem);
+}
+
+// ── Kernel 3: page attention kernel ───────────────────────────────
+void page_attention_forward_kernel(
+  uint8_t* qState,
+  uint8_t* kvCache,
+  uint32_t* pageTable,
+  uint32_t* kvSeqLens,
+  uint8_t* out,
+  float* pState,
+  float* pMax,
+  uint32_t batches,
+  uint32_t nTokens,
+  uint32_t headQk,
+  uint32_t headV,
+  uint32_t headDim,
+  uint32_t kvCacheStride0,
+  uint32_t kvCacheStride1,
+  uint32_t pageTableBatchStride,
+  uint32_t pageTableSizeLog2,
+  uint32_t pStride,
+  uint32_t maxStride,
+  uint32_t maxKvSeqLen,
+  const torch::Device& device) {
+  uint32_t groupH, groupV, groupD;
+  groupH = headV;
+  groupV = (maxKvSeqLen + 63) / 64;
+  groupD = batches;
+  sycl::range<3> globalPaPhase1(groupH * 4, groupV, groupD);
+  sycl::range<3> localPaPhase1(4, 1, 1);
+  sycl::nd_range<3> rangePaPhase1(globalPaPhase1, localPaPhase1);
+
+  groupH = headDim / 16;
+  groupV = headV;
+  groupD = batches;
+  sycl::range<3> globalPaPhase2(groupH * 2, groupV, groupD);
+  sycl::range<3> localPaPhase2(2, 1, 1);
+  sycl::nd_range<3> rangePaPhase2(globalPaPhase2, localPaPhase2);
+  std::function<void(sycl::handler&)> kernelPhase1;
+  std::function<void(sycl::handler&)> kernelPhase2;
+
+  kernelPhase1 = [&](sycl::handler& cgh) {
+    cgh.parallel_for<class paPhase1Forward>(
+      rangePaPhase1, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
+        sdpaDecodeGqa4Phase1(qState, kvCache, (uint8_t*)pState, pMax, pageTable, kvSeqLens,
+          batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, idx);
+      });
+    };
+
+  kernelPhase2 = [&](sycl::handler& cgh) {
+    cgh.parallel_for<class paPhase2Forward>(
+      rangePaPhase2, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
+        sdpaDecodeGqa4Phase2((uint8_t*)pState, pMax, kvCache, out, pageTable, kvSeqLens,
+          batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, idx);
+      });
+    };
+
+  submit_kernel(kernelPhase1, device, "page_attn_ph1 forward");
+  submit_kernel(kernelPhase2, device, "page_attn_ph2 forward");
+}
+
+
+torch::Tensor gdn_eagle(
+    torch::Tensor& qkvz,
+    torch::Tensor& z_out,
+    torch::Tensor conv_w,
+    const std::optional<torch::Tensor>& conv_b,
+    torch::Tensor& conv_state,
+    torch::Tensor accepted_tokens,
+    torch::Tensor ba,
+    torch::Tensor a_log,
+    torch::Tensor dt_bias,
+    torch::Tensor& state_in,
+    torch::Tensor ssm_state_idx,
+    torch::Tensor norm_w,
+    int64_t max_query_len
+) {
+    TORCH_CHECK(ssm_state_idx.dim() == 2);
+    TORCH_CHECK(qkvz.scalar_type() == torch::kBFloat16 || qkvz.scalar_type() == torch::kHalf);
+    int64_t conv_stride0 = conv_state.stride(0);
+
+    int64_t ssm_stride0 = state_in.stride(0);
+    int64_t ba_stride0 = ba.stride(0);
+    int64_t ssm_state_idx_stride0 = ssm_state_idx.stride(0);
+    uint32_t cacheIdx;
+    uint32_t* dumpTemp = nullptr;
+    uint32_t totalDims = state_in.dim();
+    uint32_t qkvzDims = qkvz.dim();
+    TORCH_CHECK(totalDims >= 3);
+    TORCH_CHECK(qkvzDims >= 2);
+
+    uint32_t hiddenDim = qkvz.size(qkvzDims - 1);
+    uint32_t qkvzStride = qkvz.stride(qkvzDims - 2);
+    uint32_t headDim = state_in.size(totalDims - 1);
+    uint32_t headV = state_in.size(totalDims - 3);
+    uint32_t batches = ssm_state_idx.size(0);
+    uint32_t nTokens = qkvz.size(qkvzDims - 2);
+    uint32_t headQk = headV >> 1;
+    TORCH_CHECK(hiddenDim == (headQk * 2 + headV * 2) * headDim);
+    TORCH_CHECK(headDim == 128);
+    TORCH_CHECK(nTokens <= 4);
+
+    torch::Tensor gdn_out = torch::empty({batches * nTokens, headV, headDim},
+        torch::device(qkvz.device()).dtype(qkvz.scalar_type()));
+
+    conv1d_forward_kernel(
+        (uint8_t*)qkvz.data_ptr(),
+        (uint8_t*)z_out.data_ptr(),
+        (uint8_t*)conv_w.data_ptr(),
+        conv_b.has_value() ? (uint8_t*)conv_b->data_ptr() : nullptr,
+        (uint8_t*)conv_state.data_ptr(),
+        (uint32_t*)ssm_state_idx.data_ptr(),
+        (uint32_t*)accepted_tokens.data_ptr(),
+        qkvz.scalar_type(),
+        batches, nTokens, headQk, headV, headDim, qkvzStride, (uint32_t)conv_stride0,
+        qkvz.device());
+
+    gdn_eagle_forward_kernel(
+        (uint8_t*)qkvz.data_ptr(),
+        (uint8_t*)ba.data_ptr(),
+        (uint8_t*)a_log.data_ptr(),
+        (uint8_t*)dt_bias.data_ptr(),
+        (uint32_t*)accepted_tokens.data_ptr(),
+        (uint32_t*)ssm_state_idx.data_ptr(),
+        (uint8_t*)state_in.data_ptr(),
+        (uint8_t*)gdn_out.data_ptr(),
+        qkvz.scalar_type(),
+        batches, nTokens, headQk, headV, headDim, qkvzStride, (uint32_t)ssm_stride0,
+        qkvz.device());
+
+    return gdn_out;
+}
+
+void page_attn_decode(
+  torch::Tensor query,
+  torch::Tensor kv_cache,
+  torch::Tensor block_table,
+  torch::Tensor seq_lens,
+  torch::Tensor& out,
+  int64_t max_query_len,
+  int64_t max_seq_len
+) {
+  TORCH_CHECK(block_table.dim() == 2);
+  TORCH_CHECK(seq_lens.dim() == 1);
+  TORCH_CHECK(kv_cache.dim() == 5);
+  TORCH_CHECK(query.scalar_type() == torch::kHalf);
+  TORCH_CHECK(kv_cache.scalar_type() == torch::kHalf);
+  TORCH_CHECK(out.scalar_type() == torch::kHalf);
+
+  uint32_t kvCacheStride0 = kv_cache.stride(0);
+  uint32_t kvCacheStride1 = kv_cache.stride(1);
+  uint32_t totalDimsKv = kv_cache.dim();
+
+  uint32_t headDim = kv_cache.size(totalDimsKv - 1);
+  uint32_t headV = kv_cache.size(totalDimsKv - 2);
+  uint32_t pageSize = kv_cache.size(totalDimsKv - 3);
+  uint32_t batches = seq_lens.size(0);
+  uint32_t headQk = headV << 2;
+  uint32_t maxSeqLen = max_seq_len;
+  uint32_t hiddenDimP = ((maxSeqLen + 63) / 64) * 64;
+  uint32_t hiddenDimPMax = ((maxSeqLen + 63) / 64);
+  uint32_t nTokens = 1;
+  uint32_t pageTableSizeLog2 = getHighestBit(pageSize);
+  uint32_t pageTableBatchStride = block_table.stride(0);
+
+  TORCH_CHECK(headDim == 256);
+  TORCH_CHECK(max_query_len == 1);
+
+  torch::Tensor temp_p = torch::empty({ batches, headQk, hiddenDimP + hiddenDimPMax },
+    torch::device(kv_cache.device()).dtype(torch::kFloat32));
+
+  size_t offsetMax = batches * headQk * hiddenDimP;
+  float* pState = (float*)temp_p.data_ptr();
+  float* pMax = pState + offsetMax;
+
+  page_attention_forward_kernel(
+    (uint8_t*)query.data_ptr(),
+    (uint8_t*)kv_cache.data_ptr(),
+    (uint32_t*)block_table.data_ptr(),
+    (uint32_t*)seq_lens.data_ptr(),
+    (uint8_t*)out.data_ptr(),
+    pState,
+    pMax,
+    batches,
+    nTokens,
+    headQk,
+    headV,
+    headDim,
+    kvCacheStride0,
+    kvCacheStride1,
+    pageTableBatchStride,
+    pageTableSizeLog2,
+    hiddenDimP,
+    hiddenDimPMax,
+    maxSeqLen,
+    kv_cache.device()
+  );
+}
+
+TORCH_LIBRARY_FRAGMENT(eagle_ops, m) {
+    m.def("gdn_eagle(Tensor! qkvz, Tensor! z_out, Tensor conv_w, Tensor? conv_b, Tensor! conv_state, Tensor accepted_tokens, Tensor ba, Tensor a_log, Tensor dt_bias, Tensor! state_in, Tensor ssm_state_idx, Tensor norm_w, int max_query_len) -> Tensor");
+    m.def("page_attn_decode(Tensor query, Tensor kv_cache, Tensor block_table, Tensor seq_lens, Tensor! out, int max_query_len, int max_seq_len) -> ()");
+}
+
+TORCH_LIBRARY_IMPL(eagle_ops, XPU, m) {
+    m.impl("gdn_eagle", &gdn_eagle);
+    m.impl("page_attn_decode", &page_attn_decode);
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("gdn_eagle", &gdn_eagle, "gdn_eagle");
+    m.def("page_attn_decode", &page_attn_decode, "page_attn_decode");
+}

--- a/vllm/custom-esimd-kernels-vllm/csrc/eagle/page.attn.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/eagle/page.attn.h
@@ -1,0 +1,385 @@
+#define FP32_MIN (-1e+38)
+// kv cache shape [2 (k/v), reserved size, page_size, head_num, head_dim]
+// kv cache strid: [2 * page_size * head_num * head_dim, page_size * head_num * head_dim, head_dim, head_dim, 1]
+ESIMD_INLINE void sdpaDecodeGqa4Phase1(
+  uint8_t* qState,
+  uint8_t* kState,
+  uint8_t* pState,
+  float* pMax,
+  uint32_t* pageTable,
+  uint32_t* batchKvSeqLen,
+  uint32_t batchSize,
+  uint32_t kvCacheBatchStride0, 
+  uint32_t kvCacheBatchStride1,
+  uint32_t pageTableBatchStride,
+  uint32_t pageTableSizeLog2,
+  uint32_t pStride,
+  uint32_t maxStride,
+  uint32_t headKv,
+  sycl::nd_item<3>& ndi) {
+  constexpr uint32_t baseOffsetInc16[16] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+  constexpr float matMulQuantCoeff = 0.0625f;
+  constexpr uint32_t gqaRatio = 4;
+  constexpr uint32_t headDim = 256;
+  constexpr uint32_t maxPGroupOut = 128;
+  constexpr uint32_t outputPerGroup = 64;
+  constexpr uint32_t slmSize = (4 * maxPGroupOut * gqaRatio * sizeof(float));
+  constexpr uint32_t loopCount = outputPerGroup / 16;
+  __ESIMD_NS::slm_init(slmSize);
+  int localLinearId = ndi.get_local_id(0);
+  int globalLinearId0 = ndi.get_group(0); // [0, kvHead)
+  int globalLinearId1 = ndi.get_group(1); // [0, keSeqLen / 64)
+  int globalLinearId2 = ndi.get_group(2); // [0, bs)
+  int hh = localLinearId & 0x3;
+  int vv = localLinearId >> 2;
+  int batchIdx = globalLinearId2;
+  int qHeadIdx = globalLinearId0 * 4;
+  uint32_t pageTableSize = 1 << pageTableSizeLog2;
+  uint32_t pageTableLoopMask = pageTableSize - 1;
+  uint32_t kvSeqLen = batchKvSeqLen[batchIdx];
+  uint32_t pageTableBase = pageTableBatchStride * batchIdx;
+  simd<uint32_t, 16> simdOffsetsK;
+
+  simd<uint32_t, 16> baseOffsetInc16AsSimd(baseOffsetInc16);
+  simd<float, 64 * 4> qqFp32;
+  simd<fp16, 64 * 4> qqFp16;
+  simd<float, 16 * 4> ppFp32;
+  simd<fp16, 16 * 64> kkCache;
+  simd<float, 1> ppMax;
+
+  uint32_t headQ = headKv * gqaRatio;
+  uint64_t outputOffset = qHeadIdx * pStride + globalLinearId1 * outputPerGroup + hh * pStride + batchIdx * headQ * pStride;
+  uint32_t outputMaxOffset = qHeadIdx * maxStride + globalLinearId1 + hh * maxStride + batchIdx * headQ * maxStride;
+  uint32_t offsetQ = qHeadIdx * headDim * sizeof(fp16) + hh * 32 * sizeof(fp16) + batchIdx * headQ * headDim * sizeof(fp16);
+  uint32_t baseCoordK = globalLinearId1 * outputPerGroup;
+  uint32_t offsetBaseK = hh * 32 * sizeof(fp16) + headDim * globalLinearId0 * sizeof(fp16);
+  uint32_t kvSeqOffset = baseCoordK;
+
+  if (baseCoordK >= kvSeqLen) {
+    return;
+  }
+
+#pragma unroll
+  for (int qn = 0; qn < 4; qn++) {
+#pragma unroll
+    for (int qk = 0; qk < 2; qk++) {
+      qqFp16.template bit_cast_view<uint8_t>().select<64, 1>(128 * qn + 64 * qk) =
+        __ESIMD_ENS::lsc_block_load<
+        uint8_t,
+        64,
+        __ESIMD_ENS::lsc_data_size::default_size,
+        __ESIMD_ENS::cache_hint::cached,
+        __ESIMD_ENS::cache_hint::cached>((uint8_t*)qState + offsetQ + qn * headDim * sizeof(fp16) + qk * 4 * 32 * sizeof(fp16));
+    }
+  }
+
+  qqFp32 = qqFp16;
+
+#pragma unroll
+  for (int loopIdx = 0; loopIdx < loopCount; loopIdx++) {
+    ppFp32 = 0.0f;
+    if (kvSeqOffset < kvSeqLen) {
+      uint32_t pageTableIdx = kvSeqOffset >> pageTableSizeLog2;
+      uint32_t pageTableOffset = kvSeqOffset & pageTableLoopMask;
+      uint32_t pageIdx = pageTable[pageTableBase + pageTableIdx];
+      simd<uint16_t, 16> mask;
+      simd<uint16_t, 16> maskNeg;
+      simd<float, 16 * 32> kkFp32;
+      simd<uint32_t, 16> logicSimdOffsetK;
+      logicSimdOffsetK = baseOffsetInc16AsSimd + kvSeqOffset;
+      mask = logicSimdOffsetK < kvSeqLen;
+      maskNeg = logicSimdOffsetK >= kvSeqLen;
+      simdOffsetsK = baseOffsetInc16AsSimd;
+
+      simdOffsetsK = 
+        simdOffsetsK * headKv * headDim * sizeof(fp16) +
+        offsetBaseK +
+        pageIdx * kvCacheBatchStride1 * sizeof(fp16) +
+        pageTableOffset * headKv * headDim * sizeof(fp16)
+        ;
+
+#pragma unroll
+      for (int kk = 0; kk < 2; kk++) {
+#pragma unroll
+        for (int kkk = 0; kkk < 4; kkk++) {
+          kkCache.template bit_cast_view<uint32_t>().select<64, 1>(256 * kk + 64 * kkk) =
+            __ESIMD_ENS::lsc_gather<
+            uint32_t,
+            4,
+            __ESIMD_ENS::lsc_data_size::u32,
+            __ESIMD_ENS::cache_hint::cached,
+            __ESIMD_ENS::cache_hint::cached,
+            16,
+            uint32_t
+            >((uint32_t*)kState, simdOffsetsK, mask);
+          simdOffsetsK += 8 * sizeof(fp16);
+        }
+
+        simdOffsetsK += 3 * 32 * sizeof(fp16);
+
+#pragma unroll
+        for (int kkk = 0; kkk < 16; kkk++) {
+          kkFp32.select<16, 1>(32 * kkk + 16 * 0) = kkCache.select<16, 2>(512 * kk + 32 * kkk + 0);
+          kkFp32.select<16, 1>(32 * kkk + 16 * 1) = kkCache.select<16, 2>(512 * kk + 32 * kkk + 1);
+        }
+
+#pragma unroll
+        for (int kkk = 0; kkk < 32; kkk++) {
+#pragma unroll
+          for (int pn = 0; pn < 4; pn++) {
+            ppFp32.select<16, 1>(16 * pn) = ppFp32.select<16, 1>(16 * pn) + kkFp32.select<16, 1>(16 * kkk) * qqFp32[64 * pn + 32 * kk + kkk];
+          }
+        }
+      }
+
+#pragma unroll
+      for (int pn = 0; pn < 4; pn++) {
+        ppFp32.select<16, 1>(pn * 16).merge(FP32_MIN, maskNeg);
+      }
+    }
+    else {
+      ppFp32 = FP32_MIN;
+    }
+
+#pragma unroll
+    for (int pn = 0; pn < 4; pn++) {
+      slm_block_store<float, 16>(
+        loopIdx * 4 * 64 * sizeof(float) +
+        pn * 64 * sizeof(float) +
+        hh * 16 * sizeof(float),
+        ppFp32.select<16, 1>(16 * pn));
+    }
+    kvSeqOffset += 16;
+  }
+
+  barrier();
+
+  {
+    simd<float, 16 * 4> ppOut;
+    simd<float, 16> maxTemp;
+    simd<float, 64> ppTemp;
+#pragma unroll
+    for (int pk = 0; pk < 4; pk++) {
+      ppTemp = slm_block_load<float, 64>(pk * 64 * 4 * sizeof(float) + hh * 64 * sizeof(float));
+#pragma unroll
+      for (int pn = 0; pn < 1; pn++) {
+        ppOut.select<16, 1>(4 * 16 * pn + 16 * pk) = ppTemp.select<16, 1>(64 * pn) + ppTemp.select<16, 1>(64 * pn + 16);
+        ppOut.select<16, 1>(4 * 16 * pn + 16 * pk) = ppOut.select<16, 1>(4 * 16 * pn + 16 * pk) + ppTemp.select<16, 1>(64 * pn + 32);
+        ppOut.select<16, 1>(4 * 16 * pn + 16 * pk) = ppOut.select<16, 1>(4 * 16 * pn + 16 * pk) + ppTemp.select<16, 1>(64 * pn + 48);
+      }
+    }
+
+    ppOut = ppOut * matMulQuantCoeff;
+    maxTemp = ppOut.select<16, 1>(0);
+#pragma unroll
+    for (int pk = 1; pk < 4; pk++) {
+      maxTemp = __ESIMD_NS::max<float, 16, float>(maxTemp, ppOut.select<16, 1>(16 * pk));
+    }
+
+    maxTemp.select<8, 1>(0) = __ESIMD_NS::max<float, 8, float>(maxTemp.select<8, 1>(0), maxTemp.select<8, 1>(8));
+    maxTemp.select<4, 1>(0) = __ESIMD_NS::max<float, 4, float>(maxTemp.select<4, 1>(0), maxTemp.select<4, 1>(4));
+    maxTemp.select<2, 1>(0) = __ESIMD_NS::max<float, 2, float>(maxTemp.select<2, 1>(0), maxTemp.select<2, 1>(2));
+    ppMax[0] = __ESIMD_NS::max<float>(maxTemp[0], maxTemp[1]);
+    ppOut.select<64, 1>(0) = ppOut.select<64, 1>(0) - ppMax[0];
+    ppOut = __ESIMD_NS::pow<float, 64, float>(2.718281828459f, ppOut);
+
+    {
+      block_store<float, 64>((float*)pState + outputOffset, ppOut.select<64, 1>(0));
+
+      pMax[outputMaxOffset] = ppMax[0];
+      outputOffset += pStride;
+      outputMaxOffset += maxStride;
+    }
+  }
+}
+
+ESIMD_INLINE void sdpaDecodeGqa4Phase2(
+  uint8_t* pState,
+  float* pMax,
+  uint8_t* vState,
+  uint8_t* out,
+  uint32_t* pageTable,
+  uint32_t* batchKvSeqLen,
+  uint32_t batchSize,
+  uint32_t kvCacheBatchStride0,
+  uint32_t kvCacheBatchStride1,
+  uint32_t pageTableBatchStride,
+  uint32_t pageTableSizeLog2,
+  uint32_t pStride,
+  uint32_t maxStride,
+  uint32_t headKv,
+  sycl::nd_item<3>& ndi) {
+  constexpr uint32_t gqaRatio = 4;
+  constexpr uint32_t headDim = 256;
+  constexpr uint32_t maxPGroupOut = 128;
+  constexpr uint32_t outputPerGroup = 64;
+  constexpr float matMulQuantCoeff = 0.0625f;
+  constexpr uint32_t slmSizeOut = 2 * gqaRatio * 16 * sizeof(float);
+  constexpr uint32_t slmSizeSoftmaxSum = 2 * gqaRatio * sizeof(float);
+  constexpr uint32_t slmSize = slmSizeOut + slmSizeSoftmaxSum;
+  __ESIMD_NS::slm_init(slmSize);
+  int localLinearId = ndi.get_local_id(0);
+  int globalLinearId0 = ndi.get_group(0); // [0, head dim / 16)
+  int globalLinearId1 = ndi.get_group(1); // [0, kvHead)
+  int globalLinearId2 = ndi.get_group(2); // [0, bs)
+  int hh = localLinearId & 0x1;
+  int vv = localLinearId >> 1;
+  int batchIdx = globalLinearId2;
+  uint32_t kvSeqLen = batchKvSeqLen[batchIdx];
+  int kvSeqOutLoopCount = (kvSeqLen + 0x3f) >> 6;
+  uint32_t pageTableSize = 1 << pageTableSizeLog2;
+  uint32_t pageTableLoopMask = (1 << pageTableSizeLog2) - 1;
+  uint32_t pageTableBase = pageTableBatchStride * batchIdx;
+  simd<uint32_t, 32> simdOffsetsVs;
+  simd<float, 4 * 32> ppFp32;
+  simd<float, 4> historicMax;
+  simd<fp16, 32 * 16> vvCache;
+  simd<float, 16 * 16> vvFp32;
+  simd<float, 4 * 16> softmaxSum;
+  simd<float, 4 * 16> outputFp32;
+  simd<float, 32> vvScale;
+
+  uint32_t headQ = headKv * gqaRatio;
+  uint32_t outputOffset = globalLinearId1 * gqaRatio * headDim + globalLinearId0 * 16 + hh * 2 * headDim + batchIdx * headQ * headDim;
+  uint32_t offsetP = globalLinearId1 * gqaRatio * pStride + hh * 32 + batchIdx * headQ * pStride;
+  uint32_t offsetMax = globalLinearId1 * gqaRatio * maxStride + batchIdx * headQ * maxStride;
+  uint32_t widthV = headKv * headDim * sizeof(fp16) - 1;
+  uint32_t heightV = pageTableSize - 1;
+  uint32_t vX = globalLinearId0 * 16 + headDim * globalLinearId1;
+  uint32_t vY = 32 * hh;
+  uint32_t totalPages = (kvSeqLen + pageTableSize - 1) >> pageTableSizeLog2;
+  uint32_t lastPageHeight = (kvSeqLen - 1) & (pageTableSize - 1);
+  if (kvSeqLen == 0) {
+    lastPageHeight = 0;
+  }
+  fp16* vPtrBase = (fp16*)vState + kvCacheBatchStride0;
+
+  historicMax = FP32_MIN * matMulQuantCoeff;
+  softmaxSum = 0;
+  outputFp32 = 0;
+
+  for (int loopIdx = 0; loopIdx < kvSeqOutLoopCount; loopIdx++) {
+    simd<float, 4> loopMax;
+    simd<float, 4> currMax;
+    simd<float, 4> compensationP;
+    simd<float, 4> compensationO;
+    simd<uint16_t, 32> mask;
+    uint32_t kvSeqOffset = loopIdx * 64;
+    uint32_t pageTableIdx = kvSeqOffset >> pageTableSizeLog2;
+    uint32_t pageTableOffset = kvSeqOffset & pageTableLoopMask;
+    uint32_t pageIdx = pageTable[pageTableBase + pageTableIdx];
+    uint32_t pageOffset = pageIdx * kvCacheBatchStride1;
+    fp16* currPtrV = vPtrBase + pageOffset;
+    if (pageTableIdx + 1 < totalPages) {
+      heightV = pageTableSize - 1;
+    }
+    else {
+      heightV = lastPageHeight;
+    }
+    vY = pageTableOffset + 32 * hh;
+
+#pragma unroll
+    for (int pn = 0; pn < 4; pn++) {
+      ppFp32.select<32, 1>(32 * pn) = block_load<float, 32>((float*)pState + offsetP + pStride * pn);
+      currMax[pn] = pMax[offsetMax + maxStride * pn];
+    }
+
+    vvCache.select<256, 1>(0 * 256) =
+      __ESIMD_ENS::lsc_load_2d<
+      fp16,
+      16,
+      16,
+      1,
+      false,
+      false,
+      __ESIMD_ENS::cache_hint::cached,
+      __ESIMD_ENS::cache_hint::cached
+      >(currPtrV, widthV, heightV, widthV, vX, vY);
+    vY += 16;
+
+    vvCache.select<256, 1>(1 * 256) =
+      __ESIMD_ENS::lsc_load_2d<
+      fp16,
+      16,
+      16,
+      1,
+      false,
+      false,
+      __ESIMD_ENS::cache_hint::cached,
+      __ESIMD_ENS::cache_hint::cached>
+      (currPtrV, widthV, heightV, widthV, vX, vY);
+
+    loopMax = __ESIMD_NS::max<float, 4, float>(currMax, historicMax);
+    compensationO = historicMax - loopMax;
+    compensationP = currMax - loopMax;
+    compensationO = exp(compensationO);
+    compensationP = exp(compensationP);
+
+#pragma unroll
+    for (int oc = 0; oc < 4; oc++) {
+      ppFp32.select<32, 1>(32 * oc) = ppFp32.select<32, 1>(32 * oc) * compensationP[oc];
+    }
+
+#pragma unroll
+    for (int oc = 0; oc < 4; oc++) {
+      outputFp32.select<16, 1>(16 * oc) = outputFp32.select<16, 1>(16 * oc) * compensationO[oc];
+      softmaxSum.select<16, 1>(16 * oc) = softmaxSum.select<16, 1>(16 * oc) * compensationO[oc];
+    }
+
+#pragma unroll
+    for (int oc = 0; oc < 4; oc++) {
+#pragma unroll
+      for (int pk = 0; pk < 2; pk++)
+        softmaxSum.select<16, 1>(16 * oc) = softmaxSum.select<16, 1>(16 * oc) + ppFp32.select<16, 1>(32 * oc + 16 * pk);
+    }
+
+#pragma unroll
+    for (int vk = 0; vk < 2; vk++) {
+      vvFp32 = vvCache.select<256, 1>(256 * vk);
+#pragma unroll
+      for (int oc = 0; oc < 4; oc++) {
+#pragma unroll
+        for (int pk = 0; pk < 16; pk++) {
+          outputFp32.select<16, 1>(16 * oc) += vvFp32.select<16, 1>(16 * pk) * ppFp32[32 * oc + 16 * vk + pk];
+        }
+      }
+    }
+
+    historicMax = loopMax;
+    offsetP += 64;
+    offsetMax += 1;
+  }
+
+#pragma unroll
+  for (int32_t kk = 0; kk < 4; kk++) {
+    slm_block_store<float, 16>(hh * 16 * sizeof(float) + 32 * kk * sizeof(float), outputFp32.select<16, 1>(16 * kk));
+  }
+
+#pragma unroll
+  for (int32_t kk = 0; kk < 4; kk++) {
+    float slmTempSoftmaxSum;
+    slmTempSoftmaxSum = __ESIMD_DNS::sum<float, float, 16>(softmaxSum.select<16, 1>(16 * kk));
+    slm_block_store<float, 1>(slmSizeOut + hh * sizeof(float) + 2 * kk * sizeof(float), slmTempSoftmaxSum);
+  }
+
+  barrier();
+
+  {
+    simd<float, 4> dividor;
+    simd<float, 64> outputTempFp32;
+    dividor = slm_block_load<float, 4>(slmSizeOut + hh * 4 * sizeof(float));
+    dividor.select<2, 2>(0) = dividor.select<2, 2>(0) + dividor.select<2, 2>(1);
+    dividor = 1.0f / dividor;
+    outputTempFp32 = slm_block_load<float, 64>(hh * 4 * 16 * sizeof(float));
+#pragma unroll
+    for (int oc = 0; oc < 2; oc++) {
+      outputFp32.select<16, 1>(16 * oc) = outputTempFp32.select<16, 1>(32 * oc) + outputTempFp32.select<16, 1>(32 * oc + 16);
+      outputFp32.select<16, 1>(16 * oc) = outputFp32.select<16, 1>(16 * oc) * dividor[2 * oc];
+    }
+    simd<fp16, 32> outputTemp = outputFp32.select<32, 1>(0);
+#pragma unroll
+    for (int oc = 0; oc < 2; oc++) {
+      block_store<fp16, 16>((fp16*)out + outputOffset + oc * headDim, outputTemp.select<16, 1>(16 * oc));
+    }
+  }
+}

--- a/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe.sycl
@@ -1,0 +1,1355 @@
+#include <torch/extension.h>
+#include <c10/xpu/XPUStream.h>
+#include <sycl/ext/intel/esimd.hpp>
+#include <sycl/ext/intel/experimental/esimd/memory.hpp>
+
+using fp16 = sycl::half;
+using namespace sycl::ext::intel::esimd;
+using namespace sycl::ext::intel::esimd::xmx;
+namespace xesimd = sycl::ext::intel::experimental::esimd;
+
+static inline sycl::event submit_kernel(
+    std::function<void(sycl::handler&)> kernel,
+    const torch::Device& device,
+    const char* desc) {
+    sycl::queue& queue = c10::xpu::getCurrentXPUStream(device.index()).queue();
+    return queue.submit(kernel);
+}
+
+// ── FP8 E4M3 → half conversion ───────────────────────────────────────────────
+template<int N>
+SYCL_ESIMD_FUNCTION
+simd<fp16, N> fp8e4m3_to_half(simd<uint8_t, N> raw) {
+    simd<uint32_t, N> val = convert<uint32_t>(raw);
+    simd<uint32_t, N> s = val >> 7;
+    simd<uint32_t, N> e = (val >> 3) & 0xF;
+    simd<uint32_t, N> m = val & 0x7;
+
+    simd<uint32_t, N> fp32_bits = (s << 31) | ((e + 120) << 23) | (m << 20);
+
+    simd<float, N> sub_val = convert<float>(m) * (1.0f / 512.0f);
+    simd<uint32_t, N> sub_bits = sub_val.template bit_cast_view<uint32_t>();
+    sub_bits = sub_bits | (s << 31);
+
+    fp32_bits.merge(sub_bits, e == 0);
+    fp32_bits.merge(s << 31, (e == 0) & (m == 0));
+
+    return fp32_bits.template bit_cast_view<float>();
+}
+
+// ── FP8 E5M2 → half conversion ───────────────────────────────────────────────
+template<int N>
+SYCL_ESIMD_FUNCTION
+simd<fp16, N> fp8e5m2_to_half(simd<uint8_t, N> raw) {
+    simd<uint16_t, N> u16 = convert<uint16_t>(raw);
+    simd<uint16_t, N> fp8_sign = (u16 >> 7) & 1;
+    simd<uint16_t, N> fp16_bits;
+
+    simd<uint16_t, N> fp8_exp  = (u16 >> 2) & 0x1F;
+    simd<uint16_t, N> fp8_mant = u16 & 0x3;
+    fp16_bits = (fp8_sign << 15) | (fp8_exp << 10) | (fp8_mant << 8);
+    fp16_bits.merge(fp8_sign << 15, fp8_exp == 0);
+
+    return fp16_bits.template bit_cast_view<fp16>();
+}
+
+// ── FP8 [16,16] block → DPAS b_tile (VNNI-packed fp16) ──────────────────────
+// Input:  raw uint8[256] = row-major [16 K-rows, 16 N-cols] FP8
+// Output: fp16[256] in VNNI uint32 layout: u32[kp*16+n] = {fp16[2*kp,n], fp16[2*kp+1,n]}
+SYCL_ESIMD_FUNCTION
+simd<fp16, 256> fp8e4m3_block_to_vnni(simd<uint8_t, 256> raw) {
+    simd<fp16, 256> w = fp8e4m3_to_half<256>(raw);
+    simd<uint32_t, 128> vnni;
+    #pragma unroll
+    for (int kp = 0; kp < 8; kp++) {
+        simd<uint16_t, 16> even_u16 = w.select<16, 1>(2*kp*16).template bit_cast_view<uint16_t>().read();
+        simd<uint16_t, 16> odd_u16  = w.select<16, 1>((2*kp+1)*16).template bit_cast_view<uint16_t>().read();
+        vnni.select<16, 1>(kp*16) =
+            convert<uint32_t>(even_u16) | (convert<uint32_t>(odd_u16) << 16);
+    }
+    return vnni.template bit_cast_view<fp16>();
+}
+
+SYCL_ESIMD_FUNCTION
+simd<fp16, 256> fp8e5m2_block_to_vnni(simd<uint8_t, 256> raw) {
+    simd<fp16, 256> w = fp8e5m2_to_half<256>(raw);
+    simd<uint32_t, 128> vnni;
+    #pragma unroll
+    for (int kp = 0; kp < 8; kp++) {
+        simd<uint16_t, 16> even_u16 = w.select<16, 1>(2*kp*16).template bit_cast_view<uint16_t>().read();
+        simd<uint16_t, 16> odd_u16  = w.select<16, 1>((2*kp+1)*16).template bit_cast_view<uint16_t>().read();
+        vnni.select<16, 1>(kp*16) =
+            convert<uint32_t>(even_u16) | (convert<uint32_t>(odd_u16) << 16);
+    }
+    return vnni.template bit_cast_view<fp16>();
+}
+
+// ── Kernel 1: Router GEMV ────────────────────────────────────────────────────
+// Hybrid dispatch:
+//   n_tokens <= 4: Option A — 1 WI per expert, weight-reuse across tokens
+//                  (4 hardcoded accumulators, fits in GRF without spill)
+//   n_tokens >  4: Option C — 1 WI per (token, expert), max parallelism
+//                  (1 accumulator per WI, no register pressure)
+
+// -- Option A: weight-reuse, 1 WI per expert, n_tokens <= 4 --
+void moe_router_forward_e4m3_kernel(
+    const fp16* x,
+    const uint8_t* weight,
+    const float* scale,
+    fp16* output,
+    const int n_tokens, const int hidden_size, const int num_experts,
+    const torch::Device& device) {
+
+    auto cgf = [&](sycl::handler& cgh) {
+        cgh.parallel_for<class MoeRouterForwardE4M3>(
+            sycl::range<1>(num_experts),
+            [=](sycl::id<1> idx) SYCL_ESIMD_KERNEL {
+                const int row = (int)idx[0];
+                fp16 s = fp16(scale[0]);
+
+                simd<float, 64> acc0(0.f), acc1(0.f), acc2(0.f), acc3(0.f);
+
+                for (int k = 0; k < hidden_size; k += 64) {
+                    simd<fp16, 64> wv = fp8e4m3_to_half<64>(
+                        block_load<uint8_t, 64>(
+                            weight + (size_t)row * hidden_size + k)) * s;
+
+                    simd<fp16, 64> xv0 = block_load<fp16, 64>(x + k);
+                    acc0 += convert<float>(xv0 * wv);
+
+                    if (n_tokens > 1) {
+                        simd<fp16, 64> xv1 = block_load<fp16, 64>(x + (size_t)1 * hidden_size + k);
+                        acc1 += convert<float>(xv1 * wv);
+                    }
+                    if (n_tokens > 2) {
+                        simd<fp16, 64> xv2 = block_load<fp16, 64>(x + (size_t)2 * hidden_size + k);
+                        acc2 += convert<float>(xv2 * wv);
+                    }
+                    if (n_tokens > 3) {
+                        simd<fp16, 64> xv3 = block_load<fp16, 64>(x + (size_t)3 * hidden_size + k);
+                        acc3 += convert<float>(xv3 * wv);
+                    }
+                }
+
+                output[0 * num_experts + row] = fp16(sycl::ext::intel::esimd::detail::sum<float, float, 64>(acc0));
+                if (n_tokens > 1)
+                    output[1 * num_experts + row] = fp16(sycl::ext::intel::esimd::detail::sum<float, float, 64>(acc1));
+                if (n_tokens > 2)
+                    output[2 * num_experts + row] = fp16(sycl::ext::intel::esimd::detail::sum<float, float, 64>(acc2));
+                if (n_tokens > 3)
+                    output[3 * num_experts + row] = fp16(sycl::ext::intel::esimd::detail::sum<float, float, 64>(acc3));
+            });
+    };
+
+    submit_kernel(cgf, device, "moe router forward e4m3");
+}
+
+void moe_router_forward_e5m2_kernel(
+    const fp16* x,
+    const uint8_t* weight,
+    const float* scale,
+    fp16* output,
+    const int n_tokens, const int hidden_size, const int num_experts,
+    const torch::Device& device) {
+
+    auto cgf = [&](sycl::handler& cgh) {
+        cgh.parallel_for<class MoeRouterForwardE5M2>(
+            sycl::range<1>(num_experts),
+            [=](sycl::id<1> idx) SYCL_ESIMD_KERNEL {
+                const int row = (int)idx[0];
+                float s = scale[0];
+
+                simd<float, 64> acc0(0.f), acc1(0.f), acc2(0.f), acc3(0.f);
+
+                for (int k = 0; k < hidden_size; k += 64) {
+                    simd<fp16, 64> wv = fp8e5m2_to_half<64>(
+                        block_load<uint8_t, 64>(
+                            weight + (size_t)row * hidden_size + k)) * (fp16)s;
+
+                    simd<fp16, 64> xv0 = block_load<fp16, 64>(x + k);
+                    acc0 = acc0 + xv0 * wv;
+
+                    if (n_tokens > 1) {
+                        simd<fp16, 64> xv1 = block_load<fp16, 64>(x + (size_t)1 * hidden_size + k);
+                        acc1 = acc1 + xv1 * wv;
+                    }
+                    if (n_tokens > 2) {
+                        simd<fp16, 64> xv2 = block_load<fp16, 64>(x + (size_t)2 * hidden_size + k);
+                        acc2 = acc2 + xv2 * wv;
+                    }
+                    if (n_tokens > 3) {
+                        simd<fp16, 64> xv3 = block_load<fp16, 64>(x + (size_t)3 * hidden_size + k);
+                        acc3 = acc3 + xv3 * wv;
+                    }
+                }
+
+                output[0 * num_experts + row] = fp16(sycl::ext::intel::esimd::detail::sum<float, float, 64>(acc0));
+                if (n_tokens > 1)
+                    output[1 * num_experts + row] = fp16(sycl::ext::intel::esimd::detail::sum<float, float, 64>(acc1));
+                if (n_tokens > 2)
+                    output[2 * num_experts + row] = fp16(sycl::ext::intel::esimd::detail::sum<float, float, 64>(acc2));
+                if (n_tokens > 3)
+                    output[3 * num_experts + row] = fp16(sycl::ext::intel::esimd::detail::sum<float, float, 64>(acc3));
+            });
+    };
+
+    submit_kernel(cgf, device, "moe router forward e5m2");
+}
+
+// -- Option C: 1 WI per (token, expert), n_tokens > 4 --
+void moe_router_forward_e4m3_wide_kernel(
+    const fp16* x,
+    const uint8_t* weight,
+    const float* scale,
+    fp16* output,
+    const int n_tokens, const int hidden_size, const int num_experts,
+    const torch::Device& device) {
+
+    auto cgf = [&](sycl::handler& cgh) {
+        cgh.parallel_for<class MoeRouterForwardE4M3Wide>(
+            sycl::range<2>(n_tokens, num_experts),
+            [=](sycl::id<2> idx) SYCL_ESIMD_KERNEL {
+                const int token = (int)idx[0];
+                const int row   = (int)idx[1];
+                fp16 s = fp16(scale[0]);
+
+                simd<float, 64> acc(0.f);
+                for (int k = 0; k < hidden_size; k += 64) {
+                    simd<fp16, 64> wv = fp8e4m3_to_half<64>(
+                        block_load<uint8_t, 64>(
+                            weight + (size_t)row * hidden_size + k)) * s;
+                    simd<fp16, 64> xv = block_load<fp16, 64>(
+                        x + (size_t)token * hidden_size + k);
+                    acc += convert<float>(xv * wv);
+                }
+
+                output[token * num_experts + row] = fp16(
+                    sycl::ext::intel::esimd::detail::sum<float, float, 64>(acc));
+            });
+    };
+
+    submit_kernel(cgf, device, "moe router forward e4m3 wide");
+}
+
+void moe_router_forward_e5m2_wide_kernel(
+    const fp16* x,
+    const uint8_t* weight,
+    const float* scale,
+    fp16* output,
+    const int n_tokens, const int hidden_size, const int num_experts,
+    const torch::Device& device) {
+
+    auto cgf = [&](sycl::handler& cgh) {
+        cgh.parallel_for<class MoeRouterForwardE5M2Wide>(
+            sycl::range<2>(n_tokens, num_experts),
+            [=](sycl::id<2> idx) SYCL_ESIMD_KERNEL {
+                const int token = (int)idx[0];
+                const int row   = (int)idx[1];
+                float s = scale[0];
+
+                simd<float, 64> acc(0.f);
+                for (int k = 0; k < hidden_size; k += 64) {
+                    simd<fp16, 64> wv = fp8e5m2_to_half<64>(
+                        block_load<uint8_t, 64>(
+                            weight + (size_t)row * hidden_size + k)) * (fp16)s;
+                    simd<fp16, 64> xv = block_load<fp16, 64>(
+                        x + (size_t)token * hidden_size + k);
+                    acc = acc + xv * wv;
+                }
+
+                output[token * num_experts + row] = fp16(
+                    sycl::ext::intel::esimd::detail::sum<float, float, 64>(acc));
+            });
+    };
+
+    submit_kernel(cgf, device, "moe router forward e5m2 wide");
+}
+
+// -- Host dispatch: hybrid A/C based on n_tokens --
+torch::Tensor moe_router_forward(
+    torch::Tensor x,
+    torch::Tensor weight,
+    torch::Tensor scale) {
+
+    TORCH_CHECK(x.dim() == 2);
+    TORCH_CHECK(x.is_contiguous());
+    TORCH_CHECK(x.scalar_type() == torch::kHalf);
+    TORCH_CHECK(scale.scalar_type() == torch::kFloat32);
+
+    int n_tokens = x.size(0);
+    int hidden_size = x.size(1);
+    int num_experts = weight.size(0);
+
+    TORCH_CHECK(hidden_size % 64 == 0);
+    TORCH_CHECK(weight.size(1) == hidden_size);
+
+    torch::Tensor output = torch::empty({n_tokens, num_experts},
+        torch::device(x.device()).dtype(torch::kHalf));
+
+    const fp16* x_ptr = (const fp16*)x.data_ptr();
+    const uint8_t* w_ptr = (const uint8_t*)weight.data_ptr();
+    float* s_ptr = scale.data_ptr<float>();
+    fp16* o_ptr = (fp16*)output.data_ptr();
+
+    if (n_tokens <= 4) {
+        // Option A: weight-reuse, 4 hardcoded accumulators (no spill)
+        switch (weight.scalar_type()) {
+            case at::kFloat8_e4m3fn:
+                moe_router_forward_e4m3_kernel(
+                    x_ptr, w_ptr, s_ptr, o_ptr,
+                    n_tokens, hidden_size, num_experts, x.device());
+                break;
+            case at::kFloat8_e5m2:
+                moe_router_forward_e5m2_kernel(
+                    x_ptr, w_ptr, s_ptr, o_ptr,
+                    n_tokens, hidden_size, num_experts, x.device());
+                break;
+            default:
+                TORCH_CHECK(false, "unsupported weight dtype, only float8_e4m3fn and float8_e5m2 are supported");
+        }
+    } else {
+        // Option C: 1 WI per (token, expert), no register pressure
+        switch (weight.scalar_type()) {
+            case at::kFloat8_e4m3fn:
+                moe_router_forward_e4m3_wide_kernel(
+                    x_ptr, w_ptr, s_ptr, o_ptr,
+                    n_tokens, hidden_size, num_experts, x.device());
+                break;
+            case at::kFloat8_e5m2:
+                moe_router_forward_e5m2_wide_kernel(
+                    x_ptr, w_ptr, s_ptr, o_ptr,
+                    n_tokens, hidden_size, num_experts, x.device());
+                break;
+            default:
+                TORCH_CHECK(false, "unsupported weight dtype, only float8_e4m3fn and float8_e5m2 are supported");
+        }
+    }
+
+    return output;
+}
+
+// ── Kernel 2: Fused Gate+Up+SiLU ─────────────────────────────────────────────
+// Routed experts: gate_up_weight [num_experts, hidden_size, 2*intermediate_size] FP8 (gather)
+// Shared experts: shared_gate_up_weight [num_shared_experts, 2*intermediate_size, hidden_size] FP8 (block_load)
+
+// -- Routed expert up kernels (DPAS + 2D load + SLM reduction) --
+// Weight layout: gate_up_weight [num_experts, hidden_size, 2*intermediate_size] FP8
+// Grid dim0 = n_tokens * top_k (flattened token+route), dim1 = n_tiles * GS
+void moe_up_routed_e4m3_kernel(
+    const fp16* x,
+    const uint8_t* gate_up_weight, const float* gate_up_scale,
+    const int* selected_experts,
+    fp16* intermediates,
+    const int n_tokens, const int hidden_size, const int intermediate_size,
+    const int top_k, const int rows_per_token,
+    const torch::Device& device) {
+
+    constexpr int GS = 16;
+    const int two_inter = 2 * intermediate_size;
+    const int n_tiles = intermediate_size / 16;
+
+    auto cgf = [&](sycl::handler& cgh) {
+        cgh.parallel_for<class MoeUpRoutedE4M3>(
+            sycl::nd_range<2>(
+                sycl::range<2>(n_tokens * top_k, n_tiles * GS),
+                sycl::range<2>(1, GS)),
+            [=](sycl::nd_item<2> item) SYCL_ESIMD_KERNEL {
+                slm_init<GS * 32 * sizeof(float)>();
+
+                const int route_idx = (int)item.get_global_id(0);
+                const int token     = route_idx / top_k;
+                const int k_idx     = route_idx % top_k;
+                const int n_tile    = (int)item.get_group(1);
+                const int tid       = (int)item.get_local_id(1);
+
+                const fp16* x_row = x + (size_t)token * hidden_size;
+                const int eid = selected_experts[route_idx];
+                const uint8_t* base = gate_up_weight + (size_t)eid * hidden_size * two_inter;
+                const int ng = n_tile * 16;
+                const int nu = intermediate_size + ng;
+                simd<float, 16> g_acc(0.f), u_acc(0.f);
+
+                for (int k = 16 * tid; k < hidden_size; k += 16 * GS) {
+                    simd<fp16, 16> a_tile = block_load<fp16, 16>(x_row + k);
+
+                    xesimd::config_2d_mem_access<uint8_t, 16, 16, 1> pgW(
+                        base, (uint32_t)two_inter - 1u, (uint32_t)hidden_size - 1u,
+                        (uint32_t)two_inter - 1u, (uint32_t)ng, (uint32_t)k);
+                    auto rg = xesimd::lsc_load_2d<uint8_t, 16, 16, 1, false, false,
+                        xesimd::cache_hint::cached, xesimd::cache_hint::cached>(pgW);
+                    simd<fp16, 256> bg = fp8e4m3_block_to_vnni(rg);
+                    g_acc = dpas<8, 1, float, float, fp16, fp16>(g_acc, bg, a_tile);
+
+                    xesimd::config_2d_mem_access<uint8_t, 16, 16, 1> puW(
+                        base, (uint32_t)two_inter - 1u, (uint32_t)hidden_size - 1u,
+                        (uint32_t)two_inter - 1u, (uint32_t)nu, (uint32_t)k);
+                    auto ru = xesimd::lsc_load_2d<uint8_t, 16, 16, 1, false, false,
+                        xesimd::cache_hint::cached, xesimd::cache_hint::cached>(puW);
+                    simd<fp16, 256> bu = fp8e4m3_block_to_vnni(ru);
+                    u_acc = dpas<8, 1, float, float, fp16, fp16>(u_acc, bu, a_tile);
+                }
+
+                uint32_t slm_off = (uint32_t)(tid * 32) * 4u;
+                slm_block_store<float, 16>(slm_off, g_acc);
+                slm_block_store<float, 16>(slm_off + 64u, u_acc);
+
+                barrier();
+
+                if (tid == 0) {
+                    simd<float, 16> gs(0.f), us(0.f);
+                    #pragma unroll
+                    for (int i = 0; i < GS; i++) {
+                        gs += slm_block_load<float, 16>((uint32_t)(i * 128));
+                        us += slm_block_load<float, 16>((uint32_t)(i * 128 + 64));
+                    }
+
+                    float scale = gate_up_scale[eid];
+                    gs *= scale;
+                    us *= scale;
+
+                    simd<float, 16> silu = gs / (1.f + exp(-gs));
+                    simd<float, 16> result = silu * us;
+
+                    const int routed_row = token * rows_per_token + k_idx;
+                    block_store<fp16, 16>(
+                        intermediates + (size_t)routed_row * intermediate_size + ng,
+                        convert<fp16>(result));
+                }
+            });
+    };
+
+    submit_kernel(cgf, device, "moe up routed e4m3");
+}
+
+void moe_up_routed_e5m2_kernel(
+    const fp16* x,
+    const uint8_t* gate_up_weight, const float* gate_up_scale,
+    const int* selected_experts,
+    fp16* intermediates,
+    const int n_tokens, const int hidden_size, const int intermediate_size,
+    const int top_k, const int rows_per_token,
+    const torch::Device& device) {
+
+    constexpr int GS = 16;
+    const int two_inter = 2 * intermediate_size;
+    const int n_tiles = intermediate_size / 16;
+
+    auto cgf = [&](sycl::handler& cgh) {
+        cgh.parallel_for<class MoeUpRoutedE5M2>(
+            sycl::nd_range<2>(
+                sycl::range<2>(n_tokens * top_k, n_tiles * GS),
+                sycl::range<2>(1, GS)),
+            [=](sycl::nd_item<2> item) SYCL_ESIMD_KERNEL {
+                slm_init<GS * 32 * sizeof(float)>();
+
+                const int route_idx = (int)item.get_global_id(0);
+                const int token     = route_idx / top_k;
+                const int k_idx     = route_idx % top_k;
+                const int n_tile    = (int)item.get_group(1);
+                const int tid       = (int)item.get_local_id(1);
+
+                const fp16* x_row = x + (size_t)token * hidden_size;
+                const int eid = selected_experts[route_idx];
+                const uint8_t* base = gate_up_weight + (size_t)eid * hidden_size * two_inter;
+                const int ng = n_tile * 16;
+                const int nu = intermediate_size + ng;
+                simd<float, 16> g_acc(0.f), u_acc(0.f);
+
+                for (int k = 16 * tid; k < hidden_size; k += 16 * GS) {
+                    simd<fp16, 16> a_tile = block_load<fp16, 16>(x_row + k);
+
+                    xesimd::config_2d_mem_access<uint8_t, 16, 16, 1> pgW(
+                        base, (uint32_t)two_inter - 1u, (uint32_t)hidden_size - 1u,
+                        (uint32_t)two_inter - 1u, (uint32_t)ng, (uint32_t)k);
+                    auto rg = xesimd::lsc_load_2d<uint8_t, 16, 16, 1, false, false,
+                        xesimd::cache_hint::cached, xesimd::cache_hint::cached>(pgW);
+                    simd<fp16, 256> bg = fp8e5m2_block_to_vnni(rg);
+                    g_acc = dpas<8, 1, float, float, fp16, fp16>(g_acc, bg, a_tile);
+
+                    xesimd::config_2d_mem_access<uint8_t, 16, 16, 1> puW(
+                        base, (uint32_t)two_inter - 1u, (uint32_t)hidden_size - 1u,
+                        (uint32_t)two_inter - 1u, (uint32_t)nu, (uint32_t)k);
+                    auto ru = xesimd::lsc_load_2d<uint8_t, 16, 16, 1, false, false,
+                        xesimd::cache_hint::cached, xesimd::cache_hint::cached>(puW);
+                    simd<fp16, 256> bu = fp8e5m2_block_to_vnni(ru);
+                    u_acc = dpas<8, 1, float, float, fp16, fp16>(u_acc, bu, a_tile);
+                }
+
+                uint32_t slm_off = (uint32_t)(tid * 32) * 4u;
+                slm_block_store<float, 16>(slm_off, g_acc);
+                slm_block_store<float, 16>(slm_off + 64u, u_acc);
+
+                barrier();
+
+                if (tid == 0) {
+                    simd<float, 16> gs(0.f), us(0.f);
+                    #pragma unroll
+                    for (int i = 0; i < GS; i++) {
+                        gs += slm_block_load<float, 16>((uint32_t)(i * 128));
+                        us += slm_block_load<float, 16>((uint32_t)(i * 128 + 64));
+                    }
+
+                    float scale = gate_up_scale[eid];
+                    gs *= scale;
+                    us *= scale;
+
+                    simd<float, 16> silu = gs / (1.f + exp(-gs));
+                    simd<float, 16> result = silu * us;
+
+                    const int routed_row = token * rows_per_token + k_idx;
+                    block_store<fp16, 16>(
+                        intermediates + (size_t)routed_row * intermediate_size + ng,
+                        convert<fp16>(result));
+                }
+            });
+    };
+
+    submit_kernel(cgf, device, "moe up routed e5m2");
+}
+
+// -- Shared expert up kernels --
+void moe_up_shared_e4m3_kernel(
+    const fp16* x,
+    const uint8_t* shared_gate_up_weight, const float* shared_gate_up_scale,
+    fp16* intermediates,
+    const int n_tokens, const int hidden_size, const int intermediate_size,
+    const int top_k, const int num_shared_experts, const int rows_per_token,
+    const torch::Device& device) {
+
+    const int two_inter = 2 * intermediate_size;
+
+    auto cgf = [&](sycl::handler& cgh) {
+        cgh.parallel_for<class MoeUpSharedE4M3>(
+            sycl::range<2>(n_tokens * num_shared_experts, intermediate_size),
+            [=](sycl::id<2> idx) SYCL_ESIMD_KERNEL {
+                const int idx0  = (int)idx[0];
+                const int token = idx0 / num_shared_experts;
+                const int sid   = idx0 % num_shared_experts;
+                const int row   = (int)idx[1];
+
+                const fp16* x_row = x + (size_t)token * hidden_size;
+                const uint8_t* gw = shared_gate_up_weight + (size_t)sid * two_inter * hidden_size
+                                                           + (size_t)row * hidden_size;
+                const uint8_t* uw = shared_gate_up_weight + (size_t)sid * two_inter * hidden_size
+                                                           + (size_t)(intermediate_size + row) * hidden_size;
+                fp16 s = fp16(shared_gate_up_scale[sid]);
+
+                simd<float, 64> ag(0.f), au(0.f);
+                for (int k = 0; k < hidden_size; k += 64) {
+                    auto xv = block_load<fp16, 64>(x_row + k);
+                    auto g_dq = fp8e4m3_to_half<64>(block_load<uint8_t, 64>(gw + k)) * s;
+                    auto u_dq = fp8e4m3_to_half<64>(block_load<uint8_t, 64>(uw + k)) * s;
+                    ag += convert<float>(xv * g_dq);
+                    au += convert<float>(xv * u_dq);
+                }
+
+                float gv = sycl::ext::intel::esimd::detail::sum<float, float, 64>(ag);
+                float uv = sycl::ext::intel::esimd::detail::sum<float, float, 64>(au);
+
+                float silu_g = gv / (1.f + exp(simd<float, 1>(-gv))[0]);
+                const int shared_row = token * rows_per_token + top_k + sid;
+                intermediates[(size_t)shared_row * intermediate_size + row] = fp16(silu_g * uv);
+            });
+    };
+
+    submit_kernel(cgf, device, "moe up shared e4m3");
+}
+
+void moe_up_shared_e5m2_kernel(
+    const fp16* x,
+    const uint8_t* shared_gate_up_weight, const float* shared_gate_up_scale,
+    fp16* intermediates,
+    const int n_tokens, const int hidden_size, const int intermediate_size,
+    const int top_k, const int num_shared_experts, const int rows_per_token,
+    const torch::Device& device) {
+
+    const int two_inter = 2 * intermediate_size;
+
+    auto cgf = [&](sycl::handler& cgh) {
+        cgh.parallel_for<class MoeUpSharedE5M2>(
+            sycl::range<2>(n_tokens * num_shared_experts, intermediate_size),
+            [=](sycl::id<2> idx) SYCL_ESIMD_KERNEL {
+                const int idx0  = (int)idx[0];
+                const int token = idx0 / num_shared_experts;
+                const int sid   = idx0 % num_shared_experts;
+                const int row   = (int)idx[1];
+
+                const fp16* x_row = x + (size_t)token * hidden_size;
+                const uint8_t* gw = shared_gate_up_weight + (size_t)sid * two_inter * hidden_size
+                                                           + (size_t)row * hidden_size;
+                const uint8_t* uw = shared_gate_up_weight + (size_t)sid * two_inter * hidden_size
+                                                           + (size_t)(intermediate_size + row) * hidden_size;
+                fp16 s = fp16(shared_gate_up_scale[sid]);
+
+                simd<float, 64> ag(0.f), au(0.f);
+                for (int k = 0; k < hidden_size; k += 64) {
+                    auto xv = block_load<fp16, 64>(x_row + k);
+                    auto g_dq = fp8e5m2_to_half<64>(block_load<uint8_t, 64>(gw + k)) * s;
+                    auto u_dq = fp8e5m2_to_half<64>(block_load<uint8_t, 64>(uw + k)) * s;
+                    ag += convert<float>(xv * g_dq);
+                    au += convert<float>(xv * u_dq);
+                }
+
+                float gv = sycl::ext::intel::esimd::detail::sum<float, float, 64>(ag);
+                float uv = sycl::ext::intel::esimd::detail::sum<float, float, 64>(au);
+
+                float silu_g = gv / (1.f + exp(simd<float, 1>(-gv))[0]);
+                const int shared_row = token * rows_per_token + top_k + sid;
+                intermediates[(size_t)shared_row * intermediate_size + row] = fp16(silu_g * uv);
+            });
+    };
+
+    submit_kernel(cgf, device, "moe up shared e5m2");
+}
+
+torch::Tensor moe_up_forward(
+    torch::Tensor x,
+    torch::Tensor gate_up_weight, torch::Tensor gate_up_scale,
+    torch::Tensor shared_gate_up_weight, torch::Tensor shared_gate_up_scale,
+    torch::Tensor selected_experts,
+    int64_t top_k, int64_t num_shared_experts) {
+
+    TORCH_CHECK(x.dim() == 2);
+    TORCH_CHECK(x.is_contiguous());
+    TORCH_CHECK(x.scalar_type() == torch::kHalf);
+    TORCH_CHECK(selected_experts.scalar_type() == torch::kInt32);
+    TORCH_CHECK(selected_experts.is_contiguous());
+
+    int n_tokens = x.size(0);
+    int hidden_size = x.size(1);
+    int intermediate_size = gate_up_weight.size(2) / 2;
+    int rows_per_token = top_k + num_shared_experts;
+
+    TORCH_CHECK(hidden_size % 64 == 0);
+    TORCH_CHECK(gate_up_weight.size(1) == hidden_size);
+    TORCH_CHECK(gate_up_weight.size(2) % 2 == 0);
+    TORCH_CHECK(selected_experts.numel() == n_tokens * top_k);
+
+    torch::Tensor intermediates = torch::empty(
+        {n_tokens * rows_per_token, intermediate_size},
+        torch::device(x.device()).dtype(torch::kHalf));
+
+    const fp16* x_ptr = (const fp16*)x.data_ptr();
+    fp16* inter_ptr = (fp16*)intermediates.data_ptr();
+
+    switch (gate_up_weight.scalar_type()) {
+        case at::kFloat8_e4m3fn:
+            moe_up_routed_e4m3_kernel(
+                x_ptr,
+                (const uint8_t*)gate_up_weight.data_ptr(), gate_up_scale.data_ptr<float>(),
+                selected_experts.data_ptr<int>(),
+                inter_ptr,
+                n_tokens, hidden_size, intermediate_size,
+                top_k, rows_per_token, x.device());
+            moe_up_shared_e4m3_kernel(
+                x_ptr,
+                (const uint8_t*)shared_gate_up_weight.data_ptr(), shared_gate_up_scale.data_ptr<float>(),
+                inter_ptr,
+                n_tokens, hidden_size, intermediate_size,
+                top_k, num_shared_experts, rows_per_token, x.device());
+            break;
+        case at::kFloat8_e5m2:
+            moe_up_routed_e5m2_kernel(
+                x_ptr,
+                (const uint8_t*)gate_up_weight.data_ptr(), gate_up_scale.data_ptr<float>(),
+                selected_experts.data_ptr<int>(),
+                inter_ptr,
+                n_tokens, hidden_size, intermediate_size,
+                top_k, rows_per_token, x.device());
+            moe_up_shared_e5m2_kernel(
+                x_ptr,
+                (const uint8_t*)shared_gate_up_weight.data_ptr(), shared_gate_up_scale.data_ptr<float>(),
+                inter_ptr,
+                n_tokens, hidden_size, intermediate_size,
+                top_k, num_shared_experts, rows_per_token, x.device());
+            break;
+        default: TORCH_CHECK(false, "unsupported weight dtype");
+    }
+
+    return intermediates;
+}
+
+// ── Kernel 3: Down projection ────────────────────────────────────────────────
+// Routed experts: down_weight [num_experts, intermediate_size, hidden_size] FP8 (gather)
+// Shared experts: shared_down_weight [num_shared_experts, hidden_size, intermediate_size] FP8 (block_load)
+
+// -- Routed expert down kernels (DPAS + 2D load + SLM reduction) --
+// Weight layout: down_weight [num_experts, intermediate_size, hidden_size] FP8
+// Grid dim0 = n_tokens * top_k, dim1 = n_tiles * GS
+void moe_down_routed_e4m3_kernel(
+    const fp16* intermediates,
+    const uint8_t* down_weight, const float* down_scale,
+    const fp16* routing_weights, const int* selected_experts,
+    fp16* output,
+    const int n_tokens, const int hidden_size, const int intermediate_size,
+    const int top_k, const int rows_per_token,
+    const torch::Device& device) {
+
+    const int n_tiles = hidden_size / 16;
+
+    auto cgf = [&](sycl::handler& cgh) {
+        cgh.parallel_for<class MoeDownRoutedE4M3>(
+            sycl::range<2>(n_tokens * top_k, n_tiles),
+            [=](sycl::item<2> item) SYCL_ESIMD_KERNEL {
+                const int route_idx = (int)item.get_id(0);
+                const int n_tile    = (int)item.get_id(1);
+                const int token     = route_idx / top_k;
+                const int k_idx     = route_idx % top_k;
+
+                const int eid = selected_experts[route_idx];
+                const int routed_row = token * rows_per_token + k_idx;
+                const uint8_t* base = down_weight + (size_t)eid * intermediate_size * hidden_size;
+                const fp16* hi = intermediates + (size_t)routed_row * intermediate_size;
+                const int nj = n_tile * 16;
+                simd<float, 16> acc(0.f);
+
+                // Single thread does all K iterations (intermediate_size/16 = 8 DPAS ops)
+                // No SLM, no barrier — eliminates sync overhead for small K
+                for (int k = 0; k < intermediate_size; k += 16) {
+                    simd<fp16, 16> a_tile = block_load<fp16, 16>(hi + k);
+
+                    xesimd::config_2d_mem_access<uint8_t, 16, 16, 1> payW(
+                        base, (uint32_t)hidden_size - 1u, (uint32_t)intermediate_size - 1u,
+                        (uint32_t)hidden_size - 1u, (uint32_t)nj, (uint32_t)k);
+                    auto raw = xesimd::lsc_load_2d<uint8_t, 16, 16, 1, false, false,
+                        xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payW);
+                    simd<fp16, 256> b_tile = fp8e4m3_block_to_vnni(raw);
+                    acc = dpas<8, 1, float, float, fp16, fp16>(acc, b_tile, a_tile);
+                }
+
+                float w = (float)routing_weights[route_idx];
+                float ds = down_scale[eid];
+                acc *= w * ds;
+
+                block_store<fp16, 16>(
+                    output + (size_t)routed_row * hidden_size + nj,
+                    convert<fp16>(acc));
+            });
+    };
+
+    submit_kernel(cgf, device, "moe down routed e4m3");
+}
+
+void moe_down_routed_e5m2_kernel(
+    const fp16* intermediates,
+    const uint8_t* down_weight, const float* down_scale,
+    const fp16* routing_weights, const int* selected_experts,
+    fp16* output,
+    const int n_tokens, const int hidden_size, const int intermediate_size,
+    const int top_k, const int rows_per_token,
+    const torch::Device& device) {
+
+    const int n_tiles = hidden_size / 16;
+
+    auto cgf = [&](sycl::handler& cgh) {
+        cgh.parallel_for<class MoeDownRoutedE5M2>(
+            sycl::range<2>(n_tokens * top_k, n_tiles),
+            [=](sycl::item<2> item) SYCL_ESIMD_KERNEL {
+                const int route_idx = (int)item.get_id(0);
+                const int n_tile    = (int)item.get_id(1);
+                const int token     = route_idx / top_k;
+                const int k_idx     = route_idx % top_k;
+
+                const int eid = selected_experts[route_idx];
+                const int routed_row = token * rows_per_token + k_idx;
+                const uint8_t* base = down_weight + (size_t)eid * intermediate_size * hidden_size;
+                const fp16* hi = intermediates + (size_t)routed_row * intermediate_size;
+                const int nj = n_tile * 16;
+                simd<float, 16> acc(0.f);
+
+                for (int k = 0; k < intermediate_size; k += 16) {
+                    simd<fp16, 16> a_tile = block_load<fp16, 16>(hi + k);
+
+                    xesimd::config_2d_mem_access<uint8_t, 16, 16, 1> payW(
+                        base, (uint32_t)hidden_size - 1u, (uint32_t)intermediate_size - 1u,
+                        (uint32_t)hidden_size - 1u, (uint32_t)nj, (uint32_t)k);
+                    auto raw = xesimd::lsc_load_2d<uint8_t, 16, 16, 1, false, false,
+                        xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payW);
+                    simd<fp16, 256> b_tile = fp8e5m2_block_to_vnni(raw);
+                    acc = dpas<8, 1, float, float, fp16, fp16>(acc, b_tile, a_tile);
+                }
+
+                float w = (float)routing_weights[route_idx];
+                float ds = down_scale[eid];
+                acc *= w * ds;
+
+                block_store<fp16, 16>(
+                    output + (size_t)routed_row * hidden_size + nj,
+                    convert<fp16>(acc));
+            });
+    };
+
+    submit_kernel(cgf, device, "moe down routed e5m2");
+}
+
+// -- Gate precompute: one sigmoid per (token, shared_expert) --
+void moe_down_gate_precompute_kernel(
+    const fp16* x,
+    const fp16* shared_expert_gate_weight,
+    float* gate_values,
+    const int n_tokens, const int hidden_size, const int num_shared_experts,
+    const torch::Device& device) {
+
+    auto cgf = [&](sycl::handler& cgh) {
+        cgh.parallel_for<class MoeDownGatePrecompute>(
+            sycl::range<1>(n_tokens * num_shared_experts),
+            [=](sycl::id<1> idx) SYCL_ESIMD_KERNEL {
+                const int flat = (int)idx[0];
+                const int token = flat / num_shared_experts;
+                const int sid   = flat % num_shared_experts;
+
+                const fp16* x_row = x + (size_t)token * hidden_size;
+
+                // Accumulate dot product in float32 to avoid fp16 precision loss
+                simd<float, 64> seg_acc(0.f);
+                for (int k = 0; k < hidden_size; k += 64) {
+                    seg_acc += convert<float>(
+                        block_load<fp16, 64>(x_row + k) *
+                        block_load<fp16, 64>(
+                            shared_expert_gate_weight + (size_t)sid * hidden_size + k));
+                }
+                float seg_dot = sycl::ext::intel::esimd::detail::sum<float, float, 64>(seg_acc);
+                gate_values[flat] = 1.f / (1.f + exp(simd<float, 1>(-seg_dot))[0]);
+            });
+    };
+
+    submit_kernel(cgf, device, "moe down gate precompute");
+}
+
+// -- Shared expert down kernels --
+void moe_down_shared_e4m3_kernel(
+    const fp16* intermediates,
+    const uint8_t* shared_down_weight, const float* shared_down_scale,
+    const float* gate_values,
+    fp16* output,
+    const int n_tokens, const int hidden_size, const int intermediate_size,
+    const int top_k, const int num_shared_experts, const int rows_per_token,
+    const torch::Device& device) {
+
+    auto cgf = [&](sycl::handler& cgh) {
+        cgh.parallel_for<class MoeDownSharedE4M3>(
+            sycl::range<2>(n_tokens * num_shared_experts, hidden_size),
+            [=](sycl::id<2> idx) SYCL_ESIMD_KERNEL {
+                const int idx0  = (int)idx[0];
+                const int token = idx0 / num_shared_experts;
+                const int sid   = idx0 % num_shared_experts;
+                const int j     = (int)idx[1];
+
+                const int shared_row = token * rows_per_token + top_k + sid;
+                const uint8_t* dw = shared_down_weight + (size_t)sid * hidden_size * intermediate_size
+                                                        + (size_t)j * intermediate_size;
+                const fp16* hi = intermediates + (size_t)shared_row * intermediate_size;
+                fp16 ds = fp16(shared_down_scale[sid]);
+                float w = gate_values[idx0];
+
+                simd<float, 64> acc(0.f);
+                for (int k = 0; k < intermediate_size; k += 64) {
+                    auto d_dq = fp8e4m3_to_half<64>(block_load<uint8_t, 64>(dw + k)) * ds;
+                    acc += convert<float>(d_dq * block_load<fp16, 64>(hi + k));
+                }
+
+                output[(size_t)shared_row * hidden_size + j] =
+                    fp16(w * sycl::ext::intel::esimd::detail::sum<float, float, 64>(acc));
+            });
+    };
+
+    submit_kernel(cgf, device, "moe down shared e4m3");
+}
+
+void moe_down_shared_e5m2_kernel(
+    const fp16* intermediates,
+    const uint8_t* shared_down_weight, const float* shared_down_scale,
+    const float* gate_values,
+    fp16* output,
+    const int n_tokens, const int hidden_size, const int intermediate_size,
+    const int top_k, const int num_shared_experts, const int rows_per_token,
+    const torch::Device& device) {
+
+    auto cgf = [&](sycl::handler& cgh) {
+        cgh.parallel_for<class MoeDownSharedE5M2>(
+            sycl::range<2>(n_tokens * num_shared_experts, hidden_size),
+            [=](sycl::id<2> idx) SYCL_ESIMD_KERNEL {
+                const int idx0  = (int)idx[0];
+                const int token = idx0 / num_shared_experts;
+                const int sid   = idx0 % num_shared_experts;
+                const int j     = (int)idx[1];
+
+                const int shared_row = token * rows_per_token + top_k + sid;
+                const uint8_t* dw = shared_down_weight + (size_t)sid * hidden_size * intermediate_size
+                                                        + (size_t)j * intermediate_size;
+                const fp16* hi = intermediates + (size_t)shared_row * intermediate_size;
+                fp16 ds = fp16(shared_down_scale[sid]);
+                float w = gate_values[idx0];
+
+                simd<float, 64> acc(0.f);
+                for (int k = 0; k < intermediate_size; k += 64) {
+                    auto d_dq = fp8e5m2_to_half<64>(block_load<uint8_t, 64>(dw + k)) * ds;
+                    acc += convert<float>(d_dq * block_load<fp16, 64>(hi + k));
+                }
+
+                output[(size_t)shared_row * hidden_size + j] =
+                    fp16(w * sycl::ext::intel::esimd::detail::sum<float, float, 64>(acc));
+            });
+    };
+
+    submit_kernel(cgf, device, "moe down shared e5m2");
+}
+
+torch::Tensor moe_down_forward(
+    torch::Tensor x,
+    torch::Tensor intermediates,
+    torch::Tensor down_weight, torch::Tensor down_scale,
+    torch::Tensor shared_down_weight, torch::Tensor shared_down_scale,
+    torch::Tensor shared_expert_gate_weight,
+    torch::Tensor routing_weights, torch::Tensor selected_experts,
+    int64_t top_k, int64_t num_shared_experts) {
+
+    TORCH_CHECK(x.dim() == 2);
+    TORCH_CHECK(x.is_contiguous());
+    TORCH_CHECK(x.scalar_type() == torch::kHalf);
+    TORCH_CHECK(selected_experts.scalar_type() == torch::kInt32);
+    TORCH_CHECK(selected_experts.is_contiguous());
+    TORCH_CHECK(intermediates.is_contiguous());
+
+    int n_tokens = x.size(0);
+    int hidden_size = x.size(1);
+    int intermediate_size = intermediates.size(1);
+    int rows_per_token = top_k + num_shared_experts;
+
+    TORCH_CHECK(hidden_size % 64 == 0);
+    TORCH_CHECK(intermediate_size % 64 == 0);
+    TORCH_CHECK(down_weight.size(1) == intermediate_size);
+    TORCH_CHECK(down_weight.size(2) == hidden_size);
+    TORCH_CHECK(selected_experts.numel() == n_tokens * top_k);
+
+    torch::Tensor output = torch::empty(
+        {n_tokens * rows_per_token, hidden_size},
+        torch::device(x.device()).dtype(torch::kHalf));
+
+    const fp16* x_ptr = (const fp16*)x.data_ptr();
+    const fp16* inter_ptr = (const fp16*)intermediates.data_ptr();
+    fp16* out_ptr = (fp16*)output.data_ptr();
+
+    // Precompute gate values: sigmoid(dot(x, gate_weight)) for each (token, shared_expert)
+    torch::Tensor gate_values = torch::empty(
+        {n_tokens * num_shared_experts},
+        torch::device(x.device()).dtype(torch::kFloat32));
+
+    moe_down_gate_precompute_kernel(
+        x_ptr,
+        (const fp16*)shared_expert_gate_weight.data_ptr(),
+        gate_values.data_ptr<float>(),
+        n_tokens, hidden_size, num_shared_experts, x.device());
+
+    switch (down_weight.scalar_type()) {
+        case at::kFloat8_e4m3fn:
+            moe_down_routed_e4m3_kernel(
+                inter_ptr,
+                (const uint8_t*)down_weight.data_ptr(), down_scale.data_ptr<float>(),
+                (const fp16*)routing_weights.data_ptr(), selected_experts.data_ptr<int>(),
+                out_ptr,
+                n_tokens, hidden_size, intermediate_size,
+                top_k, rows_per_token, x.device());
+            moe_down_shared_e4m3_kernel(
+                inter_ptr,
+                (const uint8_t*)shared_down_weight.data_ptr(), shared_down_scale.data_ptr<float>(),
+                gate_values.data_ptr<float>(),
+                out_ptr,
+                n_tokens, hidden_size, intermediate_size,
+                top_k, num_shared_experts, rows_per_token, x.device());
+            break;
+        case at::kFloat8_e5m2:
+            moe_down_routed_e5m2_kernel(
+                inter_ptr,
+                (const uint8_t*)down_weight.data_ptr(), down_scale.data_ptr<float>(),
+                (const fp16*)routing_weights.data_ptr(), selected_experts.data_ptr<int>(),
+                out_ptr,
+                n_tokens, hidden_size, intermediate_size,
+                top_k, rows_per_token, x.device());
+            moe_down_shared_e5m2_kernel(
+                inter_ptr,
+                (const uint8_t*)shared_down_weight.data_ptr(), shared_down_scale.data_ptr<float>(),
+                gate_values.data_ptr<float>(),
+                out_ptr,
+                n_tokens, hidden_size, intermediate_size,
+                top_k, num_shared_experts, rows_per_token, x.device());
+            break;
+        default: TORCH_CHECK(false, "unsupported weight dtype");
+    }
+
+    return output;
+}
+
+// ── Kernel 4: Accumulate partials + residual ─────────────────────────────────
+void moe_accumulate_kernel(
+    const fp16* partials,
+    fp16* final_output,
+    const int n_tokens, const int hidden_size,
+    const int rows_per_token,
+    const torch::Device& device) {
+
+    const int num_chunks = hidden_size / 64;
+
+    auto cgf = [&](sycl::handler& cgh) {
+        cgh.parallel_for<class MoeAccumulate>(
+            sycl::range<2>(n_tokens, num_chunks),
+            [=](sycl::id<2> idx) SYCL_ESIMD_KERNEL {
+                const int token = (int)idx[0];
+                const int base  = (int)idx[1] * 64;
+
+                simd<float, 64> sum(0.f);
+                for (int b = 0; b < rows_per_token; b++) {
+                    sum += convert<float>(
+                        block_load<fp16, 64>(partials + (size_t)(token * rows_per_token + b) * hidden_size + base));
+                }
+                block_store<fp16, 64>(final_output + (size_t)token * hidden_size + base, convert<fp16>(sum));
+            });
+    };
+
+    submit_kernel(cgf, device, "moe accumulate");
+}
+
+torch::Tensor moe_accumulate(
+    torch::Tensor partials,
+    int64_t top_k, int64_t num_shared_experts) {
+
+    TORCH_CHECK(partials.scalar_type() == torch::kHalf);
+    TORCH_CHECK(partials.is_contiguous());
+
+    int hidden_size = partials.size(1);
+    int rows_per_token = top_k + num_shared_experts;
+    int n_tokens = partials.size(0) / rows_per_token;
+
+    TORCH_CHECK(hidden_size % 64 == 0);
+    TORCH_CHECK(partials.size(0) == n_tokens * rows_per_token);
+
+    torch::Tensor final_output = torch::empty({n_tokens, hidden_size},
+        torch::device(partials.device()).dtype(torch::kHalf));
+
+    moe_accumulate_kernel(
+        (const fp16*)partials.data_ptr(),
+        (fp16*)final_output.data_ptr(),
+        n_tokens, hidden_size,
+        rows_per_token,
+        partials.device());
+
+    return final_output;
+}
+
+// ── Kernel 5: Fused Softmax + TopK + Normalize (multi-token) ─────────────────
+// Full softmax over all experts, then top-k selection with proper heap.
+// One work-item per token (same algorithm as working bsz=1 version).
+void moe_topk_forward_kernel(
+    const fp16* logits,
+    int* topk_idx,
+    fp16* topk_weight,
+    const int n_tokens,
+    const int n_experts,
+    const int top_k,
+    const bool norm,
+    const torch::Device& device) {
+
+    auto cgf = [&](sycl::handler& cgh) {
+        cgh.parallel_for<class MoeTopKForward>(
+            sycl::range<1>(n_tokens),
+            [=](sycl::id<1> idx) SYCL_ESIMD_KERNEL {
+                const int nid = (int)idx[0];
+                const fp16* row_ptr = logits + nid * n_experts;
+
+                // Load all expert scores (padded to 512)
+                simd<fp16, 512> scores(fp16(-65504.f));
+                for (int i = 0; i < n_experts; i += 16) {
+                    scores.select<16, 1>(i) = block_load<fp16, 16>(row_ptr + i);
+                }
+
+                // Full softmax over all experts
+                fp16 max_v = hmax<fp16>(scores);
+                scores -= max_v;
+                scores = exp(scores);
+
+                // Zero out padding
+                for (int i = n_experts; i < 512; i += 16)
+                    scores.select<16, 1>(i) = fp16(0);
+
+                // Sum and normalize in float32 to avoid fp16 precision loss
+                float sum_f32 = 0.f;
+                for (int i = 0; i < 512; i += 64) {
+                    simd<float, 64> chunk = convert<float>(scores.select<64, 1>(i).read());
+                    sum_f32 += sycl::ext::intel::esimd::detail::sum<float, float, 64>(chunk);
+                }
+                float inv_sum = 1.0f / sum_f32;
+                for (int i = 0; i < 512; i += 64) {
+                    simd<float, 64> chunk = convert<float>(scores.select<64, 1>(i).read()) * inv_sum;
+                    scores.select<64, 1>(i) = convert<fp16>(chunk);
+                }
+
+                // Top-k selection with proper heap
+                const simd<int, 32> iota(0, 1);
+                simd<fp16, 32> heap(fp16(65504.f));
+                simd<int, 32> hidx(0);
+
+                // Seed heap with first top_k values
+                for (int i = 0; i < top_k; ++i) {
+                    heap[i] = scores[i];
+                    hidx[i] = i;
+                }
+
+                // Scan remaining experts
+                for (int i = top_k; i < n_experts; ++i) {
+                    fp16 v = scores[i];
+                    fp16 mn = hmin<fp16>(heap);
+                    if (v > mn) {
+                        uint32_t pos = fbl(pack_mask(heap == mn));
+                        simd_mask<32> m = (iota == (int)pos);
+                        heap.merge(simd<fp16, 32>(v), m);
+                        hidx.merge(simd<int, 32>(i), m);
+                    }
+                }
+
+                // Normalize top-k weights (float32 for precision)
+                if (norm) {
+                    float top_sum = 0.f;
+                    for (int i = 0; i < top_k; ++i) {
+                        fp16 hv = heap[i];
+                        top_sum += (float)hv;
+                    }
+                    float inv_top = 1.f / top_sum;
+                    for (int i = 0; i < top_k; ++i) {
+                        fp16 hv = heap[i];
+                        heap[i] = fp16((float)hv * inv_top);
+                    }
+                }
+
+                // Store results
+                int* idx_base = topk_idx + nid * top_k;
+                fp16* weight_base = topk_weight + nid * top_k;
+                for (int i = 0; i < top_k; ++i) {
+                    idx_base[i] = hidx[i];
+                    weight_base[i] = heap[i];
+                }
+            });
+    };
+
+    submit_kernel(cgf, device, "moe topk forward");
+}
+
+std::tuple<torch::Tensor, torch::Tensor> moe_topk(
+    torch::Tensor logits,
+    int64_t top_k,
+    bool norm) {
+
+    TORCH_CHECK(logits.dim() == 2);
+    TORCH_CHECK(logits.scalar_type() == torch::kHalf);
+
+    int n_tokens = logits.size(0);
+    int n_experts = logits.size(1);
+
+    TORCH_CHECK(n_experts <= 512);
+    TORCH_CHECK(n_experts % 16 == 0);
+    TORCH_CHECK(top_k <= 32);
+
+    torch::Tensor topk_idx = torch::empty({n_tokens, top_k},
+        torch::device(logits.device()).dtype(torch::kInt32));
+
+    torch::Tensor topk_weight = torch::empty({n_tokens, top_k},
+        torch::device(logits.device()).dtype(torch::kHalf));
+
+    moe_topk_forward_kernel(
+        (const fp16*)logits.data_ptr(),
+        topk_idx.data_ptr<int>(),
+        (fp16*)topk_weight.data_ptr(),
+        n_tokens, n_experts, top_k, norm,
+        logits.device());
+
+    return std::make_tuple(topk_idx, topk_weight);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// FUSED: DownFinalize (gate+shared_down+accumulate in 1 submit, 2048 WGs)
+// ═══════════════════════════════════════════════════════════════════════════
+void moe_down_finalize_e5m2_kernel(
+    const fp16* x, const fp16* intermediates, const fp16* routed_output,
+    const uint8_t* shared_down_weight, const float* shared_down_scale,
+    const fp16* shared_expert_gate_weight, fp16* final_output,
+    const int n_tokens, const int hidden_size, const int intermediate_size,
+    const int top_k, const int num_shared_experts, const int rows_per_token,
+    const torch::Device& device) {
+    auto cgf = [&](sycl::handler& cgh) {
+        cgh.parallel_for<class MoeDownFinalizeE5M2>(sycl::range<2>(n_tokens, hidden_size),
+            [=](sycl::id<2> idx) SYCL_ESIMD_KERNEL {
+                const int token = (int)idx[0], j = (int)idx[1];
+                float sum = 0.f;
+                for (int k = 0; k < top_k; k++)
+                    sum += (float)routed_output[(size_t)(token * rows_per_token + k) * hidden_size + j];
+                const fp16* x_row = x + (size_t)token * hidden_size;
+                for (int sid = 0; sid < num_shared_experts; sid++) {
+                    simd<float, 64> gate_acc(0.f);
+                    for (int gk = 0; gk < hidden_size; gk += 64)
+                        gate_acc += convert<float>(block_load<fp16,64>(x_row+gk)) * convert<float>(block_load<fp16,64>(shared_expert_gate_weight+sid*hidden_size+gk));
+                    float gate_w = 1.f/(1.f+sycl::exp(-sycl::ext::intel::esimd::detail::sum<float,float,64>(gate_acc)));
+                    const int shared_row = token * rows_per_token + top_k + sid;
+                    const fp16* hi = intermediates + (size_t)shared_row * intermediate_size;
+                    const uint8_t* dw = shared_down_weight + (size_t)sid*hidden_size*intermediate_size + (size_t)j*intermediate_size;
+                    fp16 ds = fp16(shared_down_scale[sid]);
+                    simd<float, 64> acc(0.f);
+                    for (int k = 0; k < intermediate_size; k += 64) {
+                        auto d_dq = fp8e5m2_to_half<64>(block_load<uint8_t,64>(dw+k)) * ds;
+                        acc += convert<float>(d_dq * block_load<fp16,64>(hi+k));
+                    }
+                    sum += sycl::ext::intel::esimd::detail::sum<float,float,64>(acc) * gate_w;
+                }
+                final_output[(size_t)token * hidden_size + j] = fp16(sum);
+            });
+    };
+    submit_kernel(cgf, device, "moe down finalize e5m2");
+}
+
+torch::Tensor moe_forward_fused(
+    torch::Tensor x, torch::Tensor gate_up_weight, torch::Tensor gate_up_scale,
+    torch::Tensor shared_gate_up_weight, torch::Tensor shared_gate_up_scale,
+    torch::Tensor down_weight, torch::Tensor down_scale,
+    torch::Tensor shared_down_weight, torch::Tensor shared_down_scale,
+    torch::Tensor shared_expert_gate_weight,
+    torch::Tensor routing_weights, torch::Tensor selected_experts,
+    int64_t top_k, int64_t num_shared_experts) {
+    TORCH_CHECK(x.scalar_type() == torch::kHalf);
+    TORCH_CHECK(gate_up_weight.scalar_type() == at::kFloat8_e5m2);
+    int n_tokens = x.size(0), hidden_size = x.size(1);
+    int intermediate_size = gate_up_weight.size(2) / 2;
+    int rows_per_token = top_k + num_shared_experts;
+    auto intermediates = moe_up_forward(x, gate_up_weight, gate_up_scale,
+        shared_gate_up_weight, shared_gate_up_scale, selected_experts, top_k, num_shared_experts);
+    auto routed_output = torch::empty({n_tokens*rows_per_token, hidden_size},
+        torch::device(x.device()).dtype(torch::kHalf));
+    moe_down_routed_e5m2_kernel((const fp16*)intermediates.data_ptr(),
+        (const uint8_t*)down_weight.data_ptr(), down_scale.data_ptr<float>(),
+        (const fp16*)routing_weights.data_ptr(), selected_experts.data_ptr<int>(),
+        (fp16*)routed_output.data_ptr(),
+        n_tokens, hidden_size, intermediate_size, top_k, rows_per_token, x.device());
+    auto final_output = torch::empty({n_tokens, hidden_size},
+        torch::device(x.device()).dtype(torch::kHalf));
+    moe_down_finalize_e5m2_kernel((const fp16*)x.data_ptr(),
+        (const fp16*)intermediates.data_ptr(), (const fp16*)routed_output.data_ptr(),
+        (const uint8_t*)shared_down_weight.data_ptr(), shared_down_scale.data_ptr<float>(),
+        (const fp16*)shared_expert_gate_weight.data_ptr(), (fp16*)final_output.data_ptr(),
+        n_tokens, hidden_size, intermediate_size, top_k, num_shared_experts, rows_per_token, x.device());
+    return final_output;
+}
+
+// Full MoE forward: topk + up + down_routed + down_finalize in one C++ call.
+// Pre-allocated buffers to eliminate torch::empty overhead (~2.6us each × 5 = 13us/call).
+// Buffers are lazily initialized on first call and reused across layers.
+
+// Static buffer cache (thread-local for safety, though typically single-threaded)
+static thread_local torch::Tensor s_topk_idx, s_topk_weight;
+static thread_local torch::Tensor s_routed_output, s_final_output;
+static thread_local torch::Tensor s_intermediates;
+static thread_local int s_cached_ntokens = -1;
+
+static void ensure_moe_buffers(int n_tokens, int top_k, int num_shared_experts,
+                                int hidden_size, int intermediate_size,
+                                const torch::Device& dev) {
+    int rows_per_token = top_k + num_shared_experts;
+    if (s_cached_ntokens != n_tokens) {
+        s_topk_idx = torch::empty({n_tokens, top_k},
+            torch::device(dev).dtype(torch::kInt32));
+        s_topk_weight = torch::empty({n_tokens, top_k},
+            torch::device(dev).dtype(torch::kHalf));
+        s_routed_output = torch::empty({n_tokens * rows_per_token, hidden_size},
+            torch::device(dev).dtype(torch::kHalf));
+        s_final_output = torch::empty({n_tokens, hidden_size},
+            torch::device(dev).dtype(torch::kHalf));
+        s_intermediates = torch::empty({n_tokens * rows_per_token, intermediate_size},
+            torch::device(dev).dtype(torch::kHalf));
+        s_cached_ntokens = n_tokens;
+    }
+}
+
+torch::Tensor moe_forward_full(
+    torch::Tensor x, torch::Tensor logits,
+    torch::Tensor gate_up_weight, torch::Tensor gate_up_scale,
+    torch::Tensor shared_gate_up_weight, torch::Tensor shared_gate_up_scale,
+    torch::Tensor down_weight, torch::Tensor down_scale,
+    torch::Tensor shared_down_weight, torch::Tensor shared_down_scale,
+    torch::Tensor shared_expert_gate_weight,
+    int64_t top_k, int64_t num_shared_experts, int64_t n_routed_experts) {
+    TORCH_CHECK(x.scalar_type() == torch::kHalf);
+    int n_tokens = x.size(0), hidden_size = x.size(1);
+    int intermediate_size = gate_up_weight.size(2) / 2;
+    int rows_per_token = top_k + num_shared_experts;
+
+    // Ensure pre-allocated buffers exist
+    ensure_moe_buffers(n_tokens, top_k, num_shared_experts, hidden_size,
+                       intermediate_size, x.device());
+
+    // TopK
+    moe_topk_forward_kernel(
+        (const fp16*)logits.data_ptr(),
+        s_topk_idx.data_ptr<int>(),
+        (fp16*)s_topk_weight.data_ptr(),
+        n_tokens, (int)n_routed_experts, (int)top_k, /*norm=*/true,
+        logits.device());
+
+    // Up forward (inlined, using pre-allocated s_intermediates)
+    const fp16* x_ptr = (const fp16*)x.data_ptr();
+    fp16* inter_ptr = (fp16*)s_intermediates.data_ptr();
+    moe_up_routed_e5m2_kernel(
+        x_ptr,
+        (const uint8_t*)gate_up_weight.data_ptr(), gate_up_scale.data_ptr<float>(),
+        s_topk_idx.data_ptr<int>(),
+        inter_ptr,
+        n_tokens, hidden_size, intermediate_size,
+        top_k, rows_per_token, x.device());
+    moe_up_shared_e5m2_kernel(
+        x_ptr,
+        (const uint8_t*)shared_gate_up_weight.data_ptr(), shared_gate_up_scale.data_ptr<float>(),
+        inter_ptr,
+        n_tokens, hidden_size, intermediate_size,
+        top_k, num_shared_experts, rows_per_token, x.device());
+
+    // Down routed
+    moe_down_routed_e5m2_kernel((const fp16*)s_intermediates.data_ptr(),
+        (const uint8_t*)down_weight.data_ptr(), down_scale.data_ptr<float>(),
+        (const fp16*)s_topk_weight.data_ptr(), s_topk_idx.data_ptr<int>(),
+        (fp16*)s_routed_output.data_ptr(),
+        n_tokens, hidden_size, intermediate_size, top_k, rows_per_token, x.device());
+
+    // Down finalize
+    moe_down_finalize_e5m2_kernel((const fp16*)x.data_ptr(),
+        (const fp16*)s_intermediates.data_ptr(), (const fp16*)s_routed_output.data_ptr(),
+        (const uint8_t*)shared_down_weight.data_ptr(), shared_down_scale.data_ptr<float>(),
+        (const fp16*)shared_expert_gate_weight.data_ptr(), (fp16*)s_final_output.data_ptr(),
+        n_tokens, hidden_size, intermediate_size, top_k, num_shared_experts, rows_per_token, x.device());
+
+    return s_final_output;
+}
+
+TORCH_LIBRARY_FRAGMENT(moe_ops, m) {
+    m.def("moe_router_forward(Tensor x, Tensor weight, Tensor scale) -> Tensor");
+    m.def("moe_up_forward(Tensor x, Tensor gate_up_weight, Tensor gate_up_scale, Tensor shared_gate_up_weight, Tensor shared_gate_up_scale, Tensor selected_experts, int top_k, int num_shared_experts) -> Tensor");
+    m.def("moe_down_forward(Tensor x, Tensor intermediates, Tensor down_weight, Tensor down_scale, Tensor shared_down_weight, Tensor shared_down_scale, Tensor shared_expert_gate_weight, Tensor routing_weights, Tensor selected_experts, int top_k, int num_shared_experts) -> Tensor");
+    m.def("moe_accumulate(Tensor partials, int top_k, int num_shared_experts) -> Tensor");
+    m.def("moe_topk(Tensor logits, int top_k, bool norm) -> (Tensor, Tensor)");
+    m.def("moe_forward_fused(Tensor x, Tensor gate_up_weight, Tensor gate_up_scale, Tensor shared_gate_up_weight, Tensor shared_gate_up_scale, Tensor down_weight, Tensor down_scale, Tensor shared_down_weight, Tensor shared_down_scale, Tensor shared_expert_gate_weight, Tensor routing_weights, Tensor selected_experts, int top_k, int num_shared_experts) -> Tensor");
+    m.def("moe_forward_full(Tensor x, Tensor logits, Tensor gate_up_weight, Tensor gate_up_scale, Tensor shared_gate_up_weight, Tensor shared_gate_up_scale, Tensor down_weight, Tensor down_scale, Tensor shared_down_weight, Tensor shared_down_scale, Tensor shared_expert_gate_weight, int top_k, int num_shared_experts, int n_routed_experts) -> Tensor");
+}
+
+TORCH_LIBRARY_IMPL(moe_ops, XPU, m) {
+    m.impl("moe_router_forward", &moe_router_forward);
+    m.impl("moe_up_forward", &moe_up_forward);
+    m.impl("moe_down_forward", &moe_down_forward);
+    m.impl("moe_accumulate", &moe_accumulate);
+    m.impl("moe_topk", &moe_topk);
+    m.impl("moe_forward_fused", &moe_forward_fused);
+    m.impl("moe_forward_full", &moe_forward_full);
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("moe_router_forward", &moe_router_forward);
+    m.def("moe_up_forward", &moe_up_forward);
+    m.def("moe_down_forward", &moe_down_forward);
+    m.def("moe_accumulate", &moe_accumulate);
+    m.def("moe_topk", &moe_topk);
+    m.def("moe_forward_fused", &moe_forward_fused);
+    m.def("moe_forward_full", &moe_forward_full);
+}

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel.sycl
@@ -1,0 +1,281 @@
+#include <ATen/ATen.h>
+#include <ATen/Parallel.h>
+#include <c10/xpu/XPUStream.h>
+#include <torch/python.h>
+
+#include <cstdint>
+#include <sycl/sycl.hpp>
+
+#include "esimd_kernels/fp8_GEMV_v2.h"
+#include "esimd_kernels/qkv_split_norm_rope.h"
+#include "esimd_kernels/norm_gemv_fused.h"
+#include "esimd_kernels/fused_add_rms_norm.h"
+#include "esimd_kernels/resadd_norm_gemv_fused.h"
+#include "esimd_kernels/resadd_norm_gemv2_fused.h"
+
+#define EXTRACT_PTR(var, tensor) auto var = reinterpret_cast<uint8_t*>(tensor.data_ptr())
+
+// 0=E4M3, 1=E5M2
+inline int get_fp8_mode(const at::Tensor& weight) {
+    return (weight.scalar_type() == at::ScalarType::Float8_e5m2) ? 1 : 0;
+}
+
+// Get queue for the specific device (multi-card safe)
+static inline sycl::queue& get_device_queue(const at::Tensor& tensor) {
+    return c10::xpu::getCurrentXPUStream(tensor.device().index()).queue();
+}
+
+at::Tensor esimd_gemv_fp8_pern(
+    at::Tensor input, at::Tensor weight, at::Tensor weight_scale,
+    at::Tensor output,
+    int64_t N, int64_t K) {
+    EXTRACT_PTR(p_in, input); EXTRACT_PTR(p_w, weight);
+    EXTRACT_PTR(p_sc, weight_scale); EXTRACT_PTR(p_out, output);
+    auto& dpcpp_queue = get_device_queue(input);
+    GEMV_fp8_pern_host(p_in, p_w, p_sc, p_out, N, K, get_fp8_mode(weight), dpcpp_queue);
+    return output;
+}
+
+at::Tensor esimd_gemv_fp8_pern_fused2(
+    at::Tensor input,
+    at::Tensor w0, at::Tensor s0, at::Tensor o0, int64_t N0,
+    at::Tensor w1, at::Tensor s1, at::Tensor o1, int64_t N1,
+    int64_t K) {
+    EXTRACT_PTR(p_in, input);
+    EXTRACT_PTR(pw0, w0); EXTRACT_PTR(ps0, s0); EXTRACT_PTR(po0, o0);
+    EXTRACT_PTR(pw1, w1); EXTRACT_PTR(ps1, s1); EXTRACT_PTR(po1, o1);
+    auto& dpcpp_queue = get_device_queue(input);
+    uint8_t* wp[2] = {pw0, pw1};
+    uint8_t* sp[2] = {ps0, ps1};
+    uint8_t* op[2] = {po0, po1};
+    uint32_t ns[2] = {(uint32_t)N0, (uint32_t)N1};
+    GEMV_fp8_pern_fused_host<2>(p_in, wp, sp, op, ns, (uint32_t)K, get_fp8_mode(w0), dpcpp_queue);
+    return o0;
+}
+
+at::Tensor esimd_gemv_fp8_pern_fused3(
+    at::Tensor input,
+    at::Tensor w0, at::Tensor s0, at::Tensor o0, int64_t N0,
+    at::Tensor w1, at::Tensor s1, at::Tensor o1, int64_t N1,
+    at::Tensor w2, at::Tensor s2, at::Tensor o2, int64_t N2,
+    int64_t K) {
+    EXTRACT_PTR(p_in, input);
+    EXTRACT_PTR(pw0, w0); EXTRACT_PTR(ps0, s0); EXTRACT_PTR(po0, o0);
+    EXTRACT_PTR(pw1, w1); EXTRACT_PTR(ps1, s1); EXTRACT_PTR(po1, o1);
+    EXTRACT_PTR(pw2, w2); EXTRACT_PTR(ps2, s2); EXTRACT_PTR(po2, o2);
+    auto& dpcpp_queue = get_device_queue(input);
+    uint8_t* wp[3] = {pw0, pw1, pw2};
+    uint8_t* sp[3] = {ps0, ps1, ps2};
+    uint8_t* op[3] = {po0, po1, po2};
+    uint32_t ns[3] = {(uint32_t)N0, (uint32_t)N1, (uint32_t)N2};
+    GEMV_fp8_pern_fused_host<3>(p_in, wp, sp, op, ns, (uint32_t)K, get_fp8_mode(w0), dpcpp_queue);
+    return o0;
+}
+
+// ---- Per-tensor scale variants (N/K auto-detected from tensor shapes) ----
+
+at::Tensor esimd_gemv_fp8_pert(
+    at::Tensor input, at::Tensor weight, at::Tensor weight_scale,
+    at::Tensor output) {
+    int64_t N = weight.size(0);
+    int64_t K = weight.size(1);
+    EXTRACT_PTR(p_in, input); EXTRACT_PTR(p_w, weight);
+    EXTRACT_PTR(p_sc, weight_scale); EXTRACT_PTR(p_out, output);
+    auto& dpcpp_queue = get_device_queue(input);
+    GEMV_fp8_pert_host(p_in, p_w, p_sc, p_out, N, K, get_fp8_mode(weight), dpcpp_queue);
+    return output;
+}
+
+at::Tensor esimd_gemv_fp8_pert_fused2(
+    at::Tensor input,
+    at::Tensor w0, at::Tensor s0, at::Tensor o0,
+    at::Tensor w1, at::Tensor s1, at::Tensor o1) {
+    int64_t K = w0.size(1);
+    int64_t N0 = w0.size(0), N1 = w1.size(0);
+    EXTRACT_PTR(p_in, input);
+    EXTRACT_PTR(pw0, w0); EXTRACT_PTR(ps0, s0); EXTRACT_PTR(po0, o0);
+    EXTRACT_PTR(pw1, w1); EXTRACT_PTR(ps1, s1); EXTRACT_PTR(po1, o1);
+    auto& dpcpp_queue = get_device_queue(input);
+    uint8_t* wp[2] = {pw0, pw1};
+    uint8_t* sp[2] = {ps0, ps1};
+    uint8_t* op[2] = {po0, po1};
+    uint32_t ns[2] = {(uint32_t)N0, (uint32_t)N1};
+    GEMV_fp8_pert_fused_host<2>(p_in, wp, sp, op, ns, (uint32_t)K, get_fp8_mode(w0), dpcpp_queue);
+    return o0;
+}
+
+at::Tensor esimd_gemv_fp8_pert_fused3(
+    at::Tensor input,
+    at::Tensor w0, at::Tensor s0, at::Tensor o0,
+    at::Tensor w1, at::Tensor s1, at::Tensor o1,
+    at::Tensor w2, at::Tensor s2, at::Tensor o2) {
+    int64_t K = w0.size(1);
+    int64_t N0 = w0.size(0), N1 = w1.size(0), N2 = w2.size(0);
+    EXTRACT_PTR(p_in, input);
+    EXTRACT_PTR(pw0, w0); EXTRACT_PTR(ps0, s0); EXTRACT_PTR(po0, o0);
+    EXTRACT_PTR(pw1, w1); EXTRACT_PTR(ps1, s1); EXTRACT_PTR(po1, o1);
+    EXTRACT_PTR(pw2, w2); EXTRACT_PTR(ps2, s2); EXTRACT_PTR(po2, o2);
+    auto& dpcpp_queue = get_device_queue(input);
+    uint8_t* wp[3] = {pw0, pw1, pw2};
+    uint8_t* sp[3] = {ps0, ps1, ps2};
+    uint8_t* op[3] = {po0, po1, po2};
+    uint32_t ns[3] = {(uint32_t)N0, (uint32_t)N1, (uint32_t)N2};
+    GEMV_fp8_pert_fused_host<3>(p_in, wp, sp, op, ns, (uint32_t)K, get_fp8_mode(w0), dpcpp_queue);
+    return o0;
+}
+
+// ---- QKV Split + RMSNorm + RoPE fused kernel ----
+
+// Persistent cos/sin cache (allocated once, FP64 precision on host -> FP16 on device)
+// cos_sin_cache now passed directly from caller (no static cache needed)
+
+at::Tensor esimd_qkv_split_norm_rope(
+    at::Tensor qkv_state,
+    at::Tensor q_out,
+    at::Tensor gate_out,
+    at::Tensor k_out,
+    at::Tensor v_out,
+    at::Tensor norm_wq,
+    at::Tensor norm_wk,
+    at::Tensor positions,
+    int64_t q_heads, int64_t kv_heads, bool attn_output_gate,
+    int64_t rotary_dim,
+    at::Tensor cos_sin_cache) {
+
+    EXTRACT_PTR(p_qkv, qkv_state);
+    EXTRACT_PTR(p_q, q_out);
+    EXTRACT_PTR(p_gate, gate_out);
+    EXTRACT_PTR(p_k, k_out);
+    EXTRACT_PTR(p_v, v_out);
+    EXTRACT_PTR(p_nwq, norm_wq);
+    EXTRACT_PTR(p_nwk, norm_wk);
+    auto p_pos = reinterpret_cast<uint32_t*>(positions.data_ptr());
+    // cos_sin_cache: [max_pos, rotary_dim] fp16, interleaved [cos, sin] per position
+    auto p_cs = reinterpret_cast<sycl::half*>(cos_sin_cache.data_ptr());
+
+    uint32_t ntoks = qkv_state.size(0);
+    uint32_t hiddenDim = qkv_state.size(1);
+
+    auto& dpcpp_queue = get_device_queue(qkv_state);
+    qkv_split_norm_rope_host(
+        p_qkv, p_q, p_gate, p_k, p_v,
+        p_nwq, p_nwk, p_pos, p_cs,
+        ntoks, hiddenDim,
+        (uint32_t)q_heads, (uint32_t)kv_heads,
+        attn_output_gate, (uint32_t)rotary_dim, dpcpp_queue);
+    return q_out;
+}
+
+// ---- Fused ResidualAdd + RMSNorm + FP8 GEMV ----
+
+at::Tensor esimd_resadd_norm_gemv_fp8_pert(
+    at::Tensor hidden_states,  // [1, K] fp16
+    at::Tensor residual,       // [1, K] fp16 — updated in-place
+    at::Tensor norm_weight,    // [K] fp16 — Gemma (w+1.0)
+    at::Tensor gemv_weight,    // [N, K] FP8
+    at::Tensor gemv_scale,     // [1] float32
+    at::Tensor output,         // [1, N] fp16 — router logits
+    at::Tensor normed_out,     // [1, K] fp16 — normed hidden for experts
+    double eps)
+{
+    int N = (int)gemv_weight.size(0);
+    int K = (int)gemv_weight.size(1);
+    int fp8_mode = get_fp8_mode(gemv_weight);
+
+    auto& dpcpp_queue = get_device_queue(hidden_states);
+
+    resadd_norm_gemv_fp8_pert_host(
+        reinterpret_cast<fp16*>(hidden_states.data_ptr()),
+        reinterpret_cast<fp16*>(residual.data_ptr()),
+        reinterpret_cast<const fp16*>(norm_weight.data_ptr()),
+        reinterpret_cast<const uint8_t*>(gemv_weight.data_ptr()),
+        gemv_scale.data_ptr<float>(),
+        reinterpret_cast<fp16*>(output.data_ptr()),
+        reinterpret_cast<fp16*>(normed_out.data_ptr()),
+        N, K, (float)eps, fp8_mode,
+        dpcpp_queue);
+
+    return output;
+}
+
+// ---- Fused RMSNormGated + FP8 GEMV (out_proj) ----
+
+at::Tensor esimd_norm_gemv_fp8_pert(
+    at::Tensor x,             // [HV, V] fp16 — core_attn_out
+    at::Tensor z,             // [HV, V] fp16 — z_out
+    at::Tensor norm_weight,   // [V] fp16
+    at::Tensor gemv_weight,   // [N, K] FP8, K = HV*V
+    at::Tensor gemv_scale,    // [1] float32
+    at::Tensor output,        // [1, N] fp16
+    int64_t HV, int64_t V,
+    double eps)
+{
+    int N = (int)gemv_weight.size(0);
+    int fp8_mode = get_fp8_mode(gemv_weight);
+
+    auto& dpcpp_queue = get_device_queue(x);
+
+    norm_gemv_fp8_pert_host(
+        reinterpret_cast<const fp16*>(x.data_ptr()),
+        reinterpret_cast<const fp16*>(z.data_ptr()),
+        reinterpret_cast<const fp16*>(norm_weight.data_ptr()),
+        reinterpret_cast<const uint8_t*>(gemv_weight.data_ptr()),
+        gemv_scale.data_ptr<float>(),
+        reinterpret_cast<fp16*>(output.data_ptr()),
+        N, (int)HV, (int)V, (float)eps, fp8_mode,
+        dpcpp_queue);
+
+    return output;
+}
+
+// ---- Fused ResidualAdd + RMSNorm + 2-matrix FP8 GEMV ----
+
+at::Tensor esimd_resadd_norm_gemv2_fp8_pert(
+    at::Tensor hidden_states,
+    at::Tensor residual,
+    at::Tensor norm_weight,
+    at::Tensor w0, at::Tensor s0, at::Tensor o0,
+    at::Tensor w1, at::Tensor s1, at::Tensor o1,
+    double eps)
+{
+    int N0 = (int)w0.size(0);
+    int N1 = (int)w1.size(0);
+    int K = (int)w0.size(1);
+    int fp8_mode = get_fp8_mode(w0);
+    auto& dpcpp_queue = get_device_queue(hidden_states);
+
+    resadd_norm_gemv2_fp8_pert_host(
+        reinterpret_cast<fp16*>(hidden_states.data_ptr()),
+        reinterpret_cast<fp16*>(residual.data_ptr()),
+        reinterpret_cast<const fp16*>(norm_weight.data_ptr()),
+        reinterpret_cast<const uint8_t*>(w0.data_ptr()),
+        s0.data_ptr<float>(),
+        reinterpret_cast<fp16*>(o0.data_ptr()),
+        reinterpret_cast<const uint8_t*>(w1.data_ptr()),
+        s1.data_ptr<float>(),
+        reinterpret_cast<fp16*>(o1.data_ptr()),
+        N0, N1, K, (float)eps, fp8_mode,
+        dpcpp_queue);
+
+    return o0;
+}
+
+// ---- Fused Add + RMSNorm (Gemma-style, replace IPEX fused_add_rms_norm) ----
+
+at::Tensor esimd_fused_add_rms_norm(
+    at::Tensor hidden_states,  // [1, K] — input/output (normalized result)
+    at::Tensor residual,       // [1, K] — updated in-place
+    at::Tensor weight,         // [K] — Gemma weight (w+1.0)
+    double eps)
+{
+    int K = (int)hidden_states.size(-1);
+    auto& dpcpp_queue = get_device_queue(hidden_states);
+
+    fused_add_rms_norm_host(
+        reinterpret_cast<fp16*>(hidden_states.data_ptr()),
+        reinterpret_cast<fp16*>(residual.data_ptr()),
+        reinterpret_cast<const fp16*>(weight.data_ptr()),
+        K, (float)eps, dpcpp_queue);
+
+    return hidden_states;
+}

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_gemm.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_gemm.sycl
@@ -1,0 +1,45 @@
+/* esimd_kernel_gemm.sycl — Compilation unit for FP8 GEMM (M>1) ESIMD kernels.
+ * Compiled with AOT for BMG (no doubleGRF). Uses DPAS for M>=2.
+ * Separate from esimd_kernel.sycl to avoid ODR conflicts with fp8_GEMV_v2.h
+ * (both define fp8_dequant, select_vl_ks with identical implementations).
+ */
+#include <ATen/ATen.h>
+#include <ATen/Parallel.h>
+#include <c10/xpu/XPUStream.h>
+#include <torch/python.h>
+
+#include <cstdint>
+#include <sycl/sycl.hpp>
+
+#include "esimd_kernels/fp8_GEMM_pert.h"
+
+#define EXTRACT_PTR(var, tensor) auto var = reinterpret_cast<uint8_t*>(tensor.data_ptr())
+
+inline int get_fp8_mode(const at::Tensor& weight) {
+    return (weight.scalar_type() == at::ScalarType::Float8_e5m2) ? 1 : 0;
+}
+
+static inline sycl::queue& get_device_queue(const at::Tensor& tensor) {
+    return c10::xpu::getCurrentXPUStream(tensor.device().index()).queue();
+}
+
+// ---- FP8 GEMM per-tensor scale: input [M, K], weight [N, K], output [M, N] ----
+// Auto-dispatches: M=1-3 → batched GEMV, M>=2 E4M3 → DPAS V9, else → WS
+at::Tensor esimd_gemm_fp8_pert(
+    at::Tensor input, at::Tensor weight, at::Tensor weight_scale,
+    at::Tensor output) {
+    int64_t M = input.size(0);
+    int64_t K = weight.size(1);
+    int64_t N = weight.size(0);
+    EXTRACT_PTR(p_in, input); EXTRACT_PTR(p_w, weight);
+    EXTRACT_PTR(p_sc, weight_scale); EXTRACT_PTR(p_out, output);
+    auto& dpcpp_queue = get_device_queue(input);
+    GEMM_fp8_pert_dispatch(
+        reinterpret_cast<const fp16*>(p_in),
+        reinterpret_cast<const uint8_t*>(p_w),
+        reinterpret_cast<const float*>(p_sc),
+        reinterpret_cast<fp16*>(p_out),
+        (uint32_t)M, (uint32_t)N, (uint32_t)K,
+        get_fp8_mode(weight), dpcpp_queue);
+    return output;
+}

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_lgrf.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_lgrf.sycl
@@ -1,0 +1,117 @@
+/* esimd_kernel_lgrf.sycl — SYCL compilation unit for doubleGRF ESIMD kernels.
+ * Compiled with -doubleGRF flags for 512 register access.
+ */
+
+#include <ATen/ATen.h>
+#include <ATen/Parallel.h>
+#include <c10/xpu/XPUStream.h>
+#include <torch/python.h>
+
+#include <cstdint>
+#include <sycl/sycl.hpp>
+
+#include "esimd_kernels/gdn_conv_fused.h"
+#include "esimd_kernels/gdn_conv_fused_seq.h"
+
+// Get queue for the specific device (multi-card safe)
+static inline sycl::queue& get_device_queue(const at::Tensor& tensor) {
+    return c10::xpu::getCurrentXPUStream(tensor.device().index()).queue();
+}
+
+at::Tensor esimd_gdn_conv_fused(
+    at::Tensor qkvz,                // [N, qkvz_dim] fp16 — projected_states_qkvz
+    at::Tensor conv_state,           // [num_cache, 3, 2048] fp16, strided dim0
+    at::Tensor conv_weight,          // [2048, 4] fp16
+    at::Tensor conv_bias,            // [2048] fp16 (zeros if model has no bias)
+    at::Tensor conv_state_indices,   // [N] int32
+    at::Tensor A_log,                // [HV] fp16
+    at::Tensor dt_bias,              // [HV] fp16
+    at::Tensor ba,                   // [N, 2*HV] fp16 — projected_states_ba
+    at::Tensor ssm_state,            // [num_states, HV, V, K] fp16, strided dim0
+    at::Tensor ssm_state_indices,    // [N] int32
+    at::Tensor output,               // [N, HV, V] fp16
+    at::Tensor z_out,                // [N, HV, V] fp16
+    int64_t N, int64_t H, int64_t HV,
+    int64_t K, int64_t V,
+    double scale)
+{
+    auto& dpcpp_queue = get_device_queue(qkvz);
+
+    // Extract strides (in fp16 elements)
+    int64_t qkvz_stride0 = qkvz.stride(0);
+    int64_t conv_stride0 = conv_state.stride(0);
+    int64_t ssm_stride0 = ssm_state.stride(0);
+    int64_t ba_stride0 = ba.stride(0);
+
+    // Extract raw fp16 pointers
+    auto* p_qkvz    = reinterpret_cast<const fp16*>(qkvz.data_ptr());
+    auto* p_cstate  = reinterpret_cast<fp16*>(conv_state.data_ptr());
+    auto* p_cweight = reinterpret_cast<const fp16*>(conv_weight.data_ptr());
+    auto* p_cbias   = reinterpret_cast<const fp16*>(conv_bias.data_ptr());
+    auto* p_csidx   = conv_state_indices.data_ptr<int>();
+    auto* p_alog    = reinterpret_cast<const fp16*>(A_log.data_ptr());
+    auto* p_dtbias  = reinterpret_cast<const fp16*>(dt_bias.data_ptr());
+    auto* p_ba      = reinterpret_cast<const fp16*>(ba.data_ptr());
+    auto* p_sstate  = reinterpret_cast<fp16*>(ssm_state.data_ptr());
+    auto* p_ssidx   = ssm_state_indices.data_ptr<int>();
+    auto* p_out     = reinterpret_cast<fp16*>(output.data_ptr());
+    auto* p_zout    = reinterpret_cast<fp16*>(z_out.data_ptr());
+
+    gdn_conv_fused_host(
+        p_qkvz, qkvz_stride0, p_cstate, p_cweight, p_cbias, p_csidx,
+        p_alog, p_dtbias, p_ba, ba_stride0,
+        p_sstate, p_ssidx, p_out, p_zout,
+        (int)N, (int)H, (int)HV, (int)K, (int)V,
+        (float)scale, conv_stride0, ssm_stride0,
+        dpcpp_queue);
+
+    return output;
+}
+
+at::Tensor esimd_gdn_conv_fused_seq(
+    at::Tensor qkvz,                // [N, qkvz_dim] fp16 — sequential [q|k|v|z]
+    at::Tensor conv_state,
+    at::Tensor conv_weight,
+    at::Tensor conv_bias,
+    at::Tensor conv_state_indices,
+    at::Tensor A_log,
+    at::Tensor dt_bias,
+    at::Tensor ba,                   // [N, 2*HV] fp16 — sequential [b|a]
+    at::Tensor ssm_state,
+    at::Tensor ssm_state_indices,
+    at::Tensor output,
+    at::Tensor z_out,
+    int64_t N, int64_t H, int64_t HV,
+    int64_t K, int64_t V,
+    double scale)
+{
+    auto& dpcpp_queue = get_device_queue(qkvz);
+
+    int64_t qkvz_stride0 = qkvz.stride(0);
+    int64_t conv_stride0 = conv_state.stride(0);
+    int64_t ssm_stride0 = ssm_state.stride(0);
+    int64_t ba_stride0 = ba.stride(0);
+
+    auto* p_qkvz    = reinterpret_cast<const fp16*>(qkvz.data_ptr());
+    auto* p_cstate  = reinterpret_cast<fp16*>(conv_state.data_ptr());
+    auto* p_cweight = reinterpret_cast<const fp16*>(conv_weight.data_ptr());
+    auto* p_cbias   = reinterpret_cast<const fp16*>(conv_bias.data_ptr());
+    auto* p_csidx   = conv_state_indices.data_ptr<int>();
+    auto* p_alog    = reinterpret_cast<const fp16*>(A_log.data_ptr());
+    auto* p_dtbias  = reinterpret_cast<const fp16*>(dt_bias.data_ptr());
+    auto* p_ba      = reinterpret_cast<const fp16*>(ba.data_ptr());
+    auto* p_sstate  = reinterpret_cast<fp16*>(ssm_state.data_ptr());
+    auto* p_ssidx   = ssm_state_indices.data_ptr<int>();
+    auto* p_out     = reinterpret_cast<fp16*>(output.data_ptr());
+    auto* p_zout    = reinterpret_cast<fp16*>(z_out.data_ptr());
+
+    gdn_conv_fused_seq_host(
+        p_qkvz, qkvz_stride0, p_cstate, p_cweight, p_cbias, p_csidx,
+        p_alog, p_dtbias, p_ba, ba_stride0,
+        p_sstate, p_ssidx, p_out, p_zout,
+        (int)N, (int)H, (int)HV, (int)K, (int)V,
+        (float)scale, conv_stride0, ssm_stride0,
+        dpcpp_queue);
+
+    return output;
+}

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_moe.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_moe.sycl
@@ -1,0 +1,154 @@
+/* esimd_kernel_moe.sycl — MoE ESIMD kernels compiled WITHOUT doubleGRF.
+ * Standard GRF (256 regs) → 8 threads/XVE → 2× occupancy vs doubleGRF.
+ * MoE kernels use ~42 GRFs — well within 256 limit.
+ */
+
+#include <ATen/ATen.h>
+#include <ATen/Parallel.h>
+#include <c10/xpu/XPUStream.h>
+#include <torch/python.h>
+
+#include <cstdint>
+#include <sycl/sycl.hpp>
+
+#include "esimd_kernels/moe_ops.h"
+#include "esimd_kernels/fp8_moe_gemm.h"
+
+// Get queue for the specific device (multi-card safe)
+static inline sycl::queue& get_device_queue(const at::Tensor& tensor) {
+    return c10::xpu::getCurrentXPUStream(tensor.device().index()).queue();
+}
+
+// ======================== MoE Auxiliary Ops ========================
+
+at::Tensor esimd_moe_topk(
+    at::Tensor router_logits,
+    at::Tensor top_values,
+    at::Tensor top_indices,
+    int64_t T)
+{
+    auto& q = get_device_queue(router_logits);
+    moe_topk_host(
+        reinterpret_cast<const fp16*>(router_logits.data_ptr()),
+        reinterpret_cast<fp16*>(top_values.data_ptr()),
+        top_indices.data_ptr<int32_t>(),
+        (int)T, q);
+    return top_values;
+}
+
+at::Tensor esimd_moe_scatter(
+    at::Tensor hidden_states,
+    at::Tensor router_top_value,
+    at::Tensor sorted_token_ids,
+    at::Tensor scattered_hidden,
+    at::Tensor scattered_weights,
+    int64_t K, int64_t topk, int64_t total_expanded)
+{
+    auto& q = get_device_queue(hidden_states);
+    moe_scatter_host(
+        reinterpret_cast<const fp16*>(hidden_states.data_ptr()),
+        reinterpret_cast<const fp16*>(router_top_value.data_ptr()),
+        sorted_token_ids.data_ptr<int32_t>(),
+        reinterpret_cast<fp16*>(scattered_hidden.data_ptr()),
+        reinterpret_cast<fp16*>(scattered_weights.data_ptr()),
+        (int)K, (int)topk, (int)total_expanded, q);
+    return scattered_hidden;
+}
+
+at::Tensor esimd_moe_scatter_fused(
+    at::Tensor hidden_states,
+    at::Tensor top_values,
+    at::Tensor top_indices,
+    at::Tensor scattered_hidden,
+    at::Tensor scattered_weights,
+    at::Tensor topk_ids,
+    at::Tensor expert_start,
+    at::Tensor max_tokens_out,
+    int64_t K, int64_t topk, int64_t T, int64_t num_experts)
+{
+    auto& q = get_device_queue(hidden_states);
+    auto experts_token_count = at::zeros({num_experts}, top_indices.options());
+    auto token_to_scatter_offset = at::empty({T * topk}, top_indices.options());
+
+    moe_scatter_fused_host(
+        reinterpret_cast<const fp16*>(hidden_states.data_ptr()),
+        reinterpret_cast<const fp16*>(top_values.data_ptr()),
+        top_indices.data_ptr<int32_t>(),
+        reinterpret_cast<fp16*>(scattered_hidden.data_ptr()),
+        reinterpret_cast<fp16*>(scattered_weights.data_ptr()),
+        topk_ids.data_ptr<int32_t>(),
+        reinterpret_cast<uint32_t*>(expert_start.data_ptr()),
+        max_tokens_out.data_ptr<int32_t>(),
+        experts_token_count.data_ptr<int32_t>(),
+        token_to_scatter_offset.data_ptr<int32_t>(),
+        (int)K, (int)topk, (int)T, (int)num_experts, q);
+    return scattered_hidden;
+}
+
+at::Tensor esimd_moe_silu_mul(
+    at::Tensor input,
+    at::Tensor output,
+    int64_t N_gate_up, int64_t N_half, int64_t total_rows)
+{
+    auto& q = get_device_queue(input);
+    moe_silu_mul_host(
+        reinterpret_cast<const fp16*>(input.data_ptr()),
+        reinterpret_cast<fp16*>(output.data_ptr()),
+        (int)N_gate_up, (int)N_half, (int)total_rows, q);
+    return output;
+}
+
+at::Tensor esimd_moe_gather(
+    at::Tensor moe_output,
+    at::Tensor topk_ids,
+    at::Tensor scattered_weights,
+    at::Tensor final_hidden,
+    int64_t K, int64_t topk, int64_t T)
+{
+    auto& q = get_device_queue(moe_output);
+    moe_gather_host(
+        reinterpret_cast<const fp16*>(moe_output.data_ptr()),
+        topk_ids.data_ptr<int32_t>(),
+        reinterpret_cast<const fp16*>(scattered_weights.data_ptr()),
+        reinterpret_cast<fp16*>(final_hidden.data_ptr()),
+        (int)K, (int)topk, (int)T, q);
+    return final_hidden;
+}
+
+at::Tensor esimd_moe_gemm_fp8(
+    at::Tensor input,
+    at::Tensor weight,
+    at::Tensor scale,
+    at::Tensor output,
+    at::Tensor expert_idx,
+    int64_t N, int64_t K, int64_t num_experts, int64_t max_tokens_per_expert)
+{
+    auto& q = get_device_queue(input);
+    moe_gemm_fp8_e5m2_dispatch(
+        reinterpret_cast<const fp16*>(input.data_ptr()),
+        reinterpret_cast<const uint8_t*>(weight.data_ptr()),
+        scale.data_ptr<float>(),
+        reinterpret_cast<fp16*>(output.data_ptr()),
+        reinterpret_cast<const uint32_t*>(expert_idx.data_ptr()),
+        (int)N, (int)K, (int)num_experts, (int)max_tokens_per_expert, q);
+    return output;
+}
+
+at::Tensor esimd_moe_gemm_fp8_pert(
+    at::Tensor input,
+    at::Tensor weight,
+    at::Tensor scale,
+    at::Tensor output,
+    at::Tensor expert_idx,
+    int64_t N, int64_t K, int64_t num_experts, int64_t max_tokens_per_expert)
+{
+    auto& q = get_device_queue(input);
+    moe_gemm_fp8_e5m2_dispatch_pert(
+        reinterpret_cast<const fp16*>(input.data_ptr()),
+        reinterpret_cast<const uint8_t*>(weight.data_ptr()),
+        scale.data_ptr<float>(),
+        reinterpret_cast<fp16*>(output.data_ptr()),
+        reinterpret_cast<const uint32_t*>(expert_idx.data_ptr()),
+        (int)N, (int)K, (int)num_experts, (int)max_tokens_per_expert, q);
+    return output;
+}

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_topk_v2.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_topk_v2.sycl
@@ -1,0 +1,44 @@
+/* esimd_kernel_topk_v2.sycl — Standalone TopK V2 kernel (no DPAS dependency) */
+
+#include <ATen/ATen.h>
+#include <ATen/Parallel.h>
+#include <c10/xpu/XPUStream.h>
+#include <torch/python.h>
+
+#include <cstdint>
+#include <sycl/sycl.hpp>
+
+// Include only moe_ops.h (TopK kernels, no DPAS)
+#include "esimd_kernels/moe_ops.h"
+
+static inline sycl::queue& get_device_queue(const at::Tensor& tensor) {
+    return c10::xpu::getCurrentXPUStream(tensor.device().index()).queue();
+}
+
+at::Tensor esimd_moe_topk_v2(
+    at::Tensor router_logits,
+    at::Tensor top_values,
+    at::Tensor top_indices,
+    int64_t T, int64_t num_experts, int64_t topk)
+{
+    auto& q = get_device_queue(router_logits);
+    const auto* logits_ptr = reinterpret_cast<const fp16*>(router_logits.data_ptr());
+    auto* values_ptr = reinterpret_cast<fp16*>(top_values.data_ptr());
+    auto* indices_ptr = top_indices.data_ptr<int32_t>();
+
+    if (num_experts == 512 && topk == 10) {
+        moe_topk_v2_host<512, 10>(logits_ptr, values_ptr, indices_ptr, (int)T, q);
+    } else if (num_experts == 512 && topk == 8) {
+        moe_topk_v2_host<512, 8>(logits_ptr, values_ptr, indices_ptr, (int)T, q);
+    } else if (num_experts == 256 && topk == 10) {
+        moe_topk_v2_host<256, 10>(logits_ptr, values_ptr, indices_ptr, (int)T, q);
+    } else if (num_experts == 128 && topk == 8) {
+        moe_topk_v2_host<128, 8>(logits_ptr, values_ptr, indices_ptr, (int)T, q);
+    } else if (num_experts == 128 && topk == 10) {
+        moe_topk_v2_host<128, 10>(logits_ptr, values_ptr, indices_ptr, (int)T, q);
+    } else {
+        TORCH_CHECK(false, "esimd_moe_topk_v2: unsupported (num_experts=", num_experts,
+                    ", topk=", topk, ")");
+    }
+    return top_values;
+}

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/fp8_GEMM_pert.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/fp8_GEMM_pert.h
@@ -1,0 +1,2951 @@
+#pragma once
+#include <sycl/sycl.hpp>
+#include <sycl/ext/intel/esimd.hpp>
+#include <sycl/ext/intel/experimental/esimd/memory.hpp>
+#include <sycl/ext/intel/esimd/xmx/dpas.hpp>
+
+using namespace sycl::ext::intel::esimd;
+using namespace sycl::ext::intel::esimd::xmx;
+using namespace sycl;
+using fp16 = sycl::half;
+
+// ============================================================================
+// FP8 Per-Tensor GEMM: M=1~64 extension of GEMV
+//
+// Three regimes based on M:
+//   A) M=1~4:  Batched GEMV — M-parallel WGs, K-split SLM reduction
+//   B) M=5~8:  Weight-stationary — one WG per N row, TILE_M=8 M-loop
+//   C) M=9~64: Weight-stationary — 2D grid, TILE_M=16 M-tiles
+//
+// Per-tensor scale only. Both E4M3 and E5M2.
+// Input: [M, K] fp16, Weight: [N, K] fp8, Output: [M, N] fp16
+// ============================================================================
+
+// ---- FP8 -> FP32 dequant ----
+// E4M3: sign(1) exp(4,bias=7) mant(3) -> fp16 bits -> fp32
+// E5M2: sign(1) exp(5,bias=15) mant(2) -> fp16 bits -> fp32
+// Subnormal (exp==0): flush to signed zero
+template<int VL>
+SYCL_ESIMD_FUNCTION inline simd<float, VL> fp8_dequant(
+    simd<uint8_t, VL> raw, int fp8_mode) {
+    simd<uint16_t, VL> u16 = convert<uint16_t>(raw);
+    simd<uint16_t, VL> fp8_sign = (u16 >> 7) & 1;
+    simd<uint16_t, VL> fp16_bits;
+
+    if (fp8_mode == 0) {
+        simd<uint16_t, VL> fp8_exp  = (u16 >> 3) & 0xF;
+        simd<uint16_t, VL> fp8_mant = u16 & 0x7;
+        fp16_bits = (fp8_sign << 15) | ((fp8_exp + 8) << 10) | (fp8_mant << 7);
+        fp16_bits.merge(fp8_sign << 15, fp8_exp == 0);
+    } else {
+        simd<uint16_t, VL> fp8_exp  = (u16 >> 2) & 0x1F;
+        simd<uint16_t, VL> fp8_mant = u16 & 0x3;
+        fp16_bits = (fp8_sign << 15) | (fp8_exp << 10) | (fp8_mant << 8);
+        fp16_bits.merge(fp8_sign << 15, fp8_exp == 0);
+    }
+
+    simd<fp16, VL> wh = fp16_bits.template bit_cast_view<fp16>().read();
+    return simd<float, VL>(wh);
+}
+
+// ---- FP8 -> FP16 dequant (for future DPAS path) ----
+template<int VL>
+SYCL_ESIMD_FUNCTION inline simd<fp16, VL> fp8_dequant_fp16(
+    simd<uint8_t, VL> raw, int fp8_mode) {
+    simd<uint16_t, VL> u16 = convert<uint16_t>(raw);
+    simd<uint16_t, VL> fp8_sign = (u16 >> 7) & 1;
+    simd<uint16_t, VL> fp16_bits;
+
+    if (fp8_mode == 0) {
+        simd<uint16_t, VL> fp8_exp  = (u16 >> 3) & 0xF;
+        simd<uint16_t, VL> fp8_mant = u16 & 0x7;
+        fp16_bits = (fp8_sign << 15) | ((fp8_exp + 8) << 10) | (fp8_mant << 7);
+        fp16_bits.merge(fp8_sign << 15, fp8_exp == 0);
+    } else {
+        simd<uint16_t, VL> fp8_exp  = (u16 >> 2) & 0x1F;
+        simd<uint16_t, VL> fp8_mant = u16 & 0x3;
+        fp16_bits = (fp8_sign << 15) | (fp8_exp << 10) | (fp8_mant << 8);
+        fp16_bits.merge(fp8_sign << 15, fp8_exp == 0);
+    }
+
+    return fp16_bits.template bit_cast_view<fp16>().read();
+}
+
+// ---- VL/K_SPLIT auto-selection (reused from GEMV) ----
+inline void select_vl_ks(uint32_t N, uint32_t K, int& vl, int& ks) {
+    vl = 512; ks = 1;
+
+    if (K < 512) {
+        vl = 128; ks = 1;
+    } else if (K == 512) {
+        vl = 256; ks = 1;
+    }
+
+    if (N <= 128 && K >= 2048) {
+        vl = 128; ks = 8;
+    } else if (N <= 512 && K >= 2048) {
+        vl = 128; ks = 4;
+    }
+
+    int kpt = K / ks;
+    while (vl > kpt || kpt % vl != 0) {
+        if (vl > 128) {
+            vl /= 2;
+        } else if (ks > 1) {
+            ks /= 2;
+            kpt = K / ks;
+        } else {
+            break;
+        }
+    }
+}
+
+// ============================================================================
+// Regime A: Batched GEMV (M=1~4)
+// nd_range<2>({N*K_SPLIT, M}, {K_SPLIT, 1})
+// Each WG handles one (n, m) output element with K_SPLIT threads
+// ============================================================================
+template<int VL, int K_SPLIT>
+struct GEMV_fp8_pert_batched_kernel {
+    const fp16*    input;      // [M, K]
+    const uint8_t* weight;     // [N, K]
+    const float*   scale_ptr;  // scalar
+    fp16*          output;     // [M, N]
+    int M, N, K;
+    int fp8_mode;
+
+    void operator()(sycl::nd_item<2> item) const SYCL_ESIMD_KERNEL {
+        if constexpr (K_SPLIT > 1) {
+            slm_init<K_SPLIT * sizeof(float)>();
+        }
+
+        int n   = item.get_group(0);
+        int m   = item.get_group(1);
+        int lid = item.get_local_id(0);
+        if (n >= N || m >= M) return;
+
+        int kp = K / K_SPLIT;
+        int ks = lid * kp;
+
+        simd<float, VL> acc = 0.0f;
+
+        for (int k = ks; k < ks + kp; k += VL) {
+            simd<fp16, VL> iv = block_load<fp16, VL>(input + (size_t)m * K + k);
+            simd<float, VL> input_f = iv;
+
+            simd<uint8_t, VL> raw = block_load<uint8_t, VL>(weight + (size_t)n * K + k);
+            simd<float, VL> wf = fp8_dequant<VL>(raw, fp8_mode);
+
+            acc += input_f * wf;
+        }
+
+        float my_sum = reduce<float>(acc, std::plus<>()) * *scale_ptr;
+
+        if constexpr (K_SPLIT == 1) {
+            output[(size_t)m * N + n] = fp16(my_sum);
+        } else {
+            slm_block_store<float, 1>(lid * sizeof(float), simd<float, 1>(my_sum));
+            barrier();
+            if (lid == 0) {
+                simd<float, K_SPLIT> parts = slm_block_load<float, K_SPLIT>(0);
+                output[(size_t)m * N + n] = fp16(reduce<float>(parts, std::plus<>()));
+            }
+        }
+    }
+};
+
+// ============================================================================
+// Regime B/C: Weight-Stationary GEMM (M=5~64)
+// nd_range<2>({N, ceil(M/TILE_M)}, {1, 1})
+// Each single-thread WG handles output[m_start:m_start+TILE_M, n]
+// Weight row loaded once, reused across TILE_M input rows
+// ============================================================================
+template<int VL, int TILE_M>
+struct GEMM_fp8_pert_ws_kernel {
+    const fp16*    input;      // [M, K]
+    const uint8_t* weight;     // [N, K]
+    const float*   scale_ptr;  // scalar
+    fp16*          output;     // [M, N]
+    int M, N, K;
+    int fp8_mode;
+
+    void operator()(sycl::nd_item<2> item) const SYCL_ESIMD_KERNEL {
+        int n       = item.get_group(0);
+        int m_tile  = item.get_group(1);
+        int m_start = m_tile * TILE_M;
+        if (n >= N) return;
+
+        simd<float, VL> acc[TILE_M];
+        #pragma unroll
+        for (int i = 0; i < TILE_M; i++) acc[i] = 0.0f;
+
+        for (int k = 0; k < K; k += VL) {
+            // Load weight row once
+            simd<uint8_t, VL> raw = block_load<uint8_t, VL>(weight + (size_t)n * K + k);
+            simd<float, VL> wf = fp8_dequant<VL>(raw, fp8_mode);
+
+            // Multiply with each active input row
+            #pragma unroll
+            for (int i = 0; i < TILE_M; i++) {
+                if (m_start + i < M) {
+                    simd<fp16, VL> iv = block_load<fp16, VL>(
+                        input + (size_t)(m_start + i) * K + k);
+                    acc[i] += simd<float, VL>(iv) * wf;
+                }
+            }
+        }
+
+        // Reduce accumulators, apply scale, store
+        float s = *scale_ptr;
+        #pragma unroll
+        for (int i = 0; i < TILE_M; i++) {
+            if (m_start + i < M) {
+                float sum = reduce<float>(acc[i], std::plus<>()) * s;
+                output[(size_t)(m_start + i) * N + n] = fp16(sum);
+            }
+        }
+    }
+};
+
+#ifdef GEMM_EXPERIMENTAL  // Dead code: old DPAS kernel struct
+// ============================================================================
+// Regime D: DPAS-based GEMM (M>=8)
+// nd_range<2>({ceil(N/TILE_N), ceil(M/8)}, {1, 1})
+// Each single-thread WG computes output[m_start:m_start+8, n_start:n_start+TILE_N]
+// Uses XMX dpas<8,8> for fp16 multiply-accumulate
+// Weight: dequant FP8->FP16 in registers, pack into VNNI for b_tile
+// Input: load as fp16 directly into a_tile
+// ============================================================================
+template<int TILE_N>
+struct GEMM_fp8_pert_dpas_kernel {
+    const fp16*    input;      // [M, K]
+    const uint8_t* weight;     // [N, K]
+    const float*   scale_ptr;  // scalar
+    fp16*          output;     // [M, N]
+    int M, N, K;
+    int fp8_mode;
+
+    void operator()(sycl::nd_item<2> item) const SYCL_ESIMD_KERNEL {
+        int n_tile  = item.get_group(0);
+        int m_tile  = item.get_group(1);
+        int n_start = n_tile * TILE_N;
+        int m_start = m_tile * 8;
+        if (n_start >= N) return;
+
+        constexpr int N_DPAS = TILE_N / 16;
+        constexpr int K_CHUNK = 128;
+        constexpr int K_SUBS = K_CHUNK / 16;  // = 8
+
+        simd<float, 128> acc[N_DPAS];
+        #pragma unroll
+        for (int j = 0; j < N_DPAS; j++) acc[j] = 0.0f;
+
+        for (int k_base = 0; k_base < K; k_base += K_CHUNK) {
+            // Pre-load and dequant weight for all N-groups
+            // w_dq[j]: 16 rows × K_CHUNK fp16 = simd<fp16, 16*K_CHUNK>
+            simd<fp16, 16 * K_CHUNK> w_dq[N_DPAS];
+
+            #pragma unroll
+            for (int j = 0; j < N_DPAS; j++) {
+                w_dq[j] = 0;
+                int n_base = n_start + j * 16;
+                #pragma unroll
+                for (int ni = 0; ni < 16; ni++) {
+                    if (n_base + ni < N) {
+                        simd<uint8_t, K_CHUNK> raw = block_load<uint8_t, K_CHUNK>(
+                            weight + (size_t)(n_base + ni) * K + k_base);
+                        w_dq[j].template select<K_CHUNK, 1>(ni * K_CHUNK) =
+                            fp8_dequant_fp16<K_CHUNK>(raw, fp8_mode);
+                    }
+                }
+            }
+
+            // K sub-steps: each processes 16 K-elements via DPAS
+            for (int ks = 0; ks < K_SUBS; ks++) {
+                int k = k_base + ks * 16;
+                if (k >= K) break;
+
+                // Load a_tile ONCE per sub-step (shared across all N-groups)
+                simd<fp16, 128> a_tile = 0;
+                #pragma unroll
+                for (int m = 0; m < 8; m++) {
+                    if (m_start + m < M) {
+                        a_tile.template select<16, 1>(m * 16) = block_load<fp16, 16>(
+                            input + (size_t)(m_start + m) * K + k);
+                    }
+                }
+
+                // DPAS for each N-group using pre-loaded weight
+                #pragma unroll
+                for (int j = 0; j < N_DPAS; j++) {
+                    auto w_u16 = w_dq[j].template bit_cast_view<uint16_t>();
+                    simd<uint32_t, 128> b_vnni;
+
+                    #pragma unroll
+                    for (int kp = 0; kp < 8; kp++) {
+                        simd<uint16_t, 16> lo = w_u16.template select<16, K_CHUNK>(
+                            ks * 16 + 2 * kp);
+                        simd<uint16_t, 16> hi = w_u16.template select<16, K_CHUNK>(
+                            ks * 16 + 2 * kp + 1);
+                        b_vnni.template select<16, 1>(kp * 16) =
+                            convert<uint32_t>(lo) | (convert<uint32_t>(hi) << 16);
+                    }
+
+                    simd<fp16, 256> b_tile =
+                        b_vnni.template bit_cast_view<fp16>().read();
+
+                    acc[j] = dpas<8, 8, float, float, fp16, fp16>(
+                        acc[j], b_tile, a_tile);
+                }
+            }
+        }
+
+        // Apply per-tensor scale, convert to fp16, store
+        float s = *scale_ptr;
+        #pragma unroll
+        for (int j = 0; j < N_DPAS; j++) {
+            int n_base = n_start + j * 16;
+            simd<float, 128> scaled = acc[j] * s;
+
+            #pragma unroll
+            for (int m = 0; m < 8; m++) {
+                if (m_start + m < M) {
+                    int n_cols = (n_base + 16 <= N) ? 16 : (N - n_base);
+                    simd<float, 16> row_f = scaled.template select<16, 1>(m * 16);
+                    simd<fp16, 16> out_row = convert<fp16>(row_f);
+                    if (n_cols == 16) {
+                        block_store<fp16, 16>(
+                            output + (size_t)(m_start + m) * N + n_base, out_row);
+                    } else {
+                        for (int ni = 0; ni < n_cols; ni++) {
+                            output[(size_t)(m_start + m) * N + n_base + ni] = out_row[ni];
+                        }
+                    }
+                }
+            }
+        }
+    }
+};
+#endif // GEMM_EXPERIMENTAL — old DPAS kernel struct
+
+// ============================================================================
+// Regime E: DPAS V2 — Multi-thread WG (adapted from FP16 GEMM pattern)
+//
+// Key improvement over Regime D: multiple threads per WG share the same
+// input rows via L1 cache, eliminating the N×M input re-read amplification.
+//
+// WG_SIZE threads per WG, each handles 16 N-columns × M_TILES×8 M-rows.
+// N_WG = WG_SIZE × 16 N-columns per WG.
+// Grid: ceil(N / N_WG) WGs.
+//
+// Per K-step (16 K-elements):
+//   1. Load weight [16N × 16K] via lsc_load_2d<uint8_t> — unique per thread
+//   2. Dequant FP8→FP16 in SIMD registers
+//   3. VNNI pack [N=16, K=16] → [K_pair=8, N=16] via stride-16 selects
+//   4. Load input [8M × 16K] via lsc_load_2d<fp16> — shared via L1 cache
+//   5. DPAS<8,8> for each M-tile
+// ============================================================================
+namespace xesimd = sycl::ext::intel::experimental::esimd;
+
+// --- Dequant + VNNI pack helper for 16×16 FP8 tile ---
+// Input: raw uint8 in [N=16, K=16] layout from lsc_load_2d
+// Output: DPAS b_tile in VNNI format [K_pair=8, N=16] as fp16(uint32)
+SYCL_ESIMD_FUNCTION inline simd<fp16, 256>
+fp8_tile_to_vnni(simd<uint8_t, 256> raw, int fp8_mode) {
+    simd<fp16, 256> w_fp16 = fp8_dequant_fp16<256>(raw, fp8_mode);
+    simd<uint16_t, 256> w_u16 = w_fp16.bit_cast_view<uint16_t>().read();
+    simd<uint32_t, 128> b_vnni;
+
+    #pragma unroll
+    for (int kp = 0; kp < 8; kp++) {
+        simd<uint16_t, 16> lo = w_u16.select<16, 16>(2 * kp);
+        simd<uint16_t, 16> hi = w_u16.select<16, 16>(2 * kp + 1);
+        b_vnni.select<16, 1>(kp * 16) =
+            convert<uint32_t>(lo) | (convert<uint32_t>(hi) << 16);
+    }
+
+    return b_vnni.bit_cast_view<fp16>().read();
+}
+
+// --- oneDNN-style branchless FP8 E4M3 → FP16 dequant ---
+// Derived from ISA analysis of oneDNN JIT `jit:gemm:any` kernel.
+// 4 SIMD ops vs ~8+ for the generic version, completely branchless.
+// Math: shl(byte,8) → asr(1) → and(0xBFFF) → mul(256.0)
+// This maps FP8 E4M3 (bias=7) directly to FP16 (bias=15) via exponent shift.
+// Handles normal values and zero correctly. Subnormals get small error (not flushed).
+// NaN (0x7F) maps to ~240 instead of NaN — acceptable for filtered inputs.
+template<int VL>
+SYCL_ESIMD_FUNCTION inline simd<fp16, VL> fp8_e4m3_dequant_branchless(
+    simd<uint8_t, VL> raw) {
+    // Step 1: byte → high byte of 16-bit word (equivalent to SHL 8)
+    simd<uint16_t, VL> u16 = convert<uint16_t>(raw);
+    u16 = u16 << 8;
+
+    // Step 2: arithmetic right shift 1 — sign-extends into bit 14
+    simd<int16_t, VL> s16 = u16.template bit_cast_view<int16_t>().read();
+    s16 = s16 >> 1;
+    simd<uint16_t, VL> result_u16 = s16.template bit_cast_view<uint16_t>().read();
+
+    // Step 3: clear duplicated sign bit (bit 14) — AND 0xBFFF
+    result_u16 = result_u16 & 0xBFFF;
+
+    // Step 4: multiply by 256.0 to correct exponent bias (FP8 bias=7 → FP16 bias=15)
+    simd<fp16, VL> result = result_u16.template bit_cast_view<fp16>().read();
+    result = result * fp16(256.0f);
+
+    return result;
+}
+
+// --- Fast VNNI pack using branchless dequant ---
+// Uses direct strided writes to pack lo/hi fp16 into uint32 VNNI format
+// instead of convert<uint32>+shift+or which generates excessive ALU
+SYCL_ESIMD_FUNCTION inline simd<fp16, 256>
+fp8_tile_to_vnni_fast(simd<uint8_t, 256> raw) {
+    simd<fp16, 256> w_fp16 = fp8_e4m3_dequant_branchless<256>(raw);
+    simd<uint16_t, 256> w_u16 = w_fp16.template bit_cast_view<uint16_t>().read();
+    simd<uint16_t, 256> b_vnni_u16;
+
+    #pragma unroll
+    for (int kp = 0; kp < 8; kp++) {
+        simd<uint16_t, 16> lo = w_u16.template select<16, 16>(2 * kp);
+        simd<uint16_t, 16> hi = w_u16.template select<16, 16>(2 * kp + 1);
+        // Direct strided write: lo→even uint16 slots, hi→odd uint16 slots
+        b_vnni_u16.template select<16, 2>(kp * 32) = lo;      // even positions
+        b_vnni_u16.template select<16, 2>(kp * 32 + 1) = hi;  // odd positions
+    }
+
+    return b_vnni_u16.template bit_cast_view<fp16>().read();
+}
+
+// --- Optimized FP8→FP16 dequant (E4M3 only, combined shift+add) ---
+// ~10 SIMD ops per 16 elements vs ~13 for the generic version
+SYCL_ESIMD_FUNCTION inline simd<uint16_t, 128>
+fp8_e4m3_to_fp16_bits_opt(simd<uint16_t, 128> raw) {
+    simd<uint16_t, 128> sign_bit = (raw & 0x80) << 8;     // sign at bit 15
+    simd<uint16_t, 128> upart    = raw & 0x7F;             // exp|mant (7 bits)
+    simd<uint16_t, 128> fp16     = sign_bit | ((upart << 7) + 0x2000);  // bias exp by +8
+    fp16.merge(sign_bit, (raw & 0x78) == 0);               // flush subnormal to ±0
+    return fp16;
+}
+
+// --- Gather-based weight load + inline dequant → VNNI b_tile ---
+// Uses lsc_gather<u32, 4, N=16>: 4 uint32 per lane = 16 bytes = 16 fp8 values.
+// SOA layout: result[e*16+n] = {fp8[n,k+4e+0], fp8[n,k+4e+1], fp8[n,k+4e+2], fp8[n,k+4e+3]}
+// Then extract bytes, dequant to fp16, VNNI pack pairs.
+SYCL_ESIMD_FUNCTION inline simd<fp16, 256>
+fp8_gather_to_vnni(const uint8_t* weight, int n_start, int k, int K, int fp8_mode) {
+    simd<uint32_t, 16> b_off;
+    #pragma unroll
+    for (int n = 0; n < 16; n++)
+        b_off[n] = (uint32_t)(n_start + n) * (uint32_t)K + (uint32_t)k;
+
+    const uint32_t* w_u32 = reinterpret_cast<const uint32_t*>(weight);
+    simd<uint32_t, 64> raw_u32 = xesimd::lsc_gather<uint32_t, 4,
+        xesimd::lsc_data_size::default_size,
+        xesimd::cache_hint::cached, xesimd::cache_hint::cached,
+        16, uint32_t>(w_u32, b_off);
+
+    // raw_u32[e*16+n] has 4 fp8 bytes for K indices k+4e+{0,1,2,3}
+    // Each group e produces 2 VNNI k-pairs: kp=2e, kp=2e+1
+    simd<uint32_t, 128> b_vnni;
+
+    #pragma unroll
+    for (int e = 0; e < 4; e++) {
+        simd<uint32_t, 16> grp = raw_u32.template select<16, 1>(e * 16);
+
+        // Extract 4 bytes as uint16 for dequant
+        simd<uint16_t, 16> b0 = convert<uint16_t>(grp & 0xFF);
+        simd<uint16_t, 16> b1 = convert<uint16_t>((grp >> 8) & 0xFF);
+        simd<uint16_t, 16> b2 = convert<uint16_t>((grp >> 16) & 0xFF);
+        simd<uint16_t, 16> b3 = convert<uint16_t>((grp >> 24) & 0xFF);
+
+        simd<uint16_t, 16> fp0, fp1, fp2, fp3;
+        if (fp8_mode == 0) {
+            // E4M3 optimized dequant
+            auto dq = [](simd<uint16_t, 16> r) -> simd<uint16_t, 16> {
+                simd<uint16_t, 16> s = (r & 0x80) << 8;
+                simd<uint16_t, 16> u = r & 0x7F;
+                simd<uint16_t, 16> f = s | ((u << 7) + 0x2000);
+                f.merge(s, (r & 0x78) == 0);
+                return f;
+            };
+            fp0 = dq(b0); fp1 = dq(b1); fp2 = dq(b2); fp3 = dq(b3);
+        } else {
+            // E5M2 dequant
+            auto dq = [](simd<uint16_t, 16> r) -> simd<uint16_t, 16> {
+                simd<uint16_t, 16> s = (r & 0x80) << 8;
+                simd<uint16_t, 16> e = (r >> 2) & 0x1F;
+                simd<uint16_t, 16> m = r & 0x3;
+                simd<uint16_t, 16> f = s | (e << 10) | (m << 8);
+                f.merge(s, e == 0);
+                return f;
+            };
+            fp0 = dq(b0); fp1 = dq(b1); fp2 = dq(b2); fp3 = dq(b3);
+        }
+
+        // VNNI pack: pair (fp0,fp1) → kp=2e, pair (fp2,fp3) → kp=2e+1
+        b_vnni.template select<16, 1>(e * 2 * 16) =
+            convert<uint32_t>(fp0) | (convert<uint32_t>(fp1) << 16);
+        b_vnni.template select<16, 1>((e * 2 + 1) * 16) =
+            convert<uint32_t>(fp2) | (convert<uint32_t>(fp3) << 16);
+    }
+
+    return b_vnni.template bit_cast_view<fp16>().read();
+}
+
+#ifdef GEMM_EXPERIMENTAL  // Dead code: V2, V3, V4, V5 kernel structs
+template<int WG_SIZE, int M_TILES>
+struct FP8_GEMM_DPAS_V2 {
+    const fp16*    input;      // [M, K]
+    const uint8_t* weight;     // [N, K]
+    const float*   scale_ptr;  // scalar
+    fp16*          output;     // [M, N]
+    int M, N, K;
+    int fp8_mode;
+
+    void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+        constexpr int N_PER_THREAD = 16;
+        constexpr int N_WG = WG_SIZE * N_PER_THREAD;
+        constexpr int K_SUB = 16;
+
+        int wg_id = item.get_group(0);
+        int tid   = item.get_local_id(0);
+
+        int n_start = wg_id * N_WG + tid * N_PER_THREAD;
+        if (n_start >= N) return;
+
+        // Accumulators: M_TILES × 1 DPAS tile (8×16 = 128 floats each)
+        simd<float, 128> acc[M_TILES];
+        #pragma unroll
+        for (int i = 0; i < M_TILES; i++) acc[i] = 0.0f;
+
+        // 2D payload for input A: [M, K] fp16
+        const uint32_t surfW_A = (uint32_t)K * 2u - 1u;
+        const uint32_t surfH_A = (uint32_t)M - 1u;
+        xesimd::config_2d_mem_access<fp16, 16, 8, 1> payA(
+            input, surfW_A, surfH_A, surfW_A, 0u, 0u);
+
+        // --- MAIN K-LOOP ---
+        // K_STEP=32: load 2 weight tiles per iteration, do 2 DPAS calls per tile
+        // Double-buffer: load weight[k+32], compute weight[k..k+31]
+        constexpr int K_STEP = 32;
+
+        // 2D payload for weight B: [N, K] uint8
+        const uint32_t surfW_B = (uint32_t)K - 1u;
+        const uint32_t surfH_B = (uint32_t)N - 1u;
+        xesimd::config_2d_mem_access<uint8_t, 16, 16, 1> payB(
+            weight, surfW_B, surfH_B, surfW_B, 0u, (uint32_t)n_start);
+
+        simd<fp16, 256> b_tile[2][2];  // [buf][sub]
+
+        // Prologue: load+dequant k=0,16
+        payB.set_x(0u);
+        {
+            simd<uint8_t, 256> raw = xesimd::lsc_load_2d<uint8_t, 16, 16, 1,
+                false, false,
+                xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payB);
+            b_tile[0][0] = ((fp8_mode == 0) ? fp8_tile_to_vnni_fast(raw) : fp8_tile_to_vnni(raw, fp8_mode));
+        }
+        payB.set_x((uint32_t)K_SUB);
+        {
+            simd<uint8_t, 256> raw = xesimd::lsc_load_2d<uint8_t, 16, 16, 1,
+                false, false,
+                xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payB);
+            b_tile[0][1] = ((fp8_mode == 0) ? fp8_tile_to_vnni_fast(raw) : fp8_tile_to_vnni(raw, fp8_mode));
+        }
+
+        for (int k = 0; k < K - K_STEP; k += K_STEP) {
+            // Load next K_STEP (2 sub-tiles)
+            payB.set_x((uint32_t)(k + K_STEP));
+            {
+                simd<uint8_t, 256> raw = xesimd::lsc_load_2d<uint8_t, 16, 16, 1,
+                    false, false,
+                    xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payB);
+                b_tile[1][0] = ((fp8_mode == 0) ? fp8_tile_to_vnni_fast(raw) : fp8_tile_to_vnni(raw, fp8_mode));
+            }
+            payB.set_x((uint32_t)(k + K_STEP + K_SUB));
+            {
+                simd<uint8_t, 256> raw = xesimd::lsc_load_2d<uint8_t, 16, 16, 1,
+                    false, false,
+                    xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payB);
+                b_tile[1][1] = ((fp8_mode == 0) ? fp8_tile_to_vnni_fast(raw) : fp8_tile_to_vnni(raw, fp8_mode));
+            }
+
+            // Compute sub-step 0 (k)
+            payA.set_x((uint32_t)k);
+            #pragma unroll
+            for (int m = 0; m < M_TILES; m++) {
+                payA.set_y((uint32_t)(m * 8));
+                simd<fp16, 128> a = xesimd::lsc_load_2d<fp16, 16, 8, 1,
+                    false, false,
+                    xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payA);
+                acc[m] = dpas<8, 8, float, float, fp16, fp16>(acc[m], b_tile[0][0], a);
+            }
+
+            // Compute sub-step 1 (k+16)
+            payA.set_x((uint32_t)(k + K_SUB));
+            #pragma unroll
+            for (int m = 0; m < M_TILES; m++) {
+                payA.set_y((uint32_t)(m * 8));
+                simd<fp16, 128> a = xesimd::lsc_load_2d<fp16, 16, 8, 1,
+                    false, false,
+                    xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payA);
+                acc[m] = dpas<8, 8, float, float, fp16, fp16>(acc[m], b_tile[0][1], a);
+            }
+
+            b_tile[0][0] = b_tile[1][0];
+            b_tile[0][1] = b_tile[1][1];
+        }
+
+        // Epilogue: last K_STEP
+        {
+            int k = K - K_STEP;
+            payA.set_x((uint32_t)k);
+            #pragma unroll
+            for (int m = 0; m < M_TILES; m++) {
+                payA.set_y((uint32_t)(m * 8));
+                simd<fp16, 128> a = xesimd::lsc_load_2d<fp16, 16, 8, 1,
+                    false, false,
+                    xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payA);
+                acc[m] = dpas<8, 8, float, float, fp16, fp16>(acc[m], b_tile[0][0], a);
+            }
+            payA.set_x((uint32_t)(k + K_SUB));
+            #pragma unroll
+            for (int m = 0; m < M_TILES; m++) {
+                payA.set_y((uint32_t)(m * 8));
+                simd<fp16, 128> a = xesimd::lsc_load_2d<fp16, 16, 8, 1,
+                    false, false,
+                    xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payA);
+                acc[m] = dpas<8, 8, float, float, fp16, fp16>(acc[m], b_tile[0][1], a);
+            }
+        }
+
+        // --- Store: apply per-tensor scale, convert fp32→fp16, write ---
+        float s = *scale_ptr;
+        #pragma unroll
+        for (int m = 0; m < M_TILES; m++) {
+            simd<float, 128> scaled = acc[m] * s;
+            int n_valid = (n_start + 16 <= N) ? 16 : (N - n_start);
+            bool full_n = (n_valid == 16);
+
+            #pragma unroll
+            for (int mi = 0; mi < 8; mi++) {
+                int row = m * 8 + mi;
+                if (row < M) {
+                    simd<float, 16> row_f = scaled.select<16, 1>(mi * 16);
+                    simd<fp16, 16> out_row = convert<fp16>(row_f);
+                    if (full_n) {
+                        block_store<fp16, 16>(
+                            output + (size_t)row * N + n_start, out_row);
+                    } else {
+                        for (int ni = 0; ni < n_valid; ni++) {
+                            output[(size_t)row * N + n_start + ni] = out_row[ni];
+                        }
+                    }
+                }
+            }
+        }
+    }
+};
+
+// ============================================================================
+// Regime F: DPAS V3 — 2D grid (M-tiles as separate WGs)
+//
+// Key improvement over V2: always M_TILES=1 per thread, with M-tiles
+// distributed across separate WGs. This gives M/8 × more total threads
+// for better memory latency hiding.
+//
+// Grid layout: M-inner so WGs with same N but different M are adjacent
+// → scheduled on same XE core → L1 weight sharing.
+//
+// For M=32, N=2560, WG_SIZE=8:
+//   V2: 20 WGs, 160 threads (1/XVE)
+//   V3: 80 WGs, 640 threads (4/XVE)
+// ============================================================================
+template<int WG_SIZE>
+struct FP8_GEMM_DPAS_V3 {
+    const fp16*    input;
+    const uint8_t* weight;
+    const float*   scale_ptr;
+    fp16*          output;
+    int M, N, K;
+    int fp8_mode;
+    int m_wgs;  // number of M-tile groups = ceil(M/8)
+
+    void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+        constexpr int N_PER_THREAD = 16;
+        constexpr int N_WG = WG_SIZE * N_PER_THREAD;
+        constexpr int K_SUB = 16;
+
+        int wg_id = item.get_group(0);
+        int tid   = item.get_local_id(0);
+
+        // M-inner layout: wg_id = n_wg * m_wgs + m_tile
+        int m_tile = wg_id % m_wgs;
+        int n_wg   = wg_id / m_wgs;
+        int m_start = m_tile * 8;
+        int n_start = n_wg * N_WG + tid * N_PER_THREAD;
+        if (n_start >= N) return;
+
+        simd<float, 128> acc = 0.0f;
+
+        // 2D payloads
+        const uint32_t surfW_A = (uint32_t)K * 2u - 1u;
+        const uint32_t surfH_A = (uint32_t)M - 1u;
+        xesimd::config_2d_mem_access<fp16, 16, 8, 1> payA(
+            input, surfW_A, surfH_A, surfW_A, 0u, (uint32_t)m_start);
+
+        const uint32_t surfW_B = (uint32_t)K - 1u;
+        const uint32_t surfH_B = (uint32_t)N - 1u;
+        xesimd::config_2d_mem_access<uint8_t, 16, 16, 1> payB(
+            weight, surfW_B, surfH_B, surfW_B, 0u, (uint32_t)n_start);
+
+        // Double-buffered weight
+        simd<fp16, 256> b_buf[2];
+
+        // Prologue
+        payB.set_x(0u);
+        {
+            simd<uint8_t, 256> raw = xesimd::lsc_load_2d<uint8_t, 16, 16, 1,
+                false, false,
+                xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payB);
+            b_buf[0] = ((fp8_mode == 0) ? fp8_tile_to_vnni_fast(raw) : fp8_tile_to_vnni(raw, fp8_mode));
+        }
+
+        for (int k = 0; k < K - K_SUB; k += K_SUB) {
+            payB.set_x((uint32_t)(k + K_SUB));
+            {
+                simd<uint8_t, 256> raw = xesimd::lsc_load_2d<uint8_t, 16, 16, 1,
+                    false, false,
+                    xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payB);
+                b_buf[1] = ((fp8_mode == 0) ? fp8_tile_to_vnni_fast(raw) : fp8_tile_to_vnni(raw, fp8_mode));
+            }
+
+            payA.set_x((uint32_t)k);
+            simd<fp16, 128> a = xesimd::lsc_load_2d<fp16, 16, 8, 1,
+                false, false,
+                xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payA);
+            acc = dpas<8, 8, float, float, fp16, fp16>(acc, b_buf[0], a);
+
+            b_buf[0] = b_buf[1];
+        }
+
+        // Epilogue
+        {
+            payA.set_x((uint32_t)(K - K_SUB));
+            simd<fp16, 128> a = xesimd::lsc_load_2d<fp16, 16, 8, 1,
+                false, false,
+                xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payA);
+            acc = dpas<8, 8, float, float, fp16, fp16>(acc, b_buf[0], a);
+        }
+
+        // Store
+        float s = *scale_ptr;
+        simd<float, 128> scaled = acc * s;
+        int n_valid = (n_start + 16 <= N) ? 16 : (N - n_start);
+        bool full_n = (n_valid == 16);
+
+        #pragma unroll
+        for (int mi = 0; mi < 8; mi++) {
+            int row = m_start + mi;
+            if (row < M) {
+                simd<float, 16> row_f = scaled.select<16, 1>(mi * 16);
+                simd<fp16, 16> out_row = convert<fp16>(row_f);
+                if (full_n) {
+                    block_store<fp16, 16>(
+                        output + (size_t)row * N + n_start, out_row);
+                } else {
+                    for (int ni = 0; ni < n_valid; ni++) {
+                        output[(size_t)row * N + n_start + ni] = out_row[ni];
+                    }
+                }
+            }
+        }
+    }
+};
+
+// Host dispatcher for DPAS V3
+template<int WG_SIZE>
+inline void dpas_v3_gemm_fp8_pert_host(
+    const fp16*    input,
+    const uint8_t* weight,
+    const float*   scale_ptr,
+    fp16*          output,
+    uint32_t M, uint32_t N, uint32_t K,
+    int fp8_mode,
+    sycl::queue& q) {
+
+    constexpr int N_WG = WG_SIZE * 16;
+    int n_wgs = ((int)N + N_WG - 1) / N_WG;
+    int m_wgs = ((int)M + 7) / 8;
+    int total_wgs = n_wgs * m_wgs;
+
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(
+            sycl::nd_range<1>({(size_t)(total_wgs * WG_SIZE)}, {(size_t)WG_SIZE}),
+            FP8_GEMM_DPAS_V3<WG_SIZE>{
+                input, weight, scale_ptr, output,
+                (int)M, (int)N, (int)K, fp8_mode, m_wgs});
+    });
+}
+
+// ============================================================================
+// Regime G: DPAS V4 — Prefetch pipeline (latency hiding)
+//
+// Same as V2 but with prefetch issued PF_DIST K-steps ahead.
+// With ~550 cycle DRAM latency and ~30 cycle compute per K-step,
+// need PF_DIST >= 18 to fully hide latency. Use 8 as practical value
+// (128 bytes = 8 K-steps ahead = ~240 cycle look-ahead).
+// ============================================================================
+template<int WG_SIZE, int M_TILES, int PF_DIST = 8>
+struct FP8_GEMM_DPAS_V4 {
+    const fp16*    input;
+    const uint8_t* weight;
+    const float*   scale_ptr;
+    fp16*          output;
+    int M, N, K;
+    int fp8_mode;
+
+    void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+        constexpr int N_PER_THREAD = 16;
+        constexpr int N_WG = WG_SIZE * N_PER_THREAD;
+        constexpr int K_SUB = 16;
+
+        int wg_id = item.get_group(0);
+        int tid   = item.get_local_id(0);
+
+        int n_start = wg_id * N_WG + tid * N_PER_THREAD;
+        if (n_start >= N) return;
+
+        simd<float, 128> acc[M_TILES];
+        #pragma unroll
+        for (int i = 0; i < M_TILES; i++) acc[i] = 0.0f;
+
+        // 2D payload for input A
+        const uint32_t surfW_A = (uint32_t)K * 2u - 1u;
+        const uint32_t surfH_A = (uint32_t)M - 1u;
+        xesimd::config_2d_mem_access<fp16, 16, 8, 1> payA(
+            input, surfW_A, surfH_A, surfW_A, 0u, 0u);
+
+        // 2D payloads for weight B: one for load, one for prefetch
+        const uint32_t surfW_B = (uint32_t)K - 1u;
+        const uint32_t surfH_B = (uint32_t)N - 1u;
+        xesimd::config_2d_mem_access<uint8_t, 16, 16, 1> payB(
+            weight, surfW_B, surfH_B, surfW_B, 0u, (uint32_t)n_start);
+        xesimd::config_2d_mem_access<uint8_t, 16, 16, 1> payB_pf(
+            weight, surfW_B, surfH_B, surfW_B, 0u, (uint32_t)n_start);
+
+        // Issue initial prefetches
+        for (int p = 0; p < PF_DIST && p * K_SUB < K; p++) {
+            payB_pf.set_x((uint32_t)(p * K_SUB));
+            xesimd::lsc_prefetch_2d<uint8_t, 16, 16, 1,
+                false, false,
+                xesimd::cache_hint::uncached, xesimd::cache_hint::cached>(payB_pf);
+        }
+
+        // Also prefetch input tiles
+        xesimd::config_2d_mem_access<fp16, 16, 8, 1> payA_pf(
+            input, surfW_A, surfH_A, surfW_A, 0u, 0u);
+        for (int p = 0; p < PF_DIST && p * K_SUB < K; p++) {
+            payA_pf.set_x((uint32_t)(p * K_SUB));
+            #pragma unroll
+            for (int m = 0; m < M_TILES; m++) {
+                payA_pf.set_y((uint32_t)(m * 8));
+                xesimd::lsc_prefetch_2d<fp16, 16, 8, 1,
+                    false, false,
+                    xesimd::cache_hint::uncached, xesimd::cache_hint::cached>(payA_pf);
+            }
+        }
+
+        // Double-buffered weight
+        simd<fp16, 256> b_buf[2];
+
+        // Prologue: load+dequant k=0
+        payB.set_x(0u);
+        {
+            simd<uint8_t, 256> raw = xesimd::lsc_load_2d<uint8_t, 16, 16, 1,
+                false, false,
+                xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payB);
+            b_buf[0] = ((fp8_mode == 0) ? fp8_tile_to_vnni_fast(raw) : fp8_tile_to_vnni(raw, fp8_mode));
+        }
+
+        for (int k = 0; k < K - K_SUB; k += K_SUB) {
+            // Issue prefetch PF_DIST steps ahead
+            int pf_k = k + PF_DIST * K_SUB;
+            if (pf_k < K) {
+                payB_pf.set_x((uint32_t)pf_k);
+                xesimd::lsc_prefetch_2d<uint8_t, 16, 16, 1,
+                    false, false,
+                    xesimd::cache_hint::uncached, xesimd::cache_hint::cached>(payB_pf);
+                payA_pf.set_x((uint32_t)pf_k);
+                #pragma unroll
+                for (int m = 0; m < M_TILES; m++) {
+                    payA_pf.set_y((uint32_t)(m * 8));
+                    xesimd::lsc_prefetch_2d<fp16, 16, 8, 1,
+                        false, false,
+                        xesimd::cache_hint::uncached, xesimd::cache_hint::cached>(payA_pf);
+                }
+            }
+
+            // Load next weight
+            payB.set_x((uint32_t)(k + K_SUB));
+            {
+                simd<uint8_t, 256> raw = xesimd::lsc_load_2d<uint8_t, 16, 16, 1,
+                    false, false,
+                    xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payB);
+                b_buf[1] = ((fp8_mode == 0) ? fp8_tile_to_vnni_fast(raw) : fp8_tile_to_vnni(raw, fp8_mode));
+            }
+
+            // Load input + DPAS
+            payA.set_x((uint32_t)k);
+            simd<fp16, 128> a_tile[M_TILES];
+            #pragma unroll
+            for (int m = 0; m < M_TILES; m++) {
+                payA.set_y((uint32_t)(m * 8));
+                a_tile[m] = xesimd::lsc_load_2d<fp16, 16, 8, 1,
+                    false, false,
+                    xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payA);
+            }
+            #pragma unroll
+            for (int m = 0; m < M_TILES; m++) {
+                acc[m] = dpas<8, 8, float, float, fp16, fp16>(
+                    acc[m], b_buf[0], a_tile[m]);
+            }
+
+            b_buf[0] = b_buf[1];
+        }
+
+        // Epilogue
+        {
+            payA.set_x((uint32_t)(K - K_SUB));
+            simd<fp16, 128> a_tile[M_TILES];
+            #pragma unroll
+            for (int m = 0; m < M_TILES; m++) {
+                payA.set_y((uint32_t)(m * 8));
+                a_tile[m] = xesimd::lsc_load_2d<fp16, 16, 8, 1,
+                    false, false,
+                    xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payA);
+            }
+            #pragma unroll
+            for (int m = 0; m < M_TILES; m++) {
+                acc[m] = dpas<8, 8, float, float, fp16, fp16>(
+                    acc[m], b_buf[0], a_tile[m]);
+            }
+        }
+
+        // Store
+        float s = *scale_ptr;
+        #pragma unroll
+        for (int m = 0; m < M_TILES; m++) {
+            simd<float, 128> scaled = acc[m] * s;
+            int n_valid = (n_start + 16 <= N) ? 16 : (N - n_start);
+            bool full_n = (n_valid == 16);
+
+            #pragma unroll
+            for (int mi = 0; mi < 8; mi++) {
+                int row = m * 8 + mi;
+                if (row < M) {
+                    simd<float, 16> row_f = scaled.select<16, 1>(mi * 16);
+                    simd<fp16, 16> out_row = convert<fp16>(row_f);
+                    if (full_n) {
+                        block_store<fp16, 16>(
+                            output + (size_t)row * N + n_start, out_row);
+                    } else {
+                        for (int ni = 0; ni < n_valid; ni++) {
+                            output[(size_t)row * N + n_start + ni] = out_row[ni];
+                        }
+                    }
+                }
+            }
+        }
+    }
+};
+
+// Host dispatcher for DPAS V4
+template<int WG_SIZE, int M_TILES, int PF_DIST = 8>
+inline void dpas_v4_gemm_fp8_pert_host(
+    const fp16*    input,
+    const uint8_t* weight,
+    const float*   scale_ptr,
+    fp16*          output,
+    uint32_t M, uint32_t N, uint32_t K,
+    int fp8_mode,
+    sycl::queue& q) {
+
+    constexpr int N_WG = WG_SIZE * 16;
+    int num_wg = ((int)N + N_WG - 1) / N_WG;
+
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(
+            sycl::nd_range<1>({(size_t)(num_wg * WG_SIZE)}, {(size_t)WG_SIZE}),
+            FP8_GEMM_DPAS_V4<WG_SIZE, M_TILES, PF_DIST>{
+                input, weight, scale_ptr, output,
+                (int)M, (int)N, (int)K, fp8_mode});
+    });
+}
+
+// ============================================================================
+// Regime H: DPAS V5 — Wide weight load (K_LOAD=64, cache-line aligned)
+//
+// Key insight: lsc_load_2d<uint8_t, 16, 16> fetches 16 cache lines (1024 bytes)
+// for only 256 bytes of data → 25% cache utilization.
+// lsc_load_2d<uint8_t, 64, 16> fetches the same 16 cache lines but uses all
+// 1024 bytes → 100% utilization. This requires processing 4 DPAS K-subs per load.
+//
+// Requires K % 64 == 0.
+// ============================================================================
+template<int WG_SIZE, int M_TILES>
+struct FP8_GEMM_DPAS_V5 {
+    const fp16*    input;
+    const uint8_t* weight;
+    const float*   scale_ptr;
+    fp16*          output;
+    int M, N, K;
+    int fp8_mode;
+
+    void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+        constexpr int N_PER_THREAD = 16;
+        constexpr int N_WG = WG_SIZE * N_PER_THREAD;
+        constexpr int K_LOAD = 64;  // Load 64 K-elements at once
+        constexpr int K_SUB = 16;   // DPAS processes 16 K-elements
+
+        int wg_id = item.get_group(0);
+        int tid   = item.get_local_id(0);
+
+        int n_start = wg_id * N_WG + tid * N_PER_THREAD;
+        if (n_start >= N) return;
+
+        simd<float, 128> acc[M_TILES];
+        #pragma unroll
+        for (int i = 0; i < M_TILES; i++) acc[i] = 0.0f;
+
+        // 2D payload for input A: [M, K] fp16
+        const uint32_t surfW_A = (uint32_t)K * 2u - 1u;
+        const uint32_t surfH_A = (uint32_t)M - 1u;
+        xesimd::config_2d_mem_access<fp16, 16, 8, 1> payA(
+            input, surfW_A, surfH_A, surfW_A, 0u, 0u);
+
+        // 2D payload for weight B: [N, K] uint8, wide load (64 cols × 16 rows)
+        const uint32_t surfW_B = (uint32_t)K - 1u;
+        const uint32_t surfH_B = (uint32_t)N - 1u;
+        xesimd::config_2d_mem_access<uint8_t, 64, 16, 1> payB(
+            weight, surfW_B, surfH_B, surfW_B, 0u, (uint32_t)n_start);
+
+        for (int k_base = 0; k_base < K; k_base += K_LOAD) {
+            // Load 16×64 uint8 weight tile — uses full cache lines
+            payB.set_x((uint32_t)k_base);
+            simd<uint8_t, 1024> w_raw = xesimd::lsc_load_2d<uint8_t, 64, 16, 1,
+                false, false,
+                xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payB);
+
+            // Process 4 K-sub-steps (each 16 K-elements)
+            #pragma unroll
+            for (int sub = 0; sub < 4; sub++) {
+                simd<uint8_t, 256> sub_raw;
+                #pragma unroll
+                for (int ni = 0; ni < 16; ni++) {
+                    sub_raw.template select<16, 1>(ni * 16) =
+                        w_raw.template select<16, 1>(ni * 64 + sub * 16);
+                }
+
+                simd<fp16, 256> b_tile = (fp8_mode == 0) ?
+                    fp8_tile_to_vnni_fast(sub_raw) :
+                    fp8_tile_to_vnni(sub_raw, fp8_mode);
+
+                int k = k_base + sub * K_SUB;
+                payA.set_x((uint32_t)k);
+                #pragma unroll
+                for (int m = 0; m < M_TILES; m++) {
+                    payA.set_y((uint32_t)(m * 8));
+                    simd<fp16, 128> a = xesimd::lsc_load_2d<fp16, 16, 8, 1,
+                        false, false,
+                        xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payA);
+                    acc[m] = dpas<8, 8, float, float, fp16, fp16>(acc[m], b_tile, a);
+                }
+            }
+        }
+
+        // Store
+        float s = *scale_ptr;
+        #pragma unroll
+        for (int m = 0; m < M_TILES; m++) {
+            simd<float, 128> scaled = acc[m] * s;
+            int n_valid = (n_start + 16 <= N) ? 16 : (N - n_start);
+            bool full_n = (n_valid == 16);
+
+            #pragma unroll
+            for (int mi = 0; mi < 8; mi++) {
+                int row = m * 8 + mi;
+                if (row < M) {
+                    simd<float, 16> row_f = scaled.select<16, 1>(mi * 16);
+                    simd<fp16, 16> out_row = convert<fp16>(row_f);
+                    if (full_n) {
+                        block_store<fp16, 16>(
+                            output + (size_t)row * N + n_start, out_row);
+                    } else {
+                        for (int ni = 0; ni < n_valid; ni++) {
+                            output[(size_t)row * N + n_start + ni] = out_row[ni];
+                        }
+                    }
+                }
+            }
+        }
+    }
+};
+#endif // GEMM_EXPERIMENTAL — old DPAS, V2-V5
+
+// ============================================================================
+// FP8 GEMM DPAS V7: K-split multi-thread WG
+// V5 has 160 threads for N=2560 = 1 thread/XVE (12.5% occupancy).
+// V6 (M-parallel) was worse because L1 weight reuse < register reuse.
+// V7 splits K across threads: each thread loads DIFFERENT weight/input data,
+// then reduces partial sums via SLM. More threads = better latency hiding.
+// ============================================================================
+template<int K_THREADS, int M_TILES>
+struct FP8_GEMM_DPAS_V7 {
+    const fp16*    input;
+    const uint8_t* weight;
+    const float*   scale_ptr;
+    fp16*          output;
+    int M, N, K;
+    int fp8_mode;
+
+    void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+        constexpr int K_LOAD = 64;
+        constexpr int K_SUB = 16;
+        // SLM layout: K_THREADS × M_TILES × 128 floats
+        // Each thread writes its partial accumulators at offset tid * M_TILES * 128 * 4
+        constexpr int SLM_PER_THREAD = M_TILES * 128 * 4;  // bytes
+        constexpr int SLM_TOTAL = K_THREADS * SLM_PER_THREAD;
+        slm_init<SLM_TOTAL>();
+
+        int wg_id = item.get_group(0);
+        int tid   = item.get_local_id(0);
+
+        int n_start = wg_id * 16;
+        if (n_start >= N) return;
+
+        // Each thread handles a K-range
+        int k_per_thread = K / K_THREADS;  // Assumes K divisible by K_THREADS
+        int k_start = tid * k_per_thread;
+        int k_end   = k_start + k_per_thread;
+
+        simd<float, 128> acc[M_TILES];
+        #pragma unroll
+        for (int i = 0; i < M_TILES; i++) acc[i] = 0.0f;
+
+        // 2D payload for input A: [M, K] fp16
+        const uint32_t surfW_A = (uint32_t)K * 2u - 1u;
+        const uint32_t surfH_A = (uint32_t)M - 1u;
+        xesimd::config_2d_mem_access<fp16, 16, 8, 1> payA(
+            input, surfW_A, surfH_A, surfW_A, 0u, 0u);
+
+        // 2D payload for weight B: [N, K] uint8, wide load
+        const uint32_t surfW_B = (uint32_t)K - 1u;
+        const uint32_t surfH_B = (uint32_t)N - 1u;
+        xesimd::config_2d_mem_access<uint8_t, 64, 16, 1> payB(
+            weight, surfW_B, surfH_B, surfW_B, 0u, (uint32_t)n_start);
+
+        for (int k_base = k_start; k_base < k_end; k_base += K_LOAD) {
+            payB.set_x((uint32_t)k_base);
+            simd<uint8_t, 1024> w_raw = xesimd::lsc_load_2d<uint8_t, 64, 16, 1,
+                false, false,
+                xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payB);
+
+            #pragma unroll
+            for (int sub = 0; sub < 4; sub++) {
+                simd<uint8_t, 256> sub_raw;
+                #pragma unroll
+                for (int ni = 0; ni < 16; ni++) {
+                    sub_raw.template select<16, 1>(ni * 16) =
+                        w_raw.template select<16, 1>(ni * 64 + sub * 16);
+                }
+
+                simd<fp16, 256> b_tile = (fp8_mode == 0) ?
+                    fp8_tile_to_vnni_fast(sub_raw) :
+                    fp8_tile_to_vnni(sub_raw, fp8_mode);
+
+                int k = k_base + sub * K_SUB;
+                payA.set_x((uint32_t)k);
+                #pragma unroll
+                for (int m = 0; m < M_TILES; m++) {
+                    payA.set_y((uint32_t)(m * 8));
+                    simd<fp16, 128> a = xesimd::lsc_load_2d<fp16, 16, 8, 1,
+                        false, false,
+                        xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payA);
+                    acc[m] = dpas<8, 8, float, float, fp16, fp16>(acc[m], b_tile, a);
+                }
+            }
+        }
+
+        if constexpr (K_THREADS == 1) {
+            // No reduction needed — single thread handles all of K
+            float s = *scale_ptr;
+            #pragma unroll
+            for (int m = 0; m < M_TILES; m++) {
+                simd<float, 128> scaled = acc[m] * s;
+                int n_valid = (n_start + 16 <= N) ? 16 : (N - n_start);
+                bool full_n = (n_valid == 16);
+                #pragma unroll
+                for (int mi = 0; mi < 8; mi++) {
+                    int row = m * 8 + mi;
+                    if (row < M) {
+                        simd<float, 16> row_f = scaled.select<16, 1>(mi * 16);
+                        simd<fp16, 16> out_row = convert<fp16>(row_f);
+                        if (full_n)
+                            block_store<fp16, 16>(output + (size_t)row * N + n_start, out_row);
+                        else
+                            for (int ni = 0; ni < n_valid; ni++)
+                                output[(size_t)row * N + n_start + ni] = out_row[ni];
+                    }
+                }
+            }
+        } else {
+            // Write partial sums to SLM
+            uint32_t slm_base = tid * SLM_PER_THREAD;
+            #pragma unroll
+            for (int m = 0; m < M_TILES; m++) {
+                slm_block_store<float, 128>(slm_base + m * 128 * 4, acc[m]);
+            }
+
+            barrier();
+
+            // Thread 0 reduces and stores
+            if (tid == 0) {
+                float s = *scale_ptr;
+                #pragma unroll
+                for (int m = 0; m < M_TILES; m++) {
+                    simd<float, 128> sum = slm_block_load<float, 128>(m * 128 * 4);
+                    #pragma unroll
+                    for (int t = 1; t < K_THREADS; t++) {
+                        simd<float, 128> partial = slm_block_load<float, 128>(
+                            t * SLM_PER_THREAD + m * 128 * 4);
+                        sum += partial;
+                    }
+                    simd<float, 128> scaled = sum * s;
+                    int n_valid = (n_start + 16 <= N) ? 16 : (N - n_start);
+                    bool full_n = (n_valid == 16);
+                    #pragma unroll
+                    for (int mi = 0; mi < 8; mi++) {
+                        int row = m * 8 + mi;
+                        if (row < M) {
+                            simd<float, 16> row_f = scaled.select<16, 1>(mi * 16);
+                            simd<fp16, 16> out_row = convert<fp16>(row_f);
+                            if (full_n)
+                                block_store<fp16, 16>(output + (size_t)row * N + n_start, out_row);
+                            else
+                                for (int ni = 0; ni < n_valid; ni++)
+                                    output[(size_t)row * N + n_start + ni] = out_row[ni];
+                        }
+                    }
+                }
+            }
+        }
+    }
+};
+
+// Host dispatcher for DPAS V7
+template<int K_THREADS, int M_TILES>
+inline void dpas_v7_gemm_fp8_pert_host(
+    const fp16*    input,
+    const uint8_t* weight,
+    const float*   scale_ptr,
+    fp16*          output,
+    uint32_t M, uint32_t N, uint32_t K,
+    int fp8_mode,
+    sycl::queue& q) {
+
+    int num_wg = ((int)N + 15) / 16;
+
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(
+            sycl::nd_range<1>({(size_t)(num_wg * K_THREADS)}, {(size_t)K_THREADS}),
+            FP8_GEMM_DPAS_V7<K_THREADS, M_TILES>{
+                input, weight, scale_ptr, output,
+                (int)M, (int)N, (int)K, fp8_mode});
+    });
+}
+
+// V7 auto-dispatch: choose K_THREADS and M_TILES
+inline void dpas_v7_auto_dispatch(
+    const fp16* input, const uint8_t* weight, const float* scale_ptr,
+    fp16* output, uint32_t M, uint32_t N, uint32_t K,
+    int fp8_mode, sycl::queue& q) {
+    int m_tiles = ((int)M + 7) / 8;
+    int n_wgs = ((int)N + 15) / 16;
+    // Target ~320-640 total threads. K_THREADS=4 sweet spot for most shapes,
+    // but K_THREADS=2 better for large N (N>2560) to avoid SLM reduction overhead.
+    // K_THREADS=8 tested and was worse (too much SLM reduction cost).
+    int k_threads = std::max(1, std::min(4, 640 / std::max(n_wgs, 1)));
+    while (k_threads > 1 && (K % (k_threads * 64) != 0)) k_threads--;
+    if (k_threads == 3) k_threads = 2;
+
+    #define V7_DISPATCH(KT, MT) dpas_v7_gemm_fp8_pert_host<KT, MT>(input, weight, scale_ptr, output, M, N, K, fp8_mode, q)
+    if (k_threads >= 4) {
+        if      (m_tiles <= 1) V7_DISPATCH(4, 1);
+        else if (m_tiles <= 2) V7_DISPATCH(4, 2);
+        else if (m_tiles <= 4) V7_DISPATCH(4, 4);
+        else                   V7_DISPATCH(4, 8);
+    } else if (k_threads >= 2) {
+        if      (m_tiles <= 1) V7_DISPATCH(2, 1);
+        else if (m_tiles <= 2) V7_DISPATCH(2, 2);
+        else if (m_tiles <= 4) V7_DISPATCH(2, 4);
+        else                   V7_DISPATCH(2, 8);
+    } else {
+        if      (m_tiles <= 1) V7_DISPATCH(1, 1);
+        else if (m_tiles <= 2) V7_DISPATCH(1, 2);
+        else if (m_tiles <= 4) V7_DISPATCH(1, 4);
+        else                   V7_DISPATCH(1, 8);
+    }
+    #undef V7_DISPATCH
+}
+
+// ============================================================================
+// FP8 GEMM DPAS V9: Transposed uint32 load + fused dequant-VNNI
+//
+// Key insight: oneDNN's JIT fuses the byte→fp16 dequant with VNNI interleave
+// via register regioning (shl with stride-4 source, stride-2 dest). ESIMD can't
+// emit these instructions, causing 64 narrow mov(4|M0) per sub-tile for VNNI pack
+// (55% of the loop body).
+//
+// V9 solution: Use lsc_load_2d<uint32_t, 4, 16, 1, TRANSPOSE=true> so each uint32
+// contains 4 adjacent FP8 bytes for one N-row. Extract byte pairs into uint32
+// with lo in [0:15] and hi in [16:31], then dequant BOTH bytes simultaneously
+// using uint16 arithmetic on the packed uint32. Result IS the VNNI format —
+// zero separate VNNI pack step. All ops at full (16|M0) or (32|M0) width.
+//
+// Per k_pair (2 bytes × 16 N-lanes):
+//   Extraction: 4 ops at (16|M0)
+//   Dequant:    4 ops at (32|M0) on 32 uint16 = both bytes simultaneously
+//   Total:      ~12 SIMD16 cycles vs ~40 SIMD16 cycles in V7 (3.3× less)
+// ============================================================================
+
+// Fused dequant+VNNI for one k_pair from a transposed uint32 column group
+// col_data[n] = {B[n, base_k], B[n, base_k+1], B[n, base_k+2], B[n, base_k+3]}
+// Processes byte_lo and byte_hi (adjacent bytes within each uint32) into VNNI u32
+SYCL_ESIMD_FUNCTION inline simd<uint32_t, 16>
+fp8_e4m3_pair_to_vnni(simd<uint32_t, 16> b0, simd<uint32_t, 16> b1_shifted) {
+    // b0 = byte_lo (0..255 in low bits), b1_shifted = byte_hi << 16
+    // Pack: lo in [0:15], hi in [16:31]
+    simd<uint32_t, 16> packed = b0 | b1_shifted;
+
+    // Dequant BOTH fp16 halves in-place via bit_cast_view compound assignment.
+    // Using compound assignment avoids .read() copies that generate movs.
+    // Each operation works on the u16/s16/fp16 view of the same u32 registers.
+    packed.template bit_cast_view<uint16_t>() <<= 8;      // SHL8 each u16
+    packed.template bit_cast_view<int16_t>() >>= 1;       // ASR1 each s16
+    packed.template bit_cast_view<uint16_t>() &= 0xBFFF;  // clear bit 14
+    packed.template bit_cast_view<fp16>() *= fp16(256.0f); // bias adjust
+
+    // Result: packed uint32 with {dequant(lo), dequant(hi)} = VNNI format!
+    return packed;
+}
+
+namespace xesimd = sycl::ext::intel::experimental::esimd;
+
+#ifdef GEMM_EXPERIMENTAL  // Dead code: V11, V12 kernel structs
+// ============================================================================
+// V11: Multi-N-thread WG — K_THREADS × N_THREADS threads per WG
+// Key insight from oneDNN ISA: 4 N-subgroups in same WG share XE core L1 cache
+// for input loads. V9's 160 independent WGs don't benefit from L1 input sharing.
+// V11 puts N_THREADS N-tiles in the same WG so they share L1 for input loads.
+// Each thread is identical to V9 — same registers, same DPAS — just different
+// n_start. The L1 cache sharing happens automatically via hardware.
+// ============================================================================
+template<int K_THREADS, int M_TILES, int N_THREADS>
+struct FP8_GEMM_DPAS_V11 {
+    const fp16*    input;
+    const uint8_t* weight;
+    const float*   scale_ptr;
+    fp16*          output;
+    int M, N, K;
+
+    void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+        constexpr int K_LOAD = 64;
+        constexpr int K_SUB = 16;
+        constexpr int WG_SIZE = K_THREADS * N_THREADS;
+        constexpr int SLM_PER_K_THREAD = M_TILES * 128 * 4;
+        constexpr int SLM_PER_N_THREAD = K_THREADS * SLM_PER_K_THREAD;
+        constexpr int SLM_TOTAL = N_THREADS * SLM_PER_N_THREAD;
+        slm_init<SLM_TOTAL>();
+
+        int wg_id   = item.get_group(0);
+        int local_id = item.get_local_id(0);
+
+        // Decompose local_id into N-thread and K-thread
+        int n_tid = local_id / K_THREADS;  // which N-tile
+        int k_tid = local_id % K_THREADS;  // which K-split
+
+        int n_start = wg_id * (N_THREADS * 16) + n_tid * 16;
+        if (n_start >= N) return;
+
+        int k_per_thread = K / K_THREADS;
+        int k_start = k_tid * k_per_thread;
+        int k_end   = k_start + k_per_thread;
+
+        simd<float, 128> acc[M_TILES];
+        #pragma unroll
+        for (int i = 0; i < M_TILES; i++) acc[i] = 0.0f;
+
+        // 2D payload for input A: [M, K] fp16 — SHARED across N-threads via L1
+        const uint32_t surfW_A = (uint32_t)K * 2u - 1u;
+        const uint32_t surfH_A = (uint32_t)M - 1u;
+        xesimd::config_2d_mem_access<fp16, 16, 8, 1> payA(
+            input, surfW_A, surfH_A, surfW_A, 0u, 0u);
+        xesimd::config_2d_mem_access<fp16, 16, 16, 1> payA16(
+            input, surfW_A, surfH_A, surfW_A, 0u, 0u);
+
+        // 2D payload for weight B: [N, K] — unique per N-thread
+        const uint32_t surfW_B = (uint32_t)K - 1u;
+        const uint32_t surfH_B = (uint32_t)N - 1u;
+        xesimd::config_2d_mem_access<uint32_t, 4, 16, 1> payB_t(
+            reinterpret_cast<const uint32_t*>(weight),
+            surfW_B, surfH_B, surfW_B,
+            0u, (uint32_t)n_start);
+
+        for (int k_base = k_start; k_base < k_end; k_base += K_LOAD) {
+            #pragma unroll
+            for (int sub = 0; sub < 4; sub++) {
+                int k_sub = k_base + sub * K_SUB;
+
+                // Transposed uint32 load for weight — unique per N-thread
+                payB_t.set_x((uint32_t)(k_sub / 4));
+                simd<uint32_t, 64> w_t = xesimd::lsc_load_2d<uint32_t, 4, 16, 1,
+                    true, false,
+                    xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payB_t);
+
+                simd<uint32_t, 128> b_vnni_u32;
+                #pragma unroll
+                for (int col = 0; col < 4; col++) {
+                    simd<uint32_t, 16> group = w_t.template select<16, 1>(col * 16);
+                    simd<uint32_t, 16> b0 = group & 0xFF;
+                    simd<uint32_t, 16> b1 = (group & 0xFF00) << 8;
+                    b_vnni_u32.template select<16, 1>(col * 2 * 16) =
+                        fp8_e4m3_pair_to_vnni(b0, b1);
+                    simd<uint32_t, 16> group_hi = group >> 16;
+                    simd<uint32_t, 16> b2 = group_hi & 0xFF;
+                    simd<uint32_t, 16> b3 = (group_hi & 0xFF00) << 8;
+                    b_vnni_u32.template select<16, 1>((col * 2 + 1) * 16) =
+                        fp8_e4m3_pair_to_vnni(b2, b3);
+                }
+
+                simd<fp16, 256> b_tile =
+                    b_vnni_u32.template bit_cast_view<fp16>().read();
+
+                // Load input and DPAS — merged 16-row loads for M_TILES≥2
+                if constexpr (M_TILES >= 2) {
+                    payA16.set_x((uint32_t)k_sub);
+                    #pragma unroll
+                    for (int m = 0; m < M_TILES; m += 2) {
+                        payA16.set_y((uint32_t)(m * 8));
+                        simd<fp16, 256> a2 = xesimd::lsc_load_2d<fp16, 16, 16, 1,
+                            false, false,
+                            xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payA16);
+                        simd<fp16, 128> a0 = a2.template select<128, 1>(0);
+                        simd<fp16, 128> a1 = a2.template select<128, 1>(128);
+                        acc[m]   = dpas<8, 8, float, float, fp16, fp16>(acc[m],   b_tile, a0);
+                        acc[m+1] = dpas<8, 8, float, float, fp16, fp16>(acc[m+1], b_tile, a1);
+                    }
+                } else {
+                    payA.set_x((uint32_t)k_sub);
+                    payA.set_y(0u);
+                    simd<fp16, 128> a = xesimd::lsc_load_2d<fp16, 16, 8, 1,
+                        false, false,
+                        xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payA);
+                    acc[0] = dpas<8, 8, float, float, fp16, fp16>(acc[0], b_tile, a);
+                }
+            }
+        }
+
+        if constexpr (K_THREADS == 1) {
+            float s = *scale_ptr;
+            #pragma unroll
+            for (int m = 0; m < M_TILES; m++) {
+                simd<float, 128> scaled = acc[m] * s;
+                int n_valid = (n_start + 16 <= N) ? 16 : (N - n_start);
+                bool full_n = (n_valid == 16);
+                #pragma unroll
+                for (int mi = 0; mi < 8; mi++) {
+                    int row = m * 8 + mi;
+                    if (row < M) {
+                        simd<float, 16> row_f = scaled.select<16, 1>(mi * 16);
+                        simd<fp16, 16> out_row = convert<fp16>(row_f);
+                        if (full_n)
+                            block_store<fp16, 16>(output + (size_t)row * N + n_start, out_row);
+                        else
+                            for (int ni = 0; ni < n_valid; ni++)
+                                output[(size_t)row * N + n_start + ni] = out_row[ni];
+                    }
+                }
+            }
+        } else {
+            // SLM reduction — each N-thread has its own SLM region
+            uint32_t slm_base = n_tid * SLM_PER_N_THREAD + k_tid * SLM_PER_K_THREAD;
+            #pragma unroll
+            for (int m = 0; m < M_TILES; m++) {
+                slm_block_store<float, 128>(slm_base + m * 128 * 4, acc[m]);
+            }
+
+            barrier();
+
+            // Each N-thread's first K-thread reduces and stores output
+            if (k_tid == 0) {
+                float s = *scale_ptr;
+                uint32_t my_slm_base = n_tid * SLM_PER_N_THREAD;
+                #pragma unroll
+                for (int m = 0; m < M_TILES; m++) {
+                    simd<float, 128> sum = slm_block_load<float, 128>(
+                        my_slm_base + m * 128 * 4);
+                    #pragma unroll
+                    for (int t = 1; t < K_THREADS; t++) {
+                        simd<float, 128> partial = slm_block_load<float, 128>(
+                            my_slm_base + t * SLM_PER_K_THREAD + m * 128 * 4);
+                        sum += partial;
+                    }
+                    simd<float, 128> scaled = sum * s;
+                    int n_valid = (n_start + 16 <= N) ? 16 : (N - n_start);
+                    bool full_n = (n_valid == 16);
+                    #pragma unroll
+                    for (int mi = 0; mi < 8; mi++) {
+                        int row = m * 8 + mi;
+                        if (row < M) {
+                            simd<float, 16> row_f = scaled.select<16, 1>(mi * 16);
+                            simd<fp16, 16> out_row = convert<fp16>(row_f);
+                            if (full_n)
+                                block_store<fp16, 16>(output + (size_t)row * N + n_start, out_row);
+                            else
+                                for (int ni = 0; ni < n_valid; ni++)
+                                    output[(size_t)row * N + n_start + ni] = out_row[ni];
+                        }
+                    }
+                }
+            }
+        }
+    }
+};
+
+// Host dispatcher for V11
+template<int K_THREADS, int M_TILES, int N_THREADS>
+inline void dpas_v11_gemm_fp8_pert_host(
+    const fp16* input, const uint8_t* weight, const float* scale_ptr,
+    fp16* output, uint32_t M, uint32_t N, uint32_t K,
+    sycl::queue& q) {
+    constexpr int N_PER_WG = N_THREADS * 16;
+    constexpr int WG_SIZE = K_THREADS * N_THREADS;
+    int num_wg = ((int)N + N_PER_WG - 1) / N_PER_WG;
+
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(
+            sycl::nd_range<1>({(size_t)(num_wg * WG_SIZE)}, {(size_t)WG_SIZE}),
+            FP8_GEMM_DPAS_V11<K_THREADS, M_TILES, N_THREADS>{
+                input, weight, scale_ptr, output,
+                (int)M, (int)N, (int)K});
+    });
+}
+
+// V11 auto-dispatch
+inline void dpas_v11_auto_dispatch(
+    const fp16* input, const uint8_t* weight, const float* scale_ptr,
+    fp16* output, uint32_t M, uint32_t N, uint32_t K,
+    sycl::queue& q) {
+    int m_tiles = ((int)M + 7) / 8;
+    int n_16 = ((int)N + 15) / 16;
+
+    // Choose N_THREADS to get ~40-80 WGs (matching oneDNN's approach)
+    // Target: at least 40 WGs for occupancy, but N_THREADS power of 2
+    int n_threads = 4;  // default: 4 N-tiles per WG like oneDNN
+    while (n_threads > 1 && (n_16 / n_threads) < 20) n_threads /= 2;
+    // For small N, fall back to 1 (= V9 behavior)
+    int n_wgs = (n_16 + n_threads - 1) / n_threads;
+
+    int k_threads = std::max(1, std::min(4, 640 / std::max(n_wgs * n_threads, 1)));
+    while (k_threads > 1 && (K % (k_threads * 64) != 0)) k_threads--;
+    if (k_threads == 3) k_threads = 2;
+
+    // Limit total WG size
+    while (k_threads * n_threads > 16) {
+        if (n_threads > 1) n_threads /= 2;
+        else k_threads /= 2;
+    }
+
+    #define V11_DISPATCH(KT, MT, NT) dpas_v11_gemm_fp8_pert_host<KT, MT, NT>(input, weight, scale_ptr, output, M, N, K, q)
+
+    // Simplified dispatch — main cases
+    if (n_threads == 4) {
+        if (k_threads >= 4) {
+            if      (m_tiles <= 1) V11_DISPATCH(4, 1, 4);
+            else if (m_tiles <= 2) V11_DISPATCH(4, 2, 4);
+            else if (m_tiles <= 4) V11_DISPATCH(4, 4, 4);
+            else                   V11_DISPATCH(4, 8, 4);
+        } else if (k_threads >= 2) {
+            if      (m_tiles <= 1) V11_DISPATCH(2, 1, 4);
+            else if (m_tiles <= 2) V11_DISPATCH(2, 2, 4);
+            else if (m_tiles <= 4) V11_DISPATCH(2, 4, 4);
+            else                   V11_DISPATCH(2, 8, 4);
+        } else {
+            if      (m_tiles <= 1) V11_DISPATCH(1, 1, 4);
+            else if (m_tiles <= 2) V11_DISPATCH(1, 2, 4);
+            else if (m_tiles <= 4) V11_DISPATCH(1, 4, 4);
+            else                   V11_DISPATCH(1, 8, 4);
+        }
+    } else if (n_threads == 2) {
+        if (k_threads >= 4) {
+            if      (m_tiles <= 1) V11_DISPATCH(4, 1, 2);
+            else if (m_tiles <= 2) V11_DISPATCH(4, 2, 2);
+            else if (m_tiles <= 4) V11_DISPATCH(4, 4, 2);
+            else                   V11_DISPATCH(4, 8, 2);
+        } else if (k_threads >= 2) {
+            if      (m_tiles <= 1) V11_DISPATCH(2, 1, 2);
+            else if (m_tiles <= 2) V11_DISPATCH(2, 2, 2);
+            else if (m_tiles <= 4) V11_DISPATCH(2, 4, 2);
+            else                   V11_DISPATCH(2, 8, 2);
+        } else {
+            if      (m_tiles <= 1) V11_DISPATCH(1, 1, 2);
+            else if (m_tiles <= 2) V11_DISPATCH(1, 2, 2);
+            else if (m_tiles <= 4) V11_DISPATCH(1, 4, 2);
+            else                   V11_DISPATCH(1, 8, 2);
+        }
+    } else {
+        // N_THREADS=1 fallback (same per-thread work as V9)
+        if (k_threads >= 4) {
+            if      (m_tiles <= 1) V11_DISPATCH(4, 1, 1);
+            else if (m_tiles <= 2) V11_DISPATCH(4, 2, 1);
+            else if (m_tiles <= 4) V11_DISPATCH(4, 4, 1);
+            else                   V11_DISPATCH(4, 8, 1);
+        } else if (k_threads >= 2) {
+            if      (m_tiles <= 1) V11_DISPATCH(2, 1, 1);
+            else if (m_tiles <= 2) V11_DISPATCH(2, 2, 1);
+            else if (m_tiles <= 4) V11_DISPATCH(2, 4, 1);
+            else                   V11_DISPATCH(2, 8, 1);
+        } else {
+            if      (m_tiles <= 1) V11_DISPATCH(1, 1, 1);
+            else if (m_tiles <= 2) V11_DISPATCH(1, 2, 1);
+            else if (m_tiles <= 4) V11_DISPATCH(1, 4, 1);
+            else                   V11_DISPATCH(1, 8, 1);
+        }
+    }
+    #undef V11_DISPATCH
+}
+
+// Forward declarations for cross-references
+inline void dpas_v9_auto_dispatch(
+    const fp16* input, const uint8_t* weight, const float* scale_ptr,
+    fp16* output, uint32_t M, uint32_t N, uint32_t K,
+    sycl::queue& q);
+
+// ============================================================================
+// V12: Cooperative input loading via SLM
+//
+// Key insight from oneDNN ISA analysis: oneDNN's JIT uses cooperative loading
+// where threads in a WG distribute input loads, barrier sync, then all threads
+// read from SLM. This eliminates redundant input loads across N-subgroups.
+// V9's independent WGs each redundantly load the same input data.
+//
+// Design:
+// - WG = N_THREADS × K_THREADS threads (e.g. 4×4=16)
+// - All threads step through K in K_LOAD=64 chunks (lock-step)
+// - Per K_LOAD: threads cooperatively load input tiles to SLM, barrier,
+//   each thread reads its K_SUB's input from SLM, loads own weight, DPAS
+// - Double-buffered SLM: load next K_LOAD while computing current → 1 barrier/iter
+// - After K loop: K-thread partial sum reduction via SLM (same as V9)
+//
+// Traffic savings (N=2560, M=32, NT=4):
+//   V9:  160 WGs × full input = 20.5MB input loads
+//   V12:  40 WGs × full input =  5.1MB input loads (4× reduction)
+// ============================================================================
+template<int K_THREADS, int M_TILES, int N_THREADS>
+struct FP8_GEMM_DPAS_V12 {
+    const fp16*    input;
+    const uint8_t* weight;
+    const float*   scale_ptr;
+    fp16*          output;
+    int M, N, K;
+
+    void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+        constexpr int K_LOAD = 64;
+        constexpr int K_SUB = 16;
+        constexpr int WG_SIZE = K_THREADS * N_THREADS;
+        constexpr int SUBS_PER_KLOAD = K_LOAD / K_SUB;  // = 4
+        constexpr int SUBS_PER_THREAD = SUBS_PER_KLOAD / K_THREADS;
+        constexpr int TILES_PER_KLOAD = SUBS_PER_KLOAD * M_TILES;
+
+        // SLM: double-buffered input OR reduction (non-overlapping phases)
+        constexpr int INPUT_TILE_BYTES = 128 * 2;  // 8×16 fp16 = 256 bytes
+        constexpr int INPUT_BUF_BYTES = TILES_PER_KLOAD * INPUT_TILE_BYTES;
+        constexpr int INPUT_SLM = 2 * INPUT_BUF_BYTES;  // double buffer
+        constexpr int SLM_PER_K = M_TILES * 128 * 4;    // per K-thread reduction
+        constexpr int SLM_PER_N = K_THREADS * SLM_PER_K;
+        constexpr int REDUCE_SLM = N_THREADS * SLM_PER_N;
+        constexpr int SLM_TOTAL = (INPUT_SLM > REDUCE_SLM) ? INPUT_SLM : REDUCE_SLM;
+        slm_init<SLM_TOTAL>();
+
+        int wg_id    = item.get_group(0);
+        int local_id = item.get_local_id(0);
+        int n_tid    = local_id / K_THREADS;
+        int k_tid    = local_id % K_THREADS;
+
+        int n_start = wg_id * (N_THREADS * 16) + n_tid * 16;
+        bool valid_n = (n_start < N);  // Must not early-return — barriers
+
+        simd<float, 128> acc[M_TILES];
+        #pragma unroll
+        for (int i = 0; i < M_TILES; i++) acc[i] = 0.0f;
+
+        // 2D payload for input A (cooperative loading)
+        const uint32_t surfW_A = (uint32_t)K * 2u - 1u;
+        const uint32_t surfH_A = (uint32_t)M - 1u;
+        xesimd::config_2d_mem_access<fp16, 16, 8, 1> payA(
+            input, surfW_A, surfH_A, surfW_A, 0u, 0u);
+
+        // 2D payload for weight B — unique per N-thread
+        const uint32_t surfW_B = (uint32_t)K - 1u;
+        const uint32_t surfH_B = (uint32_t)N - 1u;
+        xesimd::config_2d_mem_access<uint32_t, 4, 16, 1> payB_t(
+            reinterpret_cast<const uint32_t*>(weight),
+            surfW_B, surfH_B, surfW_B,
+            0u, (uint32_t)(valid_n ? n_start : 0));
+
+        int k_iters = K / K_LOAD;
+        int buf = 0;
+
+        // === Initial cooperative load: buffer 0, k_base=0 ===
+        for (int tile_idx = local_id; tile_idx < TILES_PER_KLOAD;
+             tile_idx += WG_SIZE) {
+            int sub_idx = tile_idx / M_TILES;
+            int m_idx   = tile_idx % M_TILES;
+            payA.set_x((uint32_t)(sub_idx * K_SUB));
+            payA.set_y((uint32_t)(m_idx * 8));
+            simd<fp16, 128> a = xesimd::lsc_load_2d<fp16, 16, 8, 1,
+                false, false,
+                xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payA);
+            uint32_t slm_off = (uint32_t)(
+                (sub_idx * M_TILES + m_idx) * INPUT_TILE_BYTES);
+            slm_block_store<fp16, 128>(slm_off, a);
+        }
+        barrier();
+
+        // === Main K loop (double-buffered) ===
+        for (int ki = 0; ki < k_iters; ki++) {
+            int k_base = ki * K_LOAD;
+            int next_buf = 1 - buf;
+
+            // --- Load next K_LOAD into other buffer ---
+            if (ki < k_iters - 1) {
+                int next_k = (ki + 1) * K_LOAD;
+                for (int tile_idx = local_id; tile_idx < TILES_PER_KLOAD;
+                     tile_idx += WG_SIZE) {
+                    int sub_idx = tile_idx / M_TILES;
+                    int m_idx   = tile_idx % M_TILES;
+                    payA.set_x((uint32_t)(next_k + sub_idx * K_SUB));
+                    payA.set_y((uint32_t)(m_idx * 8));
+                    simd<fp16, 128> a = xesimd::lsc_load_2d<fp16, 16, 8, 1,
+                        false, false,
+                        xesimd::cache_hint::cached,
+                        xesimd::cache_hint::cached>(payA);
+                    uint32_t slm_off = (uint32_t)(
+                        next_buf * INPUT_BUF_BYTES +
+                        (sub_idx * M_TILES + m_idx) * INPUT_TILE_BYTES);
+                    slm_block_store<fp16, 128>(slm_off, a);
+                }
+            }
+
+            // --- Compute on current buffer ---
+            if (valid_n) {
+                #pragma unroll
+                for (int sub_off = 0; sub_off < SUBS_PER_THREAD; sub_off++) {
+                    int sub_idx = k_tid * SUBS_PER_THREAD + sub_off;
+                    int k_sub = k_base + sub_idx * K_SUB;
+
+                    // Transposed uint32 weight load + dequant
+                    payB_t.set_x((uint32_t)(k_sub / 4));
+                    simd<uint32_t, 64> w_t =
+                        xesimd::lsc_load_2d<uint32_t, 4, 16, 1,
+                            true, false,
+                            xesimd::cache_hint::cached,
+                            xesimd::cache_hint::cached>(payB_t);
+
+                    simd<uint32_t, 128> b_vnni_u32;
+                    #pragma unroll
+                    for (int col = 0; col < 4; col++) {
+                        simd<uint32_t, 16> group =
+                            w_t.template select<16, 1>(col * 16);
+                        simd<uint32_t, 16> b0 = group & 0xFF;
+                        simd<uint32_t, 16> b1 = (group & 0xFF00) << 8;
+                        b_vnni_u32.template select<16, 1>(col * 2 * 16) =
+                            fp8_e4m3_pair_to_vnni(b0, b1);
+                        simd<uint32_t, 16> group_hi = group >> 16;
+                        simd<uint32_t, 16> b2 = group_hi & 0xFF;
+                        simd<uint32_t, 16> b3 = (group_hi & 0xFF00) << 8;
+                        b_vnni_u32.template select<16, 1>(
+                            (col * 2 + 1) * 16) =
+                            fp8_e4m3_pair_to_vnni(b2, b3);
+                    }
+                    simd<fp16, 256> b_tile =
+                        b_vnni_u32.template bit_cast_view<fp16>().read();
+
+                    // Read input from SLM and DPAS
+                    #pragma unroll
+                    for (int m = 0; m < M_TILES; m++) {
+                        uint32_t slm_off = (uint32_t)(
+                            buf * INPUT_BUF_BYTES +
+                            (sub_idx * M_TILES + m) * INPUT_TILE_BYTES);
+                        simd<fp16, 128> a =
+                            slm_block_load<fp16, 128>(slm_off);
+                        acc[m] = dpas<8, 8, float, float, fp16, fp16>(
+                            acc[m], b_tile, a);
+                    }
+                }
+            }
+
+            barrier();
+            buf = next_buf;
+        }
+
+        // === K-reduction and output ===
+        if constexpr (K_THREADS == 1) {
+            if (!valid_n) return;
+            float s = *scale_ptr;
+            #pragma unroll
+            for (int m = 0; m < M_TILES; m++) {
+                simd<float, 128> scaled = acc[m] * s;
+                int n_valid = (n_start + 16 <= N) ? 16 : (N - n_start);
+                bool full_n = (n_valid == 16);
+                #pragma unroll
+                for (int mi = 0; mi < 8; mi++) {
+                    int row = m * 8 + mi;
+                    if (row < M) {
+                        simd<float, 16> row_f = scaled.select<16, 1>(mi * 16);
+                        simd<fp16, 16> out_row = convert<fp16>(row_f);
+                        if (full_n)
+                            block_store<fp16, 16>(
+                                output + (size_t)row * N + n_start, out_row);
+                        else
+                            for (int ni = 0; ni < n_valid; ni++)
+                                output[(size_t)row * N + n_start + ni] =
+                                    out_row[ni];
+                    }
+                }
+            }
+        } else {
+            // SLM reduction (reuse SLM — input phase done)
+            if (valid_n) {
+                uint32_t slm_base =
+                    n_tid * SLM_PER_N + k_tid * SLM_PER_K;
+                #pragma unroll
+                for (int m = 0; m < M_TILES; m++)
+                    slm_block_store<float, 128>(
+                        slm_base + m * 128 * 4, acc[m]);
+            }
+
+            barrier();
+
+            if (valid_n && k_tid == 0) {
+                float s = *scale_ptr;
+                uint32_t my_slm = n_tid * SLM_PER_N;
+                #pragma unroll
+                for (int m = 0; m < M_TILES; m++) {
+                    simd<float, 128> sum =
+                        slm_block_load<float, 128>(my_slm + m * 128 * 4);
+                    #pragma unroll
+                    for (int t = 1; t < K_THREADS; t++) {
+                        simd<float, 128> partial =
+                            slm_block_load<float, 128>(
+                                my_slm + t * SLM_PER_K + m * 128 * 4);
+                        sum += partial;
+                    }
+                    simd<float, 128> scaled = sum * s;
+                    int n_valid = (n_start + 16 <= N) ? 16 : (N - n_start);
+                    bool full_n = (n_valid == 16);
+                    #pragma unroll
+                    for (int mi = 0; mi < 8; mi++) {
+                        int row = m * 8 + mi;
+                        if (row < M) {
+                            simd<float, 16> row_f =
+                                scaled.select<16, 1>(mi * 16);
+                            simd<fp16, 16> out_row = convert<fp16>(row_f);
+                            if (full_n)
+                                block_store<fp16, 16>(
+                                    output + (size_t)row * N + n_start,
+                                    out_row);
+                            else
+                                for (int ni = 0; ni < n_valid; ni++)
+                                    output[(size_t)row * N + n_start + ni] =
+                                        out_row[ni];
+                        }
+                    }
+                }
+            }
+        }
+    }
+};
+
+// Host dispatcher for V12
+template<int K_THREADS, int M_TILES, int N_THREADS>
+inline void dpas_v12_gemm_fp8_pert_host(
+    const fp16* input, const uint8_t* weight, const float* scale_ptr,
+    fp16* output, uint32_t M, uint32_t N, uint32_t K,
+    sycl::queue& q) {
+    constexpr int N_PER_WG = N_THREADS * 16;
+    constexpr int WG_SIZE = K_THREADS * N_THREADS;
+    int num_wg = ((int)N + N_PER_WG - 1) / N_PER_WG;
+
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(
+            sycl::nd_range<1>({(size_t)(num_wg * WG_SIZE)}, {(size_t)WG_SIZE}),
+            FP8_GEMM_DPAS_V12<K_THREADS, M_TILES, N_THREADS>{
+                input, weight, scale_ptr, output,
+                (int)M, (int)N, (int)K});
+    });
+}
+
+// V12 auto-dispatch
+inline void dpas_v12_auto_dispatch(
+    const fp16* input, const uint8_t* weight, const float* scale_ptr,
+    fp16* output, uint32_t M, uint32_t N, uint32_t K,
+    sycl::queue& q) {
+    int m_tiles = ((int)M + 7) / 8;
+    int n_16 = ((int)N + 15) / 16;
+
+    // Choose N_THREADS: target ~20-80 WGs for occupancy
+    int n_threads = 4;
+    while (n_threads > 1 && (n_16 + n_threads - 1) / n_threads < 10)
+        n_threads /= 2;
+
+    // K_THREADS: 4 for best occupancy (SUBS_PER_KLOAD=4, so KT=1,2,4 all work)
+    int k_threads = 4;
+
+    // Check SLM budget (64KB limit)
+    int reduce_slm = n_threads * k_threads * m_tiles * 128 * 4;
+    if (reduce_slm > 65536 || m_tiles > 4) {
+        // Too much SLM — fall back to V9
+        dpas_v9_auto_dispatch(input, weight, scale_ptr, output, M, N, K, q);
+        return;
+    }
+
+    #define V12_DISPATCH(KT, MT, NT) dpas_v12_gemm_fp8_pert_host<KT, MT, NT>( \
+        input, weight, scale_ptr, output, M, N, K, q)
+
+    if (n_threads == 4) {
+        if      (m_tiles <= 1) V12_DISPATCH(4, 1, 4);
+        else if (m_tiles <= 2) V12_DISPATCH(4, 2, 4);
+        else                   V12_DISPATCH(4, 4, 4);
+    } else if (n_threads == 2) {
+        if      (m_tiles <= 1) V12_DISPATCH(4, 1, 2);
+        else if (m_tiles <= 2) V12_DISPATCH(4, 2, 2);
+        else                   V12_DISPATCH(4, 4, 2);
+    } else {
+        // NT=1: no cooperative benefit, use V9 instead
+        dpas_v9_auto_dispatch(input, weight, scale_ptr, output, M, N, K, q);
+    }
+    #undef V12_DISPATCH
+}
+#endif // GEMM_EXPERIMENTAL — V11, V12
+
+template<int K_THREADS, int M_TILES>
+struct FP8_GEMM_DPAS_V9 {
+    const fp16*    input;
+    const uint8_t* weight;
+    const float*   scale_ptr;
+    fp16*          output;
+    int M, N, K;
+
+    void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+        constexpr int K_LOAD = 64;
+        constexpr int K_SUB = 16;
+        constexpr int SLM_PER_THREAD = M_TILES * 128 * 4;
+        constexpr int SLM_TOTAL = K_THREADS * SLM_PER_THREAD;
+        slm_init<SLM_TOTAL>();
+
+        int wg_id = item.get_group(0);
+        int tid   = item.get_local_id(0);
+
+        int n_start = wg_id * 16;
+        if (n_start >= N) return;
+
+        int k_per_thread = K / K_THREADS;
+        int k_start = tid * k_per_thread;
+        int k_end   = k_start + k_per_thread;
+
+        simd<float, 128> acc[M_TILES];
+        #pragma unroll
+        for (int i = 0; i < M_TILES; i++) acc[i] = 0.0f;
+
+        // 2D payload for input A: [M, K] fp16
+        const uint32_t surfW_A = (uint32_t)K * 2u - 1u;
+        const uint32_t surfH_A = (uint32_t)M - 1u;
+        xesimd::config_2d_mem_access<fp16, 16, 8, 1> payA(
+            input, surfW_A, surfH_A, surfW_A, 0u, 0u);
+        // Wider payload for merged 16-row input loads (2 M-tiles at once)
+        xesimd::config_2d_mem_access<fp16, 16, 16, 1> payA16(
+            input, surfW_A, surfH_A, surfW_A, 0u, 0u);
+        // Super-merged payload for 32-row input loads (4 M-tiles at once)
+        xesimd::config_2d_mem_access<fp16, 16, 32, 1> payA32(
+            input, surfW_A, surfH_A, surfW_A, 0u, 0u);
+
+        // 2D payload for weight B: [N, K] uint8
+        // Reinterpret as uint32 surface for transposed loads
+        const uint32_t surfW_B = (uint32_t)K - 1u;
+        const uint32_t surfH_B = (uint32_t)N - 1u;
+        xesimd::config_2d_mem_access<uint32_t, 4, 16, 1> payB_t(
+            reinterpret_cast<const uint32_t*>(weight),
+            surfW_B, surfH_B, surfW_B,
+            0u, (uint32_t)n_start);
+
+        // Second weight payload for prefetching next sub-step
+        xesimd::config_2d_mem_access<uint32_t, 4, 16, 1> payB_pf(
+            reinterpret_cast<const uint32_t*>(weight),
+            surfW_B, surfH_B, surfW_B,
+            0u, (uint32_t)n_start);
+
+        for (int k_base = k_start; k_base < k_end; k_base += K_LOAD) {
+            // Process 4 sub-steps of 16 K-elements each
+            #pragma unroll
+            for (int sub = 0; sub < 4; sub++) {
+                int k_sub = k_base + sub * K_SUB;
+
+                // Transposed uint32 load: 4 cols × 16 rows = 16 bytes/row × 16 rows
+                // After transpose: result[col*16 + n] = uint32 at B[n, 4*(x+col)]
+                payB_t.set_x((uint32_t)(k_sub / 4));
+                simd<uint32_t, 64> w_t = xesimd::lsc_load_2d<uint32_t, 4, 16, 1,
+                    true, false,
+                    xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payB_t);
+
+                // Prefetch weight into L1 ahead of time
+                // Only beneficial when send queue has spare capacity (not too many WGs)
+                if constexpr (M_TILES <= 2) {
+                    // For small M: prefetch next K_SUB (1 ahead)
+                    if (sub < 3) {
+                        payB_pf.set_x((uint32_t)((k_sub + K_SUB) / 4));
+                        xesimd::lsc_prefetch_2d<uint32_t, 4, 16, 1, false, false,
+                            xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payB_pf);
+                    } else if (k_base + K_LOAD < k_end) {
+                        payB_pf.set_x((uint32_t)((k_base + K_LOAD) / 4));
+                        xesimd::lsc_prefetch_2d<uint32_t, 4, 16, 1, false, false,
+                            xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payB_pf);
+                    }
+                }
+
+                // Build VNNI b_tile from 4 transposed columns
+                // Each column has 4 bytes = 2 k_pairs
+                simd<uint32_t, 128> b_vnni_u32;
+
+                #pragma unroll
+                for (int col = 0; col < 4; col++) {
+                    simd<uint32_t, 16> group = w_t.template select<16, 1>(col * 16);
+
+                    // k_pair 0: bytes 0, 1
+                    simd<uint32_t, 16> b0 = group & 0xFF;
+                    simd<uint32_t, 16> b1 = (group & 0xFF00) << 8;
+                    b_vnni_u32.template select<16, 1>(col * 2 * 16) =
+                        fp8_e4m3_pair_to_vnni(b0, b1);
+
+                    // k_pair 1: bytes 2, 3
+                    simd<uint32_t, 16> group_hi = group >> 16;
+                    simd<uint32_t, 16> b2 = group_hi & 0xFF;
+                    simd<uint32_t, 16> b3 = (group_hi & 0xFF00) << 8;
+                    b_vnni_u32.template select<16, 1>((col * 2 + 1) * 16) =
+                        fp8_e4m3_pair_to_vnni(b2, b3);
+                }
+
+                simd<fp16, 256> b_tile =
+                    b_vnni_u32.template bit_cast_view<fp16>().read();
+
+                // Load input and DPAS — use super-merged 32-row loads for M_TILES>=4
+                if constexpr (M_TILES >= 4) {
+                    payA32.set_x((uint32_t)k_sub);
+                    #pragma unroll
+                    for (int m = 0; m < M_TILES; m += 4) {
+                        payA32.set_y((uint32_t)(m * 8));
+                        simd<fp16, 512> a4 = xesimd::lsc_load_2d<fp16, 16, 32, 1,
+                            false, false,
+                            xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payA32);
+                        #pragma unroll
+                        for (int mi = 0; mi < 4; mi++) {
+                            simd<fp16, 128> a = a4.template select<128, 1>(mi * 128);
+                            acc[m + mi] = dpas<8, 8, float, float, fp16, fp16>(acc[m + mi], b_tile, a);
+                        }
+                    }
+                } else if constexpr (M_TILES >= 2) {
+                    payA16.set_x((uint32_t)k_sub);
+                    #pragma unroll
+                    for (int m = 0; m < M_TILES; m += 2) {
+                        payA16.set_y((uint32_t)(m * 8));
+                        simd<fp16, 256> a2 = xesimd::lsc_load_2d<fp16, 16, 16, 1,
+                            false, false,
+                            xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payA16);
+                        simd<fp16, 128> a0 = a2.template select<128, 1>(0);
+                        simd<fp16, 128> a1 = a2.template select<128, 1>(128);
+                        acc[m]   = dpas<8, 8, float, float, fp16, fp16>(acc[m],   b_tile, a0);
+                        acc[m+1] = dpas<8, 8, float, float, fp16, fp16>(acc[m+1], b_tile, a1);
+                    }
+                } else {
+                    payA.set_x((uint32_t)k_sub);
+                    payA.set_y(0u);
+                    simd<fp16, 128> a = xesimd::lsc_load_2d<fp16, 16, 8, 1,
+                        false, false,
+                        xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payA);
+                    acc[0] = dpas<8, 8, float, float, fp16, fp16>(acc[0], b_tile, a);
+                }
+            }
+        }
+
+        if constexpr (K_THREADS == 1) {
+            float s = *scale_ptr;
+            #pragma unroll
+            for (int m = 0; m < M_TILES; m++) {
+                simd<float, 128> scaled = acc[m] * s;
+                int n_valid = (n_start + 16 <= N) ? 16 : (N - n_start);
+                bool full_n = (n_valid == 16);
+                #pragma unroll
+                for (int mi = 0; mi < 8; mi++) {
+                    int row = m * 8 + mi;
+                    if (row < M) {
+                        simd<float, 16> row_f = scaled.select<16, 1>(mi * 16);
+                        simd<fp16, 16> out_row = convert<fp16>(row_f);
+                        if (full_n)
+                            block_store<fp16, 16>(output + (size_t)row * N + n_start, out_row);
+                        else
+                            for (int ni = 0; ni < n_valid; ni++)
+                                output[(size_t)row * N + n_start + ni] = out_row[ni];
+                    }
+                }
+            }
+        } else {
+            uint32_t slm_base = tid * SLM_PER_THREAD;
+            #pragma unroll
+            for (int m = 0; m < M_TILES; m++) {
+                slm_block_store<float, 128>(slm_base + m * 128 * 4, acc[m]);
+            }
+
+            barrier();
+
+            if (tid == 0) {
+                float s = *scale_ptr;
+                #pragma unroll
+                for (int m = 0; m < M_TILES; m++) {
+                    simd<float, 128> sum = slm_block_load<float, 128>(m * 128 * 4);
+                    #pragma unroll
+                    for (int t = 1; t < K_THREADS; t++) {
+                        simd<float, 128> partial = slm_block_load<float, 128>(
+                            t * SLM_PER_THREAD + m * 128 * 4);
+                        sum += partial;
+                    }
+                    simd<float, 128> scaled = sum * s;
+                    int n_valid = (n_start + 16 <= N) ? 16 : (N - n_start);
+                    bool full_n = (n_valid == 16);
+                    #pragma unroll
+                    for (int mi = 0; mi < 8; mi++) {
+                        int row = m * 8 + mi;
+                        if (row < M) {
+                            simd<float, 16> row_f = scaled.select<16, 1>(mi * 16);
+                            simd<fp16, 16> out_row = convert<fp16>(row_f);
+                            if (full_n)
+                                block_store<fp16, 16>(output + (size_t)row * N + n_start, out_row);
+                            else
+                                for (int ni = 0; ni < n_valid; ni++)
+                                    output[(size_t)row * N + n_start + ni] = out_row[ni];
+                        }
+                    }
+                }
+            }
+        }
+    }
+};
+
+#ifdef GEMM_EXPERIMENTAL  // Dead code: V13, V10 kernel structs + dispatchers
+// ============================================================================
+// V13: V9 + software-pipelined weight loading
+// Pre-load all 4 weight K_SUBs before processing → overlaps sends with each other
+// Also prefetches next K_LOAD's first weight sub during last processing sub
+// ============================================================================
+template<int K_THREADS, int M_TILES>
+struct FP8_GEMM_DPAS_V13 {
+    const fp16*    input;
+    const uint8_t* weight;
+    const float*   scale_ptr;
+    fp16*          output;
+    int M, N, K;
+
+    void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+        constexpr int K_LOAD = 64;
+        constexpr int K_SUB = 16;
+        constexpr int SLM_PER_THREAD = M_TILES * 128 * 4;
+        constexpr int SLM_TOTAL = K_THREADS * SLM_PER_THREAD;
+        slm_init<SLM_TOTAL>();
+
+        int wg_id = item.get_group(0);
+        int tid   = item.get_local_id(0);
+
+        int n_start = wg_id * 16;
+        if (n_start >= N) return;
+
+        int k_per_thread = K / K_THREADS;
+        int k_start = tid * k_per_thread;
+        int k_end   = k_start + k_per_thread;
+
+        simd<float, 128> acc[M_TILES];
+        #pragma unroll
+        for (int i = 0; i < M_TILES; i++) acc[i] = 0.0f;
+
+        // 2D payload for input A
+        const uint32_t surfW_A = (uint32_t)K * 2u - 1u;
+        const uint32_t surfH_A = (uint32_t)M - 1u;
+        xesimd::config_2d_mem_access<fp16, 16, 8, 1> payA(
+            input, surfW_A, surfH_A, surfW_A, 0u, 0u);
+        xesimd::config_2d_mem_access<fp16, 16, 16, 1> payA16(
+            input, surfW_A, surfH_A, surfW_A, 0u, 0u);
+        xesimd::config_2d_mem_access<fp16, 16, 32, 1> payA32(
+            input, surfW_A, surfH_A, surfW_A, 0u, 0u);
+
+        // 2D payload for weight B (transposed uint32)
+        const uint32_t surfW_B = (uint32_t)K - 1u;
+        const uint32_t surfH_B = (uint32_t)N - 1u;
+        xesimd::config_2d_mem_access<uint32_t, 4, 16, 1> payB_t(
+            reinterpret_cast<const uint32_t*>(weight),
+            surfW_B, surfH_B, surfW_B,
+            0u, (uint32_t)n_start);
+
+        for (int k_base = k_start; k_base < k_end; k_base += K_LOAD) {
+            // Phase 1: Pre-load all 4 weight K_SUBs (batch sends for pipelining)
+            simd<uint32_t, 64> w_t0, w_t1, w_t2, w_t3;
+            payB_t.set_x((uint32_t)(k_base / 4));
+            w_t0 = xesimd::lsc_load_2d<uint32_t, 4, 16, 1,
+                true, false,
+                xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payB_t);
+            payB_t.set_x((uint32_t)((k_base + K_SUB) / 4));
+            w_t1 = xesimd::lsc_load_2d<uint32_t, 4, 16, 1,
+                true, false,
+                xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payB_t);
+            payB_t.set_x((uint32_t)((k_base + 2 * K_SUB) / 4));
+            w_t2 = xesimd::lsc_load_2d<uint32_t, 4, 16, 1,
+                true, false,
+                xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payB_t);
+            payB_t.set_x((uint32_t)((k_base + 3 * K_SUB) / 4));
+            w_t3 = xesimd::lsc_load_2d<uint32_t, 4, 16, 1,
+                true, false,
+                xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payB_t);
+
+            // Phase 2: Process each K_SUB — dequant + input load + DPAS
+            simd<uint32_t, 64>* w_ptrs[4] = {&w_t0, &w_t1, &w_t2, &w_t3};
+            #pragma unroll
+            for (int sub = 0; sub < 4; sub++) {
+                int k_sub = k_base + sub * K_SUB;
+                simd<uint32_t, 64>& w_t = *w_ptrs[sub];
+
+                // Build VNNI b_tile from 4 transposed columns
+                simd<uint32_t, 128> b_vnni_u32;
+                #pragma unroll
+                for (int col = 0; col < 4; col++) {
+                    simd<uint32_t, 16> group = w_t.template select<16, 1>(col * 16);
+                    simd<uint32_t, 16> b0 = group & 0xFF;
+                    simd<uint32_t, 16> b1 = (group & 0xFF00) << 8;
+                    b_vnni_u32.template select<16, 1>(col * 2 * 16) =
+                        fp8_e4m3_pair_to_vnni(b0, b1);
+                    simd<uint32_t, 16> group_hi = group >> 16;
+                    simd<uint32_t, 16> b2 = group_hi & 0xFF;
+                    simd<uint32_t, 16> b3 = (group_hi & 0xFF00) << 8;
+                    b_vnni_u32.template select<16, 1>((col * 2 + 1) * 16) =
+                        fp8_e4m3_pair_to_vnni(b2, b3);
+                }
+                simd<fp16, 256> b_tile =
+                    b_vnni_u32.template bit_cast_view<fp16>().read();
+
+                // Load input and DPAS
+                if constexpr (M_TILES >= 4) {
+                    payA32.set_x((uint32_t)k_sub);
+                    #pragma unroll
+                    for (int m = 0; m < M_TILES; m += 4) {
+                        payA32.set_y((uint32_t)(m * 8));
+                        simd<fp16, 512> a4 = xesimd::lsc_load_2d<fp16, 16, 32, 1,
+                            false, false,
+                            xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payA32);
+                        #pragma unroll
+                        for (int mi = 0; mi < 4; mi++) {
+                            simd<fp16, 128> a = a4.template select<128, 1>(mi * 128);
+                            acc[m + mi] = dpas<8, 8, float, float, fp16, fp16>(acc[m + mi], b_tile, a);
+                        }
+                    }
+                } else if constexpr (M_TILES >= 2) {
+                    payA16.set_x((uint32_t)k_sub);
+                    #pragma unroll
+                    for (int m = 0; m < M_TILES; m += 2) {
+                        payA16.set_y((uint32_t)(m * 8));
+                        simd<fp16, 256> a2 = xesimd::lsc_load_2d<fp16, 16, 16, 1,
+                            false, false,
+                            xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payA16);
+                        simd<fp16, 128> a0 = a2.template select<128, 1>(0);
+                        simd<fp16, 128> a1 = a2.template select<128, 1>(128);
+                        acc[m]   = dpas<8, 8, float, float, fp16, fp16>(acc[m],   b_tile, a0);
+                        acc[m+1] = dpas<8, 8, float, float, fp16, fp16>(acc[m+1], b_tile, a1);
+                    }
+                } else {
+                    payA.set_x((uint32_t)k_sub);
+                    payA.set_y(0u);
+                    simd<fp16, 128> a = xesimd::lsc_load_2d<fp16, 16, 8, 1,
+                        false, false,
+                        xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payA);
+                    acc[0] = dpas<8, 8, float, float, fp16, fp16>(acc[0], b_tile, a);
+                }
+            }
+        }
+
+        // Reduction and output — same as V9
+        if constexpr (K_THREADS == 1) {
+            float s = *scale_ptr;
+            #pragma unroll
+            for (int m = 0; m < M_TILES; m++) {
+                simd<float, 128> scaled = acc[m] * s;
+                int n_valid = (n_start + 16 <= N) ? 16 : (N - n_start);
+                bool full_n = (n_valid == 16);
+                #pragma unroll
+                for (int mi = 0; mi < 8; mi++) {
+                    int row = m * 8 + mi;
+                    if (row < M) {
+                        simd<float, 16> row_f = scaled.select<16, 1>(mi * 16);
+                        simd<fp16, 16> out_row = convert<fp16>(row_f);
+                        if (full_n)
+                            block_store<fp16, 16>(output + (size_t)row * N + n_start, out_row);
+                        else
+                            for (int ni = 0; ni < n_valid; ni++)
+                                output[(size_t)row * N + n_start + ni] = out_row[ni];
+                    }
+                }
+            }
+        } else {
+            uint32_t slm_base = tid * SLM_PER_THREAD;
+            #pragma unroll
+            for (int m = 0; m < M_TILES; m++) {
+                slm_block_store<float, 128>(slm_base + m * 128 * 4, acc[m]);
+            }
+            barrier();
+            if (tid == 0) {
+                float s = *scale_ptr;
+                #pragma unroll
+                for (int m = 0; m < M_TILES; m++) {
+                    simd<float, 128> sum = slm_block_load<float, 128>(m * 128 * 4);
+                    #pragma unroll
+                    for (int t = 1; t < K_THREADS; t++) {
+                        simd<float, 128> partial = slm_block_load<float, 128>(
+                            t * SLM_PER_THREAD + m * 128 * 4);
+                        sum += partial;
+                    }
+                    simd<float, 128> scaled = sum * s;
+                    int n_valid = (n_start + 16 <= N) ? 16 : (N - n_start);
+                    bool full_n = (n_valid == 16);
+                    #pragma unroll
+                    for (int mi = 0; mi < 8; mi++) {
+                        int row = m * 8 + mi;
+                        if (row < M) {
+                            simd<float, 16> row_f = scaled.select<16, 1>(mi * 16);
+                            simd<fp16, 16> out_row = convert<fp16>(row_f);
+                            if (full_n)
+                                block_store<fp16, 16>(output + (size_t)row * N + n_start, out_row);
+                            else
+                                for (int ni = 0; ni < n_valid; ni++)
+                                    output[(size_t)row * N + n_start + ni] = out_row[ni];
+                        }
+                    }
+                }
+            }
+        }
+    }
+};
+
+// Host dispatcher for V13
+template<int K_THREADS, int M_TILES>
+inline void dpas_v13_gemm_fp8_pert_host(
+    const fp16* input, const uint8_t* weight, const float* scale_ptr,
+    fp16* output, uint32_t M, uint32_t N, uint32_t K,
+    sycl::queue& q) {
+    int num_wg = ((int)N + 15) / 16;
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(
+            sycl::nd_range<1>({(size_t)(num_wg * K_THREADS)}, {(size_t)K_THREADS}),
+            FP8_GEMM_DPAS_V13<K_THREADS, M_TILES>{
+                input, weight, scale_ptr, output,
+                (int)M, (int)N, (int)K});
+    });
+}
+
+// V13 auto-dispatch (same logic as V9)
+inline void dpas_v13_auto_dispatch(
+    const fp16* input, const uint8_t* weight, const float* scale_ptr,
+    fp16* output, uint32_t M, uint32_t N, uint32_t K,
+    sycl::queue& q) {
+    int m_tiles = ((int)M + 7) / 8;
+    int n_wgs = ((int)N + 15) / 16;
+    int k_threads = std::max(1, std::min(4, 640 / std::max(n_wgs, 1)));
+    while (k_threads > 1 && (K % (k_threads * 64) != 0)) k_threads--;
+    if (k_threads == 3) k_threads = 2;
+
+    #define V13_DISPATCH(KT, MT) dpas_v13_gemm_fp8_pert_host<KT, MT>(input, weight, scale_ptr, output, M, N, K, q)
+    if (k_threads >= 4) {
+        if      (m_tiles <= 1) V13_DISPATCH(4, 1);
+        else if (m_tiles <= 2) V13_DISPATCH(4, 2);
+        else if (m_tiles <= 4) V13_DISPATCH(4, 4);
+        else                   V13_DISPATCH(4, 8);
+    } else if (k_threads >= 2) {
+        if      (m_tiles <= 1) V13_DISPATCH(2, 1);
+        else if (m_tiles <= 2) V13_DISPATCH(2, 2);
+        else if (m_tiles <= 4) V13_DISPATCH(2, 4);
+        else                   V13_DISPATCH(2, 8);
+    } else {
+        if      (m_tiles <= 1) V13_DISPATCH(1, 1);
+        else if (m_tiles <= 2) V13_DISPATCH(1, 2);
+        else if (m_tiles <= 4) V13_DISPATCH(1, 4);
+        else                   V13_DISPATCH(1, 8);
+    }
+    #undef V13_DISPATCH
+}
+
+// ============================================================================
+// V10: V9 + N_TILES — process multiple N-columns per thread to reduce input loads
+// VTune showed V9 has 45% more Send instructions than oneDNN at M=32.
+// Root cause: V9 processes only 16 N-cols/WG → 160 WGs each redundantly loading input.
+// V10: N_TILES=2 → 32 N-cols/WG → 80 WGs → halves redundant input loads.
+// ============================================================================
+template<int K_THREADS, int M_TILES, int N_TILES>
+struct FP8_GEMM_DPAS_V10 {
+    const fp16*    input;
+    const uint8_t* weight;
+    const float*   scale_ptr;
+    fp16*          output;
+    int M, N, K;
+
+    void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+        constexpr int K_LOAD = 64;
+        constexpr int K_SUB = 16;
+        constexpr int N_PER_WG = N_TILES * 16;
+        constexpr int ACC_COUNT = M_TILES * N_TILES;
+        constexpr int SLM_PER_THREAD = ACC_COUNT * 128 * 4;
+        constexpr int SLM_TOTAL = K_THREADS * SLM_PER_THREAD;
+        slm_init<SLM_TOTAL>();
+
+        int wg_id = item.get_group(0);
+        int tid   = item.get_local_id(0);
+
+        int n_base = wg_id * N_PER_WG;
+        if (n_base >= N) return;
+
+        int k_per_thread = K / K_THREADS;
+        int k_start = tid * k_per_thread;
+        int k_end   = k_start + k_per_thread;
+
+        // Accumulators: [n_tile][m_tile]
+        simd<float, 128> acc[N_TILES][M_TILES];
+        #pragma unroll
+        for (int nt = 0; nt < N_TILES; nt++)
+            #pragma unroll
+            for (int mt = 0; mt < M_TILES; mt++)
+                acc[nt][mt] = 0.0f;
+
+        // 2D payload for input A: [M, K] fp16
+        const uint32_t surfW_A = (uint32_t)K * 2u - 1u;
+        const uint32_t surfH_A = (uint32_t)M - 1u;
+        xesimd::config_2d_mem_access<fp16, 16, 8, 1> payA(
+            input, surfW_A, surfH_A, surfW_A, 0u, 0u);
+
+        // 2D payloads for weight B — one per N-tile
+        const uint32_t surfW_B = (uint32_t)K - 1u;
+        const uint32_t surfH_B = (uint32_t)N - 1u;
+
+        xesimd::config_2d_mem_access<uint32_t, 4, 16, 1> payB_t[N_TILES];
+        #pragma unroll
+        for (int nt = 0; nt < N_TILES; nt++) {
+            payB_t[nt] = xesimd::config_2d_mem_access<uint32_t, 4, 16, 1>(
+                reinterpret_cast<const uint32_t*>(weight),
+                surfW_B, surfH_B, surfW_B,
+                0u, (uint32_t)(n_base + nt * 16));
+        }
+
+        for (int k_base = k_start; k_base < k_end; k_base += K_LOAD) {
+            #pragma unroll
+            for (int sub = 0; sub < 4; sub++) {
+                int k_sub = k_base + sub * K_SUB;
+
+                // Input-stationary: load input once per M-tile, iterate N-tiles
+                // First load all input tiles for this K-sub
+                simd<fp16, 128> a_tiles[M_TILES];
+                payA.set_x((uint32_t)k_sub);
+                #pragma unroll
+                for (int mt = 0; mt < M_TILES; mt++) {
+                    payA.set_y((uint32_t)(mt * 8));
+                    a_tiles[mt] = xesimd::lsc_load_2d<fp16, 16, 8, 1,
+                        false, false,
+                        xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payA);
+                }
+
+                // Process each N-tile: load weight, DPAS across all M-tiles
+                #pragma unroll
+                for (int nt = 0; nt < N_TILES; nt++) {
+                    payB_t[nt].set_x((uint32_t)(k_sub / 4));
+                    simd<uint32_t, 64> w_t = xesimd::lsc_load_2d<uint32_t, 4, 16, 1,
+                        true, false,
+                        xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payB_t[nt]);
+
+                    simd<uint32_t, 128> b_vnni_u32;
+                    #pragma unroll
+                    for (int col = 0; col < 4; col++) {
+                        simd<uint32_t, 16> group = w_t.template select<16, 1>(col * 16);
+                        simd<uint32_t, 16> b0 = group & 0xFF;
+                        simd<uint32_t, 16> b1 = (group & 0xFF00) << 8;
+                        b_vnni_u32.template select<16, 1>(col * 2 * 16) =
+                            fp8_e4m3_pair_to_vnni(b0, b1);
+                        simd<uint32_t, 16> group_hi = group >> 16;
+                        simd<uint32_t, 16> b2 = group_hi & 0xFF;
+                        simd<uint32_t, 16> b3 = (group_hi & 0xFF00) << 8;
+                        b_vnni_u32.template select<16, 1>((col * 2 + 1) * 16) =
+                            fp8_e4m3_pair_to_vnni(b2, b3);
+                    }
+                    simd<fp16, 256> b_tile =
+                        b_vnni_u32.template bit_cast_view<fp16>().read();
+
+                    #pragma unroll
+                    for (int mt = 0; mt < M_TILES; mt++) {
+                        acc[nt][mt] = dpas<8, 8, float, float, fp16, fp16>(
+                            acc[nt][mt], b_tile, a_tiles[mt]);
+                    }
+                }
+            }
+        }
+
+        if constexpr (K_THREADS == 1) {
+            float s = *scale_ptr;
+            #pragma unroll
+            for (int nt = 0; nt < N_TILES; nt++) {
+                int n_start = n_base + nt * 16;
+                int n_valid = (n_start + 16 <= N) ? 16 : (N - n_start);
+                if (n_valid <= 0) continue;
+                bool full_n = (n_valid == 16);
+                #pragma unroll
+                for (int mt = 0; mt < M_TILES; mt++) {
+                    simd<float, 128> scaled = acc[nt][mt] * s;
+                    #pragma unroll
+                    for (int mi = 0; mi < 8; mi++) {
+                        int row = mt * 8 + mi;
+                        if (row < M) {
+                            simd<float, 16> row_f = scaled.select<16, 1>(mi * 16);
+                            simd<fp16, 16> out_row = convert<fp16>(row_f);
+                            if (full_n)
+                                block_store<fp16, 16>(output + (size_t)row * N + n_start, out_row);
+                            else
+                                for (int ni = 0; ni < n_valid; ni++)
+                                    output[(size_t)row * N + n_start + ni] = out_row[ni];
+                        }
+                    }
+                }
+            }
+        } else {
+            // SLM reduction
+            uint32_t slm_base = tid * SLM_PER_THREAD;
+            #pragma unroll
+            for (int nt = 0; nt < N_TILES; nt++)
+                #pragma unroll
+                for (int mt = 0; mt < M_TILES; mt++)
+                    slm_block_store<float, 128>(
+                        slm_base + (nt * M_TILES + mt) * 128 * 4, acc[nt][mt]);
+
+            barrier();
+
+            if (tid == 0) {
+                float s = *scale_ptr;
+                #pragma unroll
+                for (int nt = 0; nt < N_TILES; nt++) {
+                    int n_start = n_base + nt * 16;
+                    int n_valid = (n_start + 16 <= N) ? 16 : (N - n_start);
+                    if (n_valid <= 0) continue;
+                    bool full_n = (n_valid == 16);
+                    #pragma unroll
+                    for (int mt = 0; mt < M_TILES; mt++) {
+                        int acc_idx = nt * M_TILES + mt;
+                        simd<float, 128> sum = slm_block_load<float, 128>(
+                            acc_idx * 128 * 4);
+                        #pragma unroll
+                        for (int t = 1; t < K_THREADS; t++) {
+                            simd<float, 128> partial = slm_block_load<float, 128>(
+                                t * SLM_PER_THREAD + acc_idx * 128 * 4);
+                            sum += partial;
+                        }
+                        simd<float, 128> scaled = sum * s;
+                        #pragma unroll
+                        for (int mi = 0; mi < 8; mi++) {
+                            int row = mt * 8 + mi;
+                            if (row < M) {
+                                simd<float, 16> row_f = scaled.select<16, 1>(mi * 16);
+                                simd<fp16, 16> out_row = convert<fp16>(row_f);
+                                if (full_n)
+                                    block_store<fp16, 16>(output + (size_t)row * N + n_start, out_row);
+                                else
+                                    for (int ni = 0; ni < n_valid; ni++)
+                                        output[(size_t)row * N + n_start + ni] = out_row[ni];
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+};
+
+// Host dispatcher for DPAS V10
+template<int K_THREADS, int M_TILES, int N_TILES>
+inline void dpas_v10_gemm_fp8_pert_host(
+    const fp16*    input,
+    const uint8_t* weight,
+    const float*   scale_ptr,
+    fp16*          output,
+    uint32_t M, uint32_t N, uint32_t K,
+    sycl::queue& q) {
+
+    constexpr int N_PER_WG = N_TILES * 16;
+    int num_wg = ((int)N + N_PER_WG - 1) / N_PER_WG;
+
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(
+            sycl::nd_range<1>({(size_t)(num_wg * K_THREADS)}, {(size_t)K_THREADS}),
+            FP8_GEMM_DPAS_V10<K_THREADS, M_TILES, N_TILES>{
+                input, weight, scale_ptr, output,
+                (int)M, (int)N, (int)K});
+    });
+}
+
+// V10 auto-dispatch: choose K_THREADS, M_TILES, N_TILES
+inline void dpas_v10_auto_dispatch(
+    const fp16* input, const uint8_t* weight, const float* scale_ptr,
+    fp16* output, uint32_t M, uint32_t N, uint32_t K,
+    sycl::queue& q) {
+    int m_tiles = ((int)M + 7) / 8;
+
+    // Choose N_TILES based on M: higher M benefits from more N-reuse
+    int n_tiles = (m_tiles >= 4) ? 4 : (m_tiles >= 2) ? 2 : 1;
+    // Cap N_TILES so we don't end up with too few WGs
+    int n_per_wg = n_tiles * 16;
+    int n_wgs = ((int)N + n_per_wg - 1) / n_per_wg;
+    // Ensure enough WGs for occupancy
+    while (n_tiles > 1 && n_wgs < 20) {
+        n_tiles /= 2;
+        n_per_wg = n_tiles * 16;
+        n_wgs = ((int)N + n_per_wg - 1) / n_per_wg;
+    }
+
+    int k_threads = std::max(1, std::min(4, 640 / std::max(n_wgs, 1)));
+    while (k_threads > 1 && (K % (k_threads * 64) != 0)) k_threads--;
+    if (k_threads == 3) k_threads = 2;
+
+    #define V10_DISPATCH(KT, MT, NT) dpas_v10_gemm_fp8_pert_host<KT, MT, NT>(input, weight, scale_ptr, output, M, N, K, q)
+
+    // Dispatch based on k_threads, m_tiles, n_tiles
+    if (n_tiles == 4) {
+        if (k_threads >= 4) {
+            if      (m_tiles <= 4) V10_DISPATCH(4, 4, 4);
+            else                   V10_DISPATCH(4, 8, 4);
+        } else if (k_threads >= 2) {
+            if      (m_tiles <= 4) V10_DISPATCH(2, 4, 4);
+            else                   V10_DISPATCH(2, 8, 4);
+        } else {
+            if      (m_tiles <= 4) V10_DISPATCH(1, 4, 4);
+            else                   V10_DISPATCH(1, 8, 4);
+        }
+    } else if (n_tiles == 2) {
+        if (k_threads >= 4) {
+            if      (m_tiles <= 1) V10_DISPATCH(4, 1, 2);
+            else if (m_tiles <= 2) V10_DISPATCH(4, 2, 2);
+            else if (m_tiles <= 4) V10_DISPATCH(4, 4, 2);
+            else                   V10_DISPATCH(4, 8, 2);
+        } else if (k_threads >= 2) {
+            if      (m_tiles <= 1) V10_DISPATCH(2, 1, 2);
+            else if (m_tiles <= 2) V10_DISPATCH(2, 2, 2);
+            else if (m_tiles <= 4) V10_DISPATCH(2, 4, 2);
+            else                   V10_DISPATCH(2, 8, 2);
+        } else {
+            if      (m_tiles <= 1) V10_DISPATCH(1, 1, 2);
+            else if (m_tiles <= 2) V10_DISPATCH(1, 2, 2);
+            else if (m_tiles <= 4) V10_DISPATCH(1, 4, 2);
+            else                   V10_DISPATCH(1, 8, 2);
+        }
+    } else {
+        // N_TILES=1: same as V9
+        if (k_threads >= 4) {
+            if      (m_tiles <= 1) V10_DISPATCH(4, 1, 1);
+            else if (m_tiles <= 2) V10_DISPATCH(4, 2, 1);
+            else if (m_tiles <= 4) V10_DISPATCH(4, 4, 1);
+            else                   V10_DISPATCH(4, 8, 1);
+        } else if (k_threads >= 2) {
+            if      (m_tiles <= 1) V10_DISPATCH(2, 1, 1);
+            else if (m_tiles <= 2) V10_DISPATCH(2, 2, 1);
+            else if (m_tiles <= 4) V10_DISPATCH(2, 4, 1);
+            else                   V10_DISPATCH(2, 8, 1);
+        } else {
+            if      (m_tiles <= 1) V10_DISPATCH(1, 1, 1);
+            else if (m_tiles <= 2) V10_DISPATCH(1, 2, 1);
+            else if (m_tiles <= 4) V10_DISPATCH(1, 4, 1);
+            else                   V10_DISPATCH(1, 8, 1);
+        }
+    }
+    #undef V10_DISPATCH
+}
+#endif // GEMM_EXPERIMENTAL — V13, V10
+
+// Host dispatcher for DPAS V9
+template<int K_THREADS, int M_TILES>
+inline void dpas_v9_gemm_fp8_pert_host(
+    const fp16*    input,
+    const uint8_t* weight,
+    const float*   scale_ptr,
+    fp16*          output,
+    uint32_t M, uint32_t N, uint32_t K,
+    sycl::queue& q) {
+
+    int num_wg = ((int)N + 15) / 16;
+
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(
+            sycl::nd_range<1>({(size_t)(num_wg * K_THREADS)}, {(size_t)K_THREADS}),
+            FP8_GEMM_DPAS_V9<K_THREADS, M_TILES>{
+                input, weight, scale_ptr, output,
+                (int)M, (int)N, (int)K});
+    });
+}
+
+// V9 auto-dispatch: choose K_THREADS and M_TILES
+inline void dpas_v9_auto_dispatch(
+    const fp16* input, const uint8_t* weight, const float* scale_ptr,
+    fp16* output, uint32_t M, uint32_t N, uint32_t K,
+    sycl::queue& q) {
+    int m_tiles = ((int)M + 7) / 8;
+    int n_wgs = ((int)N + 15) / 16;
+    int k_threads = std::max(1, std::min(4, 640 / std::max(n_wgs, 1)));
+    while (k_threads > 1 && (K % (k_threads * 64) != 0)) k_threads--;
+    if (k_threads == 3) k_threads = 2;
+
+    #define V9_DISPATCH(KT, MT) dpas_v9_gemm_fp8_pert_host<KT, MT>(input, weight, scale_ptr, output, M, N, K, q)
+    if (k_threads >= 4) {
+        if      (m_tiles <= 1) V9_DISPATCH(4, 1);
+        else if (m_tiles <= 2) V9_DISPATCH(4, 2);
+        else if (m_tiles <= 4) V9_DISPATCH(4, 4);
+        else                   V9_DISPATCH(4, 8);
+    } else if (k_threads >= 2) {
+        if      (m_tiles <= 1) V9_DISPATCH(2, 1);
+        else if (m_tiles <= 2) V9_DISPATCH(2, 2);
+        else if (m_tiles <= 4) V9_DISPATCH(2, 4);
+        else                   V9_DISPATCH(2, 8);
+    } else {
+        if      (m_tiles <= 1) V9_DISPATCH(1, 1);
+        else if (m_tiles <= 2) V9_DISPATCH(1, 2);
+        else if (m_tiles <= 4) V9_DISPATCH(1, 4);
+        else                   V9_DISPATCH(1, 8);
+    }
+    #undef V9_DISPATCH
+}
+
+#ifdef GEMM_EXPERIMENTAL  // Dead code: V5, V2 hosts, old dpas_gemm, old unified dispatcher, v5_auto_dispatch
+// Host dispatcher for DPAS V5
+template<int WG_SIZE, int M_TILES>
+inline void dpas_v5_gemm_fp8_pert_host(
+    const fp16*    input,
+    const uint8_t* weight,
+    const float*   scale_ptr,
+    fp16*          output,
+    uint32_t M, uint32_t N, uint32_t K,
+    int fp8_mode,
+    sycl::queue& q) {
+
+    constexpr int N_WG = WG_SIZE * 16;
+    int num_wg = ((int)N + N_WG - 1) / N_WG;
+
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(
+            sycl::nd_range<1>({(size_t)(num_wg * WG_SIZE)}, {(size_t)WG_SIZE}),
+            FP8_GEMM_DPAS_V5<WG_SIZE, M_TILES>{
+                input, weight, scale_ptr, output,
+                (int)M, (int)N, (int)K, fp8_mode});
+    });
+}
+
+// Host dispatcher for DPAS V2
+template<int WG_SIZE, int M_TILES>
+inline void dpas_v2_gemm_fp8_pert_host(
+    const fp16*    input,
+    const uint8_t* weight,
+    const float*   scale_ptr,
+    fp16*          output,
+    uint32_t M, uint32_t N, uint32_t K,
+    int fp8_mode,
+    sycl::queue& q) {
+
+    constexpr int N_WG = WG_SIZE * 16;
+    int num_wg = ((int)N + N_WG - 1) / N_WG;
+
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(
+            sycl::nd_range<1>({(size_t)(num_wg * WG_SIZE)}, {(size_t)WG_SIZE}),
+            FP8_GEMM_DPAS_V2<WG_SIZE, M_TILES>{
+                input, weight, scale_ptr, output,
+                (int)M, (int)N, (int)K, fp8_mode});
+    });
+}
+#endif // GEMM_EXPERIMENTAL — V5, V2 host dispatchers
+
+// ============================================================================
+// Host Dispatchers
+// ============================================================================
+
+// Regime A dispatcher: M=1~4, batched GEMV with K-split
+inline void batched_gemv_fp8_pert_host(
+    const fp16*    input,
+    const uint8_t* weight,
+    const float*   scale_ptr,
+    fp16*          output,
+    uint32_t M, uint32_t N, uint32_t K,
+    int fp8_mode,
+    sycl::queue& q) {
+
+    int vl, ks;
+    select_vl_ks(N, K, vl, ks);
+
+    int global0 = N * ks;
+    int global1 = M;
+    int local0  = ks;
+    int local1  = 1;
+
+    #define LAUNCH_BATCHED(V, S) \
+        q.submit([&](sycl::handler& h) { \
+            h.parallel_for( \
+                sycl::nd_range<2>({(size_t)global0, (size_t)global1}, \
+                                  {(size_t)local0, (size_t)local1}), \
+                GEMV_fp8_pert_batched_kernel<V, S>{ \
+                    input, weight, scale_ptr, output, \
+                    (int)M, (int)N, (int)K, fp8_mode}); \
+        });
+
+    if      (vl == 512 && ks == 1) { LAUNCH_BATCHED(512, 1) }
+    else if (vl == 512 && ks == 2) { LAUNCH_BATCHED(512, 2) }
+    else if (vl == 256 && ks == 1) { LAUNCH_BATCHED(256, 1) }
+    else if (vl == 256 && ks == 2) { LAUNCH_BATCHED(256, 2) }
+    else if (vl == 256 && ks == 4) { LAUNCH_BATCHED(256, 4) }
+    else if (vl == 128 && ks == 1) { LAUNCH_BATCHED(128, 1) }
+    else if (vl == 128 && ks == 2) { LAUNCH_BATCHED(128, 2) }
+    else if (vl == 128 && ks == 4) { LAUNCH_BATCHED(128, 4) }
+    else if (vl == 128 && ks == 8) { LAUNCH_BATCHED(128, 8) }
+    else                           { LAUNCH_BATCHED(128, 1) }
+
+    #undef LAUNCH_BATCHED
+}
+
+// Regime B/C dispatcher: weight-stationary GEMM
+// VL and TILE_M are both template params. Key configs:
+//   TM=8,  VL=128: 4KB accs — M=4~8, single M-tile
+//   TM=16, VL=128: 8KB accs — M=9~16, single M-tile
+//   TM=32, VL=64:  8KB accs — M=17~64, fewer M-tiles = fewer weight re-reads
+template<int VL, int TILE_M>
+inline void ws_gemm_fp8_pert_host(
+    const fp16*    input,
+    const uint8_t* weight,
+    const float*   scale_ptr,
+    fp16*          output,
+    uint32_t M, uint32_t N, uint32_t K,
+    int fp8_mode,
+    sycl::queue& q) {
+
+    int m_tiles = ((int)M + TILE_M - 1) / TILE_M;
+
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(
+            sycl::nd_range<2>({(size_t)N, (size_t)m_tiles}, {1, 1}),
+            GEMM_fp8_pert_ws_kernel<VL, TILE_M>{
+                input, weight, scale_ptr, output,
+                (int)M, (int)N, (int)K, fp8_mode});
+    });
+}
+
+#ifdef GEMM_EXPERIMENTAL  // Dead code: old dpas_gemm, old unified dispatcher, v5_auto_dispatch
+// Regime D dispatcher: DPAS-based GEMM
+// TILE_N must be a multiple of 16. Requires K % 16 == 0.
+template<int TILE_N>
+inline void dpas_gemm_fp8_pert_host(
+    const fp16*    input,
+    const uint8_t* weight,
+    const float*   scale_ptr,
+    fp16*          output,
+    uint32_t M, uint32_t N, uint32_t K,
+    int fp8_mode,
+    sycl::queue& q) {
+
+    int n_tiles = ((int)N + TILE_N - 1) / TILE_N;
+    int m_tiles = ((int)M + 7) / 8;  // DPAS always does 8 M-rows
+
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(
+            sycl::nd_range<2>({(size_t)n_tiles, (size_t)m_tiles}, {1, 1}),
+            GEMM_fp8_pert_dpas_kernel<TILE_N>{
+                input, weight, scale_ptr, output,
+                (int)M, (int)N, (int)K, fp8_mode});
+    });
+}
+
+// Unified dispatcher: selects regime based on M
+inline void GEMM_fp8_pert_host(
+    uint8_t* input_data,   // fp16[M, K]
+    uint8_t* weight_data,  // uint8[N, K]
+    uint8_t* scale_data,   // float scalar (device ptr)
+    uint8_t* output_data,  // fp16[M, N]
+    uint32_t M, uint32_t N, uint32_t K,
+    int fp8_mode,
+    sycl::queue& q) {
+
+    auto* p_in  = reinterpret_cast<const fp16*>(input_data);
+    auto* p_w   = reinterpret_cast<const uint8_t*>(weight_data);
+    auto* p_sc  = reinterpret_cast<const float*>(scale_data);
+    auto* p_out = reinterpret_cast<fp16*>(output_data);
+
+    if (M <= 3) {
+        batched_gemv_fp8_pert_host(p_in, p_w, p_sc, p_out, M, N, K, fp8_mode, q);
+    } else if (M <= 8) {
+        ws_gemm_fp8_pert_host<128, 8>(p_in, p_w, p_sc, p_out, M, N, K, fp8_mode, q);
+    } else {
+        // WS-16/128 wins across all M>8 values in crossover analysis.
+        // DPAS available via dpas_gemm_fp8_pert_host<16>() but FP8 dequant+VNNI
+        // packing overhead makes it slower than WS for these shape sizes.
+        ws_gemm_fp8_pert_host<128, 16>(p_in, p_w, p_sc, p_out, M, N, K, fp8_mode, q);
+    }
+}
+
+// V5 M_TILES dispatcher helper
+inline void dpas_v5_auto_dispatch(
+    const fp16* input, const uint8_t* weight, const float* scale_ptr,
+    fp16* output, uint32_t M, uint32_t N, uint32_t K,
+    int fp8_mode, sycl::queue& q) {
+    int m_tiles = ((int)M + 7) / 8;
+    if      (m_tiles <= 1) dpas_v5_gemm_fp8_pert_host<8, 1>(input, weight, scale_ptr, output, M, N, K, fp8_mode, q);
+    else if (m_tiles <= 2) dpas_v5_gemm_fp8_pert_host<8, 2>(input, weight, scale_ptr, output, M, N, K, fp8_mode, q);
+    else if (m_tiles <= 4) dpas_v5_gemm_fp8_pert_host<8, 4>(input, weight, scale_ptr, output, M, N, K, fp8_mode, q);
+    else                   dpas_v5_gemm_fp8_pert_host<8, 8>(input, weight, scale_ptr, output, M, N, K, fp8_mode, q);
+}
+#endif // GEMM_EXPERIMENTAL — V5, V2, old dispatchers
+
+// Direct-typed unified dispatcher (no uint8_t casts needed)
+inline void GEMM_fp8_pert_dispatch(
+    const fp16*    input,
+    const uint8_t* weight,
+    const float*   scale_ptr,
+    fp16*          output,
+    uint32_t M, uint32_t N, uint32_t K,
+    int fp8_mode,
+    sycl::queue& q) {
+
+    if (M == 1) {
+        batched_gemv_fp8_pert_host(input, weight, scale_ptr, output, M, N, K, fp8_mode, q);
+    } else if (K % 64 == 0 && fp8_mode == 0) {
+        // V9: Transposed load + fused dequant-VNNI (E4M3 only, best for M>=2)
+        dpas_v9_auto_dispatch(input, weight, scale_ptr, output, M, N, K, q);
+    } else if (K % 64 == 0 && N >= 1024) {
+        // V7: K-split multi-thread WG for E5M2 or when V9 not applicable
+        dpas_v7_auto_dispatch(input, weight, scale_ptr, output, M, N, K, fp8_mode, q);
+    } else if (M <= 3) {
+        batched_gemv_fp8_pert_host(input, weight, scale_ptr, output, M, N, K, fp8_mode, q);
+    } else if (M <= 8) {
+        ws_gemm_fp8_pert_host<128, 8>(input, weight, scale_ptr, output, M, N, K, fp8_mode, q);
+    } else {
+        ws_gemm_fp8_pert_host<128, 16>(input, weight, scale_ptr, output, M, N, K, fp8_mode, q);
+    }
+}

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/fp8_GEMV_v2.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/fp8_GEMV_v2.h
@@ -1,0 +1,499 @@
+#pragma once
+#include "utils.h"
+
+// FP8 GEMV with FP32 accumulation, element-wise acc + deferred scale.
+// Optimized for decode (M=1) on BMG. Achieves ~97% BW utilization on large shapes.
+//
+// Supports both E4M3 and E5M2 via fp8_mode (0=E4M3, 1=E5M2).
+// Input: [1, K] fp16, Weight: [N, K] fp8, Output: [1, N] fp16
+//
+// E4M3 dequant: sign<<15 | (exp+8)<<10 | mant<<7  (bias shift 7->15 = +8)
+// E5M2 dequant: sign<<15 | exp<<10 | mant<<8       (same bias, no shift)
+// Subnormal (exp==0): flush to signed zero
+
+// FP8 -> FP16 dequant: returns fp16 simd from raw uint8 simd
+template<int VL>
+SYCL_ESIMD_FUNCTION inline simd<float, VL> fp8_dequant(
+    simd<uint8_t, VL> raw, int fp8_mode) {
+    simd<uint16_t, VL> u16 = convert<uint16_t>(raw);
+    simd<uint16_t, VL> fp8_sign = (u16 >> 7) & 1;
+    simd<uint16_t, VL> fp16_bits;
+
+    if (fp8_mode == 0) {
+        // E4M3: 4-bit exp (bias 7), 3-bit mant
+        simd<uint16_t, VL> fp8_exp  = (u16 >> 3) & 0xF;
+        simd<uint16_t, VL> fp8_mant = u16 & 0x7;
+        fp16_bits = (fp8_sign << 15) | ((fp8_exp + 8) << 10) | (fp8_mant << 7);
+        fp16_bits.merge(fp8_sign << 15, fp8_exp == 0);
+    } else {
+        // E5M2: 5-bit exp (bias 15), 2-bit mant
+        simd<uint16_t, VL> fp8_exp  = (u16 >> 2) & 0x1F;
+        simd<uint16_t, VL> fp8_mant = u16 & 0x3;
+        fp16_bits = (fp8_sign << 15) | (fp8_exp << 10) | (fp8_mant << 8);
+        fp16_bits.merge(fp8_sign << 15, fp8_exp == 0);
+    }
+
+    simd<fp16, VL> wh = fp16_bits.template bit_cast_view<fp16>().read();
+    return simd<float, VL>(wh);
+}
+
+// ============================================================================
+// Per-N scale (pern): scale is fp16[N]
+// ============================================================================
+
+template<int VL, int K_SPLIT>
+struct GEMV_fp8_pern_kernel {
+    const fp16*    input;
+    const uint8_t* weight;
+    const fp16*    scale;
+    fp16*          output;
+    int N, K;
+    int fp8_mode; // 0=E4M3, 1=E5M2
+
+    void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+        if constexpr (K_SPLIT > 1) {
+            slm_init<K_SPLIT * sizeof(float)>();
+        }
+
+        int n   = item.get_group(0);
+        int lid = item.get_local_id(0);
+        if (n >= N) return;
+
+        int kp = K / K_SPLIT;
+        int ks = lid * kp;
+
+        simd<float, VL> acc = 0.0f;
+
+        for (int k = ks; k < ks + kp; k += VL) {
+            simd<fp16, VL> iv = block_load<fp16, VL>(input + k);
+            simd<float, VL> input_f = iv;
+
+            simd<uint8_t, VL> raw = block_load<uint8_t, VL>(weight + (size_t)n * K + k);
+            simd<float, VL> wf = fp8_dequant<VL>(raw, fp8_mode);
+
+            acc += input_f * wf;
+        }
+
+        float my_sum = reduce<float>(acc, std::plus<>()) * static_cast<float>(scale[n]);
+
+        if constexpr (K_SPLIT == 1) {
+            output[n] = fp16(my_sum);
+        } else {
+            slm_block_store<float, 1>(lid * sizeof(float), simd<float, 1>(my_sum));
+            barrier();
+            if (lid == 0) {
+                simd<float, K_SPLIT> parts = slm_block_load<float, K_SPLIT>(0);
+                output[n] = fp16(reduce<float>(parts, std::plus<>()));
+            }
+        }
+    }
+};
+
+// VL/K_SPLIT auto-selection helper (shared by all dispatchers)
+inline void select_vl_ks(uint32_t N, uint32_t K, int& vl, int& ks) {
+    vl = 512; ks = 1;
+
+    if (K < 512) {
+        vl = 128; ks = 1;
+    } else if (K == 512) {
+        vl = 256; ks = 1;
+    }
+
+    if (N <= 128 && K >= 2048) {
+        vl = 128; ks = 8;
+    } else if (N <= 512 && K >= 2048) {
+        vl = 128; ks = 4;
+    }
+
+    int kpt = K / ks;
+    while (vl > kpt || kpt % vl != 0) {
+        if (vl > 128) {
+            vl /= 2;
+        } else if (ks > 1) {
+            ks /= 2;
+            kpt = K / ks;
+        } else {
+            break;
+        }
+    }
+}
+
+inline void GEMV_fp8_pern_host(
+    uint8_t* input_data,
+    uint8_t* weight_data,
+    uint8_t* scale_data,
+    uint8_t* output_data,
+    uint32_t N,
+    uint32_t K,
+    int fp8_mode,
+    sycl::queue& q) {
+
+    auto* p_in  = reinterpret_cast<const fp16*>(input_data);
+    auto* p_w   = reinterpret_cast<const uint8_t*>(weight_data);
+    auto* p_sc  = reinterpret_cast<const fp16*>(scale_data);
+    auto* p_out = reinterpret_cast<fp16*>(output_data);
+
+    int vl, ks;
+    select_vl_ks(N, K, vl, ks);
+
+    int global = N * ks;
+    int local  = ks;
+
+    #define LAUNCH(V, S) \
+        q.submit([&](sycl::handler& h) { \
+            h.parallel_for(sycl::nd_range<1>(global, local), \
+                GEMV_fp8_pern_kernel<V, S>{p_in, p_w, p_sc, p_out, (int)N, (int)K, fp8_mode}); \
+        });
+
+    if (vl == 512 && ks == 1) { LAUNCH(512, 1) }
+    else if (vl == 512 && ks == 2) { LAUNCH(512, 2) }
+    else if (vl == 256 && ks == 1) { LAUNCH(256, 1) }
+    else if (vl == 256 && ks == 2) { LAUNCH(256, 2) }
+    else if (vl == 256 && ks == 4) { LAUNCH(256, 4) }
+    else if (vl == 128 && ks == 1) { LAUNCH(128, 1) }
+    else if (vl == 128 && ks == 2) { LAUNCH(128, 2) }
+    else if (vl == 128 && ks == 4) { LAUNCH(128, 4) }
+    else if (vl == 128 && ks == 8) { LAUNCH(128, 8) }
+    else { LAUNCH(128, 1) }
+
+    #undef LAUNCH
+}
+
+// ============================================================================
+// Fused per-N scale
+// ============================================================================
+
+template<int VL, int K_SPLIT, int GEMV_COUNT>
+struct GEMV_fp8_pern_fused_kernel {
+    const fp16*    input;
+    const uint8_t* weights[GEMV_COUNT];
+    const fp16*    scales[GEMV_COUNT];
+    fp16*          outputs[GEMV_COUNT];
+    int            N[GEMV_COUNT];
+    int            N_cumsum[GEMV_COUNT];
+    int            K;
+    int            fp8_mode;
+
+    void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+        if constexpr (K_SPLIT > 1) {
+            slm_init<K_SPLIT * sizeof(float)>();
+        }
+
+        int gid = item.get_group(0);
+        int lid = item.get_local_id(0);
+
+        int mat_idx = 0;
+        int local_n = gid;
+        #pragma unroll
+        for (int i = 0; i < GEMV_COUNT; i++) {
+            if (gid < N_cumsum[i]) {
+                mat_idx = i;
+                local_n = (i == 0) ? gid : gid - N_cumsum[i - 1];
+                break;
+            }
+        }
+
+        const uint8_t* w_ptr = weights[mat_idx];
+        const fp16*    s_ptr = scales[mat_idx];
+        fp16*          o_ptr = outputs[mat_idx];
+        int            n     = local_n;
+
+        int kp = K / K_SPLIT;
+        int ks = lid * kp;
+
+        simd<float, VL> acc = 0.0f;
+
+        for (int k = ks; k < ks + kp; k += VL) {
+            simd<fp16, VL> iv = block_load<fp16, VL>(input + k);
+            simd<float, VL> input_f = iv;
+
+            simd<uint8_t, VL> raw = block_load<uint8_t, VL>(w_ptr + (size_t)n * K + k);
+            simd<float, VL> wf = fp8_dequant<VL>(raw, fp8_mode);
+
+            acc += input_f * wf;
+        }
+
+        float my_sum = reduce<float>(acc, std::plus<>()) * static_cast<float>(s_ptr[n]);
+
+        if constexpr (K_SPLIT == 1) {
+            o_ptr[n] = fp16(my_sum);
+        } else {
+            slm_block_store<float, 1>(lid * sizeof(float), simd<float, 1>(my_sum));
+            barrier();
+            if (lid == 0) {
+                simd<float, K_SPLIT> parts = slm_block_load<float, K_SPLIT>(0);
+                o_ptr[n] = fp16(reduce<float>(parts, std::plus<>()));
+            }
+        }
+    }
+};
+
+template<int GEMV_COUNT>
+inline void GEMV_fp8_pern_fused_host(
+    uint8_t* input_data,
+    uint8_t* weight_ptrs[GEMV_COUNT],
+    uint8_t* scale_ptrs[GEMV_COUNT],
+    uint8_t* output_ptrs[GEMV_COUNT],
+    uint32_t Ns[GEMV_COUNT],
+    uint32_t K,
+    int fp8_mode,
+    sycl::queue& q) {
+
+    auto* p_in = reinterpret_cast<const fp16*>(input_data);
+
+    uint32_t total_N = 0;
+    for (int i = 0; i < GEMV_COUNT; i++) total_N += Ns[i];
+
+    int vl, ks;
+    select_vl_ks(total_N, K, vl, ks);
+
+    int global = total_N * ks;
+    int local  = ks;
+
+    #define LAUNCH_FUSED(V, S) \
+        q.submit([&](sycl::handler& h) { \
+            GEMV_fp8_pern_fused_kernel<V, S, GEMV_COUNT> kern; \
+            kern.input = p_in; \
+            kern.K = (int)K; \
+            kern.fp8_mode = fp8_mode; \
+            uint32_t cum = 0; \
+            for (int i = 0; i < GEMV_COUNT; i++) { \
+                kern.weights[i] = reinterpret_cast<const uint8_t*>(weight_ptrs[i]); \
+                kern.scales[i]  = reinterpret_cast<const fp16*>(scale_ptrs[i]); \
+                kern.outputs[i] = reinterpret_cast<fp16*>(output_ptrs[i]); \
+                kern.N[i] = (int)Ns[i]; \
+                cum += Ns[i]; \
+                kern.N_cumsum[i] = (int)cum; \
+            } \
+            h.parallel_for(sycl::nd_range<1>(global, local), kern); \
+        });
+
+    if (vl == 512 && ks == 1) { LAUNCH_FUSED(512, 1) }
+    else if (vl == 512 && ks == 2) { LAUNCH_FUSED(512, 2) }
+    else if (vl == 256 && ks == 1) { LAUNCH_FUSED(256, 1) }
+    else if (vl == 256 && ks == 2) { LAUNCH_FUSED(256, 2) }
+    else if (vl == 256 && ks == 4) { LAUNCH_FUSED(256, 4) }
+    else if (vl == 128 && ks == 1) { LAUNCH_FUSED(128, 1) }
+    else if (vl == 128 && ks == 2) { LAUNCH_FUSED(128, 2) }
+    else if (vl == 128 && ks == 4) { LAUNCH_FUSED(128, 4) }
+    else if (vl == 128 && ks == 8) { LAUNCH_FUSED(128, 8) }
+    else { LAUNCH_FUSED(128, 1) }
+
+    #undef LAUNCH_FUSED
+}
+
+// ============================================================================
+// Per-tensor scale (pert): scale is a single float per matrix
+// ============================================================================
+
+template<int VL, int K_SPLIT>
+struct GEMV_fp8_pert_kernel {
+    const fp16*    input;
+    const uint8_t* weight;
+    const float*   scale_ptr;  // device pointer — no host sync
+    fp16*          output;
+    int N, K;
+    int fp8_mode;
+
+    void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+        if constexpr (K_SPLIT > 1) {
+            slm_init<K_SPLIT * sizeof(float)>();
+        }
+
+        int n   = item.get_group(0);
+        int lid = item.get_local_id(0);
+        if (n >= N) return;
+
+        int kp = K / K_SPLIT;
+        int ks = lid * kp;
+
+        simd<float, VL> acc = 0.0f;
+
+        for (int k = ks; k < ks + kp; k += VL) {
+            simd<fp16, VL> iv = block_load<fp16, VL>(input + k);
+            simd<float, VL> input_f = iv;
+
+            simd<uint8_t, VL> raw = block_load<uint8_t, VL>(weight + (size_t)n * K + k);
+            simd<float, VL> wf = fp8_dequant<VL>(raw, fp8_mode);
+
+            acc += input_f * wf;
+        }
+
+        float my_sum = reduce<float>(acc, std::plus<>()) * *scale_ptr;
+
+        if constexpr (K_SPLIT == 1) {
+            output[n] = fp16(my_sum);
+        } else {
+            slm_block_store<float, 1>(lid * sizeof(float), simd<float, 1>(my_sum));
+            barrier();
+            if (lid == 0) {
+                simd<float, K_SPLIT> parts = slm_block_load<float, K_SPLIT>(0);
+                output[n] = fp16(reduce<float>(parts, std::plus<>()));
+            }
+        }
+    }
+};
+
+inline void GEMV_fp8_pert_host(
+    uint8_t* input_data,
+    uint8_t* weight_data,
+    uint8_t* scale_data,  // device pointer to float scalar — no host sync
+    uint8_t* output_data,
+    uint32_t N,
+    uint32_t K,
+    int fp8_mode,
+    sycl::queue& q) {
+
+    auto* p_in  = reinterpret_cast<const fp16*>(input_data);
+    auto* p_w   = reinterpret_cast<const uint8_t*>(weight_data);
+    auto* p_sc  = reinterpret_cast<const float*>(scale_data);
+    auto* p_out = reinterpret_cast<fp16*>(output_data);
+
+    int vl, ks;
+    select_vl_ks(N, K, vl, ks);
+
+    int global = N * ks;
+    int local  = ks;
+
+    #define LAUNCH_PERT(V, S) \
+        q.submit([&](sycl::handler& h) { \
+            h.parallel_for(sycl::nd_range<1>(global, local), \
+                GEMV_fp8_pert_kernel<V, S>{p_in, p_w, p_sc, p_out, (int)N, (int)K, fp8_mode}); \
+        });
+
+    if (vl == 512 && ks == 1) { LAUNCH_PERT(512, 1) }
+    else if (vl == 512 && ks == 2) { LAUNCH_PERT(512, 2) }
+    else if (vl == 256 && ks == 1) { LAUNCH_PERT(256, 1) }
+    else if (vl == 256 && ks == 2) { LAUNCH_PERT(256, 2) }
+    else if (vl == 256 && ks == 4) { LAUNCH_PERT(256, 4) }
+    else if (vl == 128 && ks == 1) { LAUNCH_PERT(128, 1) }
+    else if (vl == 128 && ks == 2) { LAUNCH_PERT(128, 2) }
+    else if (vl == 128 && ks == 4) { LAUNCH_PERT(128, 4) }
+    else if (vl == 128 && ks == 8) { LAUNCH_PERT(128, 8) }
+    else { LAUNCH_PERT(128, 1) }
+
+    #undef LAUNCH_PERT
+}
+
+// ============================================================================
+// Fused per-tensor scale
+// ============================================================================
+
+template<int VL, int K_SPLIT, int GEMV_COUNT>
+struct GEMV_fp8_pert_fused_kernel {
+    const fp16*    input;
+    const uint8_t* weights[GEMV_COUNT];
+    const float*   scale_ptrs[GEMV_COUNT];  // device pointers — no host sync
+    fp16*          outputs[GEMV_COUNT];
+    int            N[GEMV_COUNT];
+    int            N_cumsum[GEMV_COUNT];
+    int            K;
+    int            fp8_mode;
+
+    void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+        if constexpr (K_SPLIT > 1) {
+            slm_init<K_SPLIT * sizeof(float)>();
+        }
+
+        int gid = item.get_group(0);
+        int lid = item.get_local_id(0);
+
+        int mat_idx = 0;
+        int local_n = gid;
+        #pragma unroll
+        for (int i = 0; i < GEMV_COUNT; i++) {
+            if (gid < N_cumsum[i]) {
+                mat_idx = i;
+                local_n = (i == 0) ? gid : gid - N_cumsum[i - 1];
+                break;
+            }
+        }
+
+        const uint8_t* w_ptr = weights[mat_idx];
+        float          s_val = *scale_ptrs[mat_idx];
+        fp16*          o_ptr = outputs[mat_idx];
+        int            n     = local_n;
+
+        int kp = K / K_SPLIT;
+        int ks = lid * kp;
+
+        simd<float, VL> acc = 0.0f;
+
+        for (int k = ks; k < ks + kp; k += VL) {
+            simd<fp16, VL> iv = block_load<fp16, VL>(input + k);
+            simd<float, VL> input_f = iv;
+
+            simd<uint8_t, VL> raw = block_load<uint8_t, VL>(w_ptr + (size_t)n * K + k);
+            simd<float, VL> wf = fp8_dequant<VL>(raw, fp8_mode);
+
+            acc += input_f * wf;
+        }
+
+        float my_sum = reduce<float>(acc, std::plus<>()) * s_val;
+
+        if constexpr (K_SPLIT == 1) {
+            o_ptr[n] = fp16(my_sum);
+        } else {
+            slm_block_store<float, 1>(lid * sizeof(float), simd<float, 1>(my_sum));
+            barrier();
+            if (lid == 0) {
+                simd<float, K_SPLIT> parts = slm_block_load<float, K_SPLIT>(0);
+                o_ptr[n] = fp16(reduce<float>(parts, std::plus<>()));
+            }
+        }
+    }
+};
+
+template<int GEMV_COUNT>
+inline void GEMV_fp8_pert_fused_host(
+    uint8_t* input_data,
+    uint8_t* weight_ptrs[GEMV_COUNT],
+    uint8_t* scale_ptrs[GEMV_COUNT],  // device pointers to float scalars — no host sync
+    uint8_t* output_ptrs[GEMV_COUNT],
+    uint32_t Ns[GEMV_COUNT],
+    uint32_t K,
+    int fp8_mode,
+    sycl::queue& q) {
+
+    auto* p_in = reinterpret_cast<const fp16*>(input_data);
+
+    uint32_t total_N = 0;
+    for (int i = 0; i < GEMV_COUNT; i++) total_N += Ns[i];
+
+    int vl, ks;
+    select_vl_ks(total_N, K, vl, ks);
+
+    int global = total_N * ks;
+    int local  = ks;
+
+    #define LAUNCH_PERT_FUSED(V, S) \
+        q.submit([&](sycl::handler& h) { \
+            GEMV_fp8_pert_fused_kernel<V, S, GEMV_COUNT> kern; \
+            kern.input = p_in; \
+            kern.K = (int)K; \
+            kern.fp8_mode = fp8_mode; \
+            uint32_t cum = 0; \
+            for (int i = 0; i < GEMV_COUNT; i++) { \
+                kern.weights[i] = reinterpret_cast<const uint8_t*>(weight_ptrs[i]); \
+                kern.scale_ptrs[i] = reinterpret_cast<const float*>(scale_ptrs[i]); \
+                kern.outputs[i] = reinterpret_cast<fp16*>(output_ptrs[i]); \
+                kern.N[i] = (int)Ns[i]; \
+                cum += Ns[i]; \
+                kern.N_cumsum[i] = (int)cum; \
+            } \
+            h.parallel_for(sycl::nd_range<1>(global, local), kern); \
+        });
+
+    if (vl == 512 && ks == 1) { LAUNCH_PERT_FUSED(512, 1) }
+    else if (vl == 512 && ks == 2) { LAUNCH_PERT_FUSED(512, 2) }
+    else if (vl == 256 && ks == 1) { LAUNCH_PERT_FUSED(256, 1) }
+    else if (vl == 256 && ks == 2) { LAUNCH_PERT_FUSED(256, 2) }
+    else if (vl == 256 && ks == 4) { LAUNCH_PERT_FUSED(256, 4) }
+    else if (vl == 128 && ks == 1) { LAUNCH_PERT_FUSED(128, 1) }
+    else if (vl == 128 && ks == 2) { LAUNCH_PERT_FUSED(128, 2) }
+    else if (vl == 128 && ks == 4) { LAUNCH_PERT_FUSED(128, 4) }
+    else if (vl == 128 && ks == 8) { LAUNCH_PERT_FUSED(128, 8) }
+    else { LAUNCH_PERT_FUSED(128, 1) }
+
+    #undef LAUNCH_PERT_FUSED
+}

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/fp8_moe_gemm.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/fp8_moe_gemm.h
@@ -1,0 +1,438 @@
+#pragma once
+#include <sycl/sycl.hpp>
+#include <sycl/ext/intel/esimd.hpp>
+#include <sycl/ext/intel/experimental/esimd/memory.hpp>
+#include <sycl/ext/intel/esimd/xmx/dpas.hpp>
+
+using namespace sycl::ext::intel::esimd;
+using namespace sycl::ext::intel::esimd::xmx;
+using namespace sycl;
+using fp16 = sycl::half;
+
+namespace xesimd = sycl::ext::intel::experimental::esimd;
+
+// ============================================================================
+// MoE Grouped GEMM — FP8 E5M2 with per-N scale
+//
+// V3: Hybrid grid — each WG handles (n_per_wg N-tiles, 1 M-chunk).
+//     M-chunks parallelized across WGs (no M-chunk loop → no weight re-reads).
+//     N-tiles merged per WG to control total WG count.
+//
+// Weight: [num_experts, N, K] uint8 FP8 E5M2 (row-major per expert)
+// Scale:  [num_experts, N] float32 (per-N per-expert)
+// Input:  [total_tokens, K] fp16
+// Output: [total_tokens, N] fp16
+// Index:  [num_experts + 1] uint32 (token start per expert)
+// ============================================================================
+
+SYCL_ESIMD_FUNCTION inline simd<uint32_t, 16>
+fp8_e5m2_pair_to_vnni(simd<uint32_t, 16> b_lo, simd<uint32_t, 16> b_hi_shifted) {
+    return (b_lo | b_hi_shifted) << 8;
+}
+
+template<int MT_MAX>
+struct MoE_FP8_E5M2_Kernel_V3 {
+    const fp16*     input;
+    const uint8_t*  weight;      // [num_experts * N, K] flat
+    const float*    scale;       // [num_experts * N] flat
+    fp16*           output;      // [total_tokens, N]
+    const uint32_t* expert_idx;  // [num_experts + 1]
+    int N, K, num_experts;
+    int n_wg_count;    // number of N-tile-groups per expert
+    int n_per_wg;      // N-tiles per WG
+    int m_chunks;      // M-chunks per expert (1 per WG in M dimension)
+
+    void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+        constexpr int K_SUB = 16;
+        constexpr int M_PER_CHUNK = MT_MAX * 8;
+
+        int wgs_per_expert = n_wg_count * m_chunks;
+        int wg_id = item.get_group(0);
+        int expert_id = wg_id / wgs_per_expert;
+        int local_wg  = wg_id % wgs_per_expert;
+
+        if (expert_id >= num_experts) return;
+
+        // Decode (n_wg_id, m_chunk_id) from flat local_wg
+        int n_wg_id    = local_wg % n_wg_count;
+        int m_chunk_id = local_wg / n_wg_count;
+
+        uint32_t tok_start = expert_idx[expert_id];
+        uint32_t tok_end   = expert_idx[expert_id + 1];
+        int M_e = (int)(tok_end - tok_start);
+        if (M_e <= 0) return;
+
+        int m_row_start = m_chunk_id * M_PER_CHUNK;
+        if (m_row_start >= M_e) return;
+
+        int m_rows_left = M_e - m_row_start;
+        int total_m_tiles_here = (m_rows_left + 7) / 8;
+        if (total_m_tiles_here > MT_MAX) total_m_tiles_here = MT_MAX;
+
+        // N-tile range for this WG
+        int n_tiles_total = (N + 15) / 16;
+        int n_tile_start = n_wg_id * n_per_wg;
+        int n_tile_end = n_tile_start + n_per_wg;
+        if (n_tile_end > n_tiles_total) n_tile_end = n_tiles_total;
+
+        // 2D surface descriptors
+        uint32_t total_tokens = expert_idx[num_experts];
+        const uint32_t surfW_A = (uint32_t)K * 2u - 1u;
+        const uint32_t surfH_A = total_tokens - 1u;
+        xesimd::config_2d_mem_access<fp16, 16, 8, 1> payA(
+            input, surfW_A, surfH_A, surfW_A, 0u, 0u);
+
+        const uint32_t surfW_B = (uint32_t)K - 1u;
+        const uint32_t surfH_B = (uint32_t)(num_experts * N) - 1u;
+        xesimd::config_2d_mem_access<uint32_t, 4, 16, 1> payB_t(
+            reinterpret_cast<const uint32_t*>(weight),
+            surfW_B, surfH_B, surfW_B, 0u, 0u);
+
+        // N-tile loop (merged tiles per WG)
+        for (int nc = n_tile_start; nc < n_tile_end; nc++) {
+            int n_start = nc * 16;
+            if (n_start >= N) break;
+
+            int n_valid = (n_start + 16 <= N) ? 16 : (N - n_start);
+            bool full_n = (n_valid == 16);
+
+            // Load per-N scale
+            simd<float, 16> scale_n;
+            if (full_n)
+                scale_n = block_load<float, 16>(scale + expert_id * N + n_start);
+            else {
+                scale_n = 0.0f;
+                for (int ni = 0; ni < n_valid; ni++)
+                    scale_n[ni] = *(scale + expert_id * N + n_start + ni);
+            }
+
+            payB_t.set_y((uint32_t)(expert_id * N + n_start));
+
+            // Accumulators
+            simd<float, 128> acc[MT_MAX];
+            #pragma unroll
+            for (int i = 0; i < MT_MAX; i++) acc[i] = 0.0f;
+
+            // K loop — weight read once per N-tile
+            for (int k_base = 0; k_base < K; k_base += 64) {
+                #pragma unroll
+                for (int sub = 0; sub < 4; sub++) {
+                    int k_sub = k_base + sub * K_SUB;
+                    if (k_sub >= K) break;
+
+                    payB_t.set_x((uint32_t)(k_sub / 4));
+                    simd<uint32_t, 64> w_t = xesimd::lsc_load_2d<uint32_t, 4, 16, 1,
+                        true, false,
+                        xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payB_t);
+
+                    // E5M2 dequant + VNNI
+                    simd<uint32_t, 128> b_vnni;
+                    #pragma unroll
+                    for (int col = 0; col < 4; col++) {
+                        simd<uint32_t, 16> g = w_t.template select<16, 1>(col * 16);
+                        simd<uint32_t, 16> b0 = g & 0xFF;
+                        simd<uint32_t, 16> b1 = (g & 0xFF00) << 8;
+                        b_vnni.template select<16, 1>(col * 32) =
+                            fp8_e5m2_pair_to_vnni(b0, b1);
+                        simd<uint32_t, 16> gh = g >> 16;
+                        simd<uint32_t, 16> b2 = gh & 0xFF;
+                        simd<uint32_t, 16> b3 = (gh & 0xFF00) << 8;
+                        b_vnni.template select<16, 1>(col * 32 + 16) =
+                            fp8_e5m2_pair_to_vnni(b2, b3);
+                    }
+                    simd<fp16, 256> b_tile =
+                        b_vnni.template bit_cast_view<fp16>().read();
+
+                    // Input + DPAS — fully unrolled
+                    payA.set_x((uint32_t)k_sub);
+                    #pragma unroll
+                    for (int m = 0; m < MT_MAX; m++) {
+                        payA.set_y((uint32_t)(tok_start + m_row_start + m * 8));
+                        simd<fp16, 128> a = xesimd::lsc_load_2d<fp16, 16, 8, 1,
+                            false, false,
+                            xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payA);
+                        acc[m] = dpas<8, 8, float, float, fp16, fp16>(acc[m], b_tile, a);
+                    }
+                }
+            }
+
+            // Output
+            for (int m = 0; m < MT_MAX; m++) {
+                if (m >= total_m_tiles_here) break;
+                #pragma unroll
+                for (int mi = 0; mi < 8; mi++) {
+                    int row = m_row_start + m * 8 + mi;
+                    if (row < M_e) {
+                        simd<float, 16> rf = acc[m].template select<16, 1>(mi * 16);
+                        rf *= scale_n;
+                        simd<fp16, 16> out = convert<fp16>(rf);
+                        size_t off = (size_t)(tok_start + row) * N + n_start;
+                        if (full_n)
+                            block_store<fp16, 16>(output + off, out);
+                        else
+                            for (int ni = 0; ni < n_valid; ni++)
+                                output[off + ni] = out[ni];
+                    }
+                }
+            }
+        } // end N-tile loop
+    }
+};
+
+// ============================================================================
+// Per-tensor scale variant: scale is [num_experts] float32 (one per expert)
+// ============================================================================
+
+template<int MT_MAX>
+struct MoE_FP8_E5M2_Kernel_V3_PerT {
+    const fp16*     input;
+    const uint8_t*  weight;      // [num_experts * N, K] flat
+    const float*    scale;       // [num_experts] flat — one scalar per expert
+    fp16*           output;      // [total_tokens, N]
+    const uint32_t* expert_idx;  // [num_experts + 1]
+    int N, K, num_experts;
+    int n_wg_count, n_per_wg, m_chunks;
+
+    void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+        constexpr int K_SUB = 16;
+        constexpr int M_PER_CHUNK = MT_MAX * 8;
+
+        int wgs_per_expert = n_wg_count * m_chunks;
+        int wg_id = item.get_group(0);
+        int expert_id = wg_id / wgs_per_expert;
+        int local_wg  = wg_id % wgs_per_expert;
+
+        if (expert_id >= num_experts) return;
+
+        int n_wg_id    = local_wg % n_wg_count;
+        int m_chunk_id = local_wg / n_wg_count;
+
+        uint32_t tok_start = expert_idx[expert_id];
+        uint32_t tok_end   = expert_idx[expert_id + 1];
+        int M_e = (int)(tok_end - tok_start);
+        if (M_e <= 0) return;
+
+        int m_row_start = m_chunk_id * M_PER_CHUNK;
+        if (m_row_start >= M_e) return;
+
+        int m_rows_left = M_e - m_row_start;
+        int total_m_tiles_here = (m_rows_left + 7) / 8;
+        if (total_m_tiles_here > MT_MAX) total_m_tiles_here = MT_MAX;
+
+        int n_tiles_total = (N + 15) / 16;
+        int n_tile_start = n_wg_id * n_per_wg;
+        int n_tile_end = n_tile_start + n_per_wg;
+        if (n_tile_end > n_tiles_total) n_tile_end = n_tiles_total;
+
+        // Per-tensor scale: single scalar for this expert
+        float expert_scale = scale[expert_id];
+
+        // 2D surface descriptors
+        uint32_t total_tokens = expert_idx[num_experts];
+        const uint32_t surfW_A = (uint32_t)K * 2u - 1u;
+        const uint32_t surfH_A = total_tokens - 1u;
+        xesimd::config_2d_mem_access<fp16, 16, 8, 1> payA(
+            input, surfW_A, surfH_A, surfW_A, 0u, 0u);
+
+        const uint32_t surfW_B = (uint32_t)K - 1u;
+        const uint32_t surfH_B = (uint32_t)(num_experts * N) - 1u;
+        xesimd::config_2d_mem_access<uint32_t, 4, 16, 1> payB_t(
+            reinterpret_cast<const uint32_t*>(weight),
+            surfW_B, surfH_B, surfW_B, 0u, 0u);
+
+        for (int nc = n_tile_start; nc < n_tile_end; nc++) {
+            int n_start = nc * 16;
+            if (n_start >= N) break;
+
+            int n_valid = (n_start + 16 <= N) ? 16 : (N - n_start);
+            bool full_n = (n_valid == 16);
+
+            payB_t.set_y((uint32_t)(expert_id * N + n_start));
+
+            simd<float, 128> acc[MT_MAX];
+            #pragma unroll
+            for (int i = 0; i < MT_MAX; i++) acc[i] = 0.0f;
+
+            for (int k_base = 0; k_base < K; k_base += 64) {
+                #pragma unroll
+                for (int sub = 0; sub < 4; sub++) {
+                    int k_sub = k_base + sub * K_SUB;
+                    if (k_sub >= K) break;
+
+                    payB_t.set_x((uint32_t)(k_sub / 4));
+                    simd<uint32_t, 64> w_t = xesimd::lsc_load_2d<uint32_t, 4, 16, 1,
+                        true, false,
+                        xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payB_t);
+
+                    simd<uint32_t, 128> b_vnni;
+                    #pragma unroll
+                    for (int col = 0; col < 4; col++) {
+                        simd<uint32_t, 16> g = w_t.template select<16, 1>(col * 16);
+                        simd<uint32_t, 16> b0 = g & 0xFF;
+                        simd<uint32_t, 16> b1 = (g & 0xFF00) << 8;
+                        b_vnni.template select<16, 1>(col * 32) =
+                            fp8_e5m2_pair_to_vnni(b0, b1);
+                        simd<uint32_t, 16> gh = g >> 16;
+                        simd<uint32_t, 16> b2 = gh & 0xFF;
+                        simd<uint32_t, 16> b3 = (gh & 0xFF00) << 8;
+                        b_vnni.template select<16, 1>(col * 32 + 16) =
+                            fp8_e5m2_pair_to_vnni(b2, b3);
+                    }
+                    simd<fp16, 256> b_tile =
+                        b_vnni.template bit_cast_view<fp16>().read();
+
+                    payA.set_x((uint32_t)k_sub);
+                    #pragma unroll
+                    for (int m = 0; m < MT_MAX; m++) {
+                        payA.set_y((uint32_t)(tok_start + m_row_start + m * 8));
+                        simd<fp16, 128> a = xesimd::lsc_load_2d<fp16, 16, 8, 1,
+                            false, false,
+                            xesimd::cache_hint::cached, xesimd::cache_hint::cached>(payA);
+                        acc[m] = dpas<8, 8, float, float, fp16, fp16>(acc[m], b_tile, a);
+                    }
+                }
+            }
+
+            // Output — multiply by scalar per-tensor scale
+            for (int m = 0; m < MT_MAX; m++) {
+                if (m >= total_m_tiles_here) break;
+                #pragma unroll
+                for (int mi = 0; mi < 8; mi++) {
+                    int row = m_row_start + m * 8 + mi;
+                    if (row < M_e) {
+                        simd<float, 16> rf = acc[m].template select<16, 1>(mi * 16);
+                        rf *= expert_scale;
+                        simd<fp16, 16> out = convert<fp16>(rf);
+                        size_t off = (size_t)(tok_start + row) * N + n_start;
+                        if (full_n)
+                            block_store<fp16, 16>(output + off, out);
+                        else
+                            for (int ni = 0; ni < n_valid; ni++)
+                                output[off + ni] = out[ni];
+                    }
+                }
+            }
+        }
+    }
+};
+
+template<int MT_MAX>
+inline void moe_gemm_fp8_e5m2_host_v3_pert(
+    const fp16* input, const uint8_t* weight, const float* scale,
+    fp16* output, const uint32_t* expert_idx,
+    int N, int K, int num_experts,
+    int n_wg_count, int n_per_wg, int m_chunks,
+    sycl::queue& q)
+{
+    int wgs_per_expert = n_wg_count * m_chunks;
+    int total_wgs = num_experts * wgs_per_expert;
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(
+            sycl::nd_range<1>({(size_t)total_wgs}, {1}),
+            MoE_FP8_E5M2_Kernel_V3_PerT<MT_MAX>{
+                input, weight, scale, output, expert_idx,
+                N, K, num_experts, n_wg_count, n_per_wg, m_chunks});
+    });
+}
+
+inline void moe_gemm_fp8_e5m2_dispatch_pert(
+    const fp16* input, const uint8_t* weight, const float* scale,
+    fp16* output, const uint32_t* expert_idx,
+    int N, int K, int num_experts, int max_tokens_per_expert,
+    sycl::queue& q)
+{
+    int n_tiles = (N + 15) / 16;
+    int mt = (max_tokens_per_expert + 7) / 8;
+
+    int mt_max;
+    if (mt <= 1) mt_max = 1;
+    else if (mt <= 2) mt_max = 2;
+    else mt_max = 1;
+
+    int m_chunks = (mt + mt_max - 1) / mt_max;
+
+    // Standard GRF (8 threads/XVE): K-aware dispatch
+    //   Large K (gate_up K=2048): n_per_wg=2, weight=64KB/WG → keep moderate WG count
+    //   Small K (down K=192):     n_per_wg=8, weight=24KB/WG → fits L1 well
+    int wg_cap = (K <= 256) ? 51200 : 38400;
+
+    int n_per_wg = 1;
+    int total_wgs = num_experts * n_tiles * m_chunks;
+    while (total_wgs > wg_cap && n_per_wg < n_tiles) {
+        n_per_wg++;
+        while (n_per_wg < n_tiles && n_tiles % n_per_wg != 0) n_per_wg++;
+        int n_wg_count = (n_tiles + n_per_wg - 1) / n_per_wg;
+        total_wgs = num_experts * n_wg_count * m_chunks;
+    }
+
+    int n_wg_count = (n_tiles + n_per_wg - 1) / n_per_wg;
+
+    #define MOE_LAUNCH_V3_PERT(MT) moe_gemm_fp8_e5m2_host_v3_pert<MT>(input, weight, scale, output, expert_idx, N, K, num_experts, n_wg_count, n_per_wg, m_chunks, q)
+    if      (mt_max == 1) MOE_LAUNCH_V3_PERT(1);
+    else if (mt_max == 2) MOE_LAUNCH_V3_PERT(2);
+    else                  MOE_LAUNCH_V3_PERT(4);
+    #undef MOE_LAUNCH_V3_PERT
+}
+
+// Host launcher (per-N scale)
+template<int MT_MAX>
+inline void moe_gemm_fp8_e5m2_host_v3(
+    const fp16* input, const uint8_t* weight, const float* scale,
+    fp16* output, const uint32_t* expert_idx,
+    int N, int K, int num_experts,
+    int n_wg_count, int n_per_wg, int m_chunks,
+    sycl::queue& q)
+{
+    int wgs_per_expert = n_wg_count * m_chunks;
+    int total_wgs = num_experts * wgs_per_expert;
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(
+            sycl::nd_range<1>({(size_t)total_wgs}, {1}),
+            MoE_FP8_E5M2_Kernel_V3<MT_MAX>{
+                input, weight, scale, output, expert_idx,
+                N, K, num_experts, n_wg_count, n_per_wg, m_chunks});
+    });
+}
+
+// Auto-dispatch V3
+inline void moe_gemm_fp8_e5m2_dispatch(
+    const fp16* input, const uint8_t* weight, const float* scale,
+    fp16* output, const uint32_t* expert_idx,
+    int N, int K, int num_experts, int max_tokens_per_expert,
+    sycl::queue& q)
+{
+    int n_tiles = (N + 15) / 16;
+    int mt = (max_tokens_per_expert + 7) / 8;
+
+    // MT_MAX selection: prefer small MT_MAX to avoid wasted input loads
+    // for experts with few tokens. MT_MAX=4 would force 4 loads per K_SUB
+    // even when only 1 M-tile is needed. Weight re-reads across m_chunks
+    // hit L3 cache (weight per expert << 18MB L3).
+    int mt_max;
+    if (mt <= 1) mt_max = 1;
+    else if (mt <= 2) mt_max = 2;
+    else mt_max = 1;  // For mt>2: use MT_MAX=1 + m_chunks parallelism
+
+    int m_chunks = (mt + mt_max - 1) / mt_max;
+
+    // Merge N-tiles per WG to cap total WGs at ~4096-8192
+    // Each WG loops over n_per_wg N-tiles but handles exactly 1 M-chunk
+    int n_per_wg = 1;
+    int total_wgs = num_experts * n_tiles * m_chunks;
+    // Target: keep total WGs <= 8192
+    while (total_wgs > 8192 && n_per_wg < n_tiles) {
+        n_per_wg++;
+        // Ensure even division
+        while (n_per_wg < n_tiles && n_tiles % n_per_wg != 0) n_per_wg++;
+        int n_wg_count = (n_tiles + n_per_wg - 1) / n_per_wg;
+        total_wgs = num_experts * n_wg_count * m_chunks;
+    }
+
+    int n_wg_count = (n_tiles + n_per_wg - 1) / n_per_wg;
+
+    #define MOE_LAUNCH_V3(MT) moe_gemm_fp8_e5m2_host_v3<MT>(input, weight, scale, output, expert_idx, N, K, num_experts, n_wg_count, n_per_wg, m_chunks, q)
+    if      (mt_max == 1) MOE_LAUNCH_V3(1);
+    else if (mt_max == 2) MOE_LAUNCH_V3(2);
+    else                  MOE_LAUNCH_V3(4);
+    #undef MOE_LAUNCH_V3
+}

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/fused_add_rms_norm.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/fused_add_rms_norm.h
@@ -1,0 +1,71 @@
+/* fused_add_rms_norm.h — Fused residual add + RMSNorm (Gemma-style).
+ *
+ * For decode (bsz=1): residual[1,K] += hidden[1,K]; output[1,K] = rmsnorm(residual) * weight
+ * Gemma convention: weight is pre-adjusted (w+1.0 already applied by caller).
+ *
+ * Single WG, 1 thread. K=2048 → 4 iterations with VL=512.
+ * Two-pass: pass 1 = add + sum_sq; pass 2 = normalize + write output.
+ * Residual updated in-place.
+ */
+
+#pragma once
+#include "utils.h"
+
+struct FusedAddRmsNorm_kernel {
+    fp16*       hidden_ptr;    // [1, K] — input, also used as output
+    fp16*       residual_ptr;  // [1, K] — updated in-place
+    const fp16* weight_ptr;    // [K] — Gemma norm weight (w+1.0)
+    int K;
+    float eps;
+
+    void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+        constexpr int VL = 512;
+        int n_chunks = K / VL;
+
+        // Pass 1: residual += hidden, accumulate sum_sq
+        float sum_sq = 0.0f;
+        for (int c = 0; c < n_chunks; c++) {
+            int offset = c * VL;
+            simd<float, VL> h = block_load<fp16, VL>(hidden_ptr + offset);
+            simd<float, VL> r = block_load<fp16, VL>(residual_ptr + offset);
+            simd<float, VL> added = h + r;
+
+            // Write residual in-place
+            block_store<fp16, VL>(residual_ptr + offset, simd<fp16, VL>(added));
+
+            simd<float, VL> sq = added * added;
+            sq.select<256,1>(0) += sq.select<256,1>(256);
+            sq.select<128,1>(0) += sq.select<128,1>(128);
+            sq.select<64,1>(0) += sq.select<64,1>(64);
+            sq.select<32,1>(0) += sq.select<32,1>(32);
+            sq.select<16,1>(0) += sq.select<16,1>(16);
+            sq.select<8,1>(0) += sq.select<8,1>(8);
+            sq.select<4,1>(0) += sq.select<4,1>(4);
+            sq.select<2,1>(0) += sq.select<2,1>(2);
+            sum_sq += (float)sq[0] + (float)sq[1];
+        }
+
+        float inv_rms = sycl::ext::intel::esimd::rsqrt(
+            simd<float, 8>(sum_sq / (float)K + eps))[0];
+
+        // Pass 2: normalize and write output (reuse hidden_ptr as output)
+        for (int c = 0; c < n_chunks; c++) {
+            int offset = c * VL;
+            simd<float, VL> r = block_load<fp16, VL>(residual_ptr + offset);
+            simd<float, VL> w = block_load<fp16, VL>(weight_ptr + offset);
+            simd<float, VL> normed = r * inv_rms * w;
+            block_store<fp16, VL>(hidden_ptr + offset, simd<fp16, VL>(normed));
+        }
+    }
+};
+
+inline void fused_add_rms_norm_host(
+    fp16* hidden_ptr, fp16* residual_ptr, const fp16* weight_ptr,
+    int K, float eps, sycl::queue& q)
+{
+    q.submit([&](sycl::handler& cgh) {
+        cgh.parallel_for(
+            sycl::nd_range<1>(1, 1),
+            FusedAddRmsNorm_kernel{hidden_ptr, residual_ptr, weight_ptr, K, eps});
+    });
+}

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/gdn_conv_fused.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/gdn_conv_fused.h
@@ -1,0 +1,443 @@
+/* gdn_conv_fused.h — Fused Conv1d + GDN ESIMD kernel for Qwen3-Next-80B-A3B decode.
+ *
+ * v9: Multi-WG, single submit, reads directly from projected_states_qkvz.
+ *   - Grid: N × HV WGs, WG_SIZE=32 (one WG per sequence × value_head)
+ *   - Phase 1: All 32 threads compute conv1d
+ *     - q/k threads (tid 0..4*H-1): 64 dims each
+ *     - v threads (tid 4*H..31): 64 or 128 dims each (double_v mode for HV>8)
+ *     - Reads x from qkvz at mapped offsets (no rearrange needed)
+ *     - Store q/k/v to SLM
+ *   - barrier()
+ *   - Phase 2: First V/4 threads do GDN (V_PER_THREAD=4)
+ *   - Phase 3: conv_state shift + z extraction (hv==0 only for shift)
+ *
+ * Eliminates ALL host-side tensor ops: no cat, no reshape, no contiguous.
+ * Inputs: projected_states_qkvz [N, qkvz_dim] + projected_states_ba [N, 2*HV]
+ * Outputs: core_attn_out [N, HV, V] + z_out [N, HV, V]
+ */
+
+#include "utils.h"
+
+namespace xmem = sycl::ext::intel::experimental::esimd;
+
+/* ---- ESIMD scalar math helpers ---- */
+ESIMD_INLINE float esimd_expf(float x) {
+    simd<float, 8> v(x);
+    v = sycl::ext::intel::esimd::exp(v);
+    return v[0];
+}
+ESIMD_INLINE float esimd_logf(float x) {
+    simd<float, 8> v(x);
+    v = sycl::ext::intel::esimd::log(v);
+    return v[0];
+}
+ESIMD_INLINE float esimd_sqrtf(float x) {
+    simd<float, 8> v(x);
+    v = sycl::ext::intel::esimd::sqrt(v);
+    return v[0];
+}
+
+/* ---- LSC load/store helpers ---- */
+
+ESIMD_INLINE simd<float, 64> lsc_load_state_64(const fp16* ptr) {
+    return xmem::lsc_block_load<fp16, 64,
+        xmem::lsc_data_size::default_size,
+        xmem::cache_hint::streaming, xmem::cache_hint::cached>(ptr);
+}
+
+ESIMD_INLINE void lsc_store_state_64(fp16* ptr, simd<float, 64> val) {
+    xmem::lsc_block_store<fp16, 64,
+        xmem::lsc_data_size::default_size,
+        xmem::cache_hint::streaming, xmem::cache_hint::write_back>(
+        ptr, simd<fp16, 64>(val));
+}
+
+/* ---- Dot product 128 (split lo/hi 64) ---- */
+
+ESIMD_INLINE float gdn_dot128(simd<float, 64> a_lo, simd<float, 64> a_hi,
+                               simd<float, 64> b_lo, simd<float, 64> b_hi) {
+    simd<float, 64> p_lo = a_lo * b_lo;
+    simd<float, 64> p_hi = a_hi * b_hi;
+    p_lo += p_hi;
+    p_lo.select<32,1>(0) += p_lo.select<32,1>(32);
+    p_lo.select<16,1>(0) += p_lo.select<16,1>(16);
+    p_lo.select<8,1>(0) += p_lo.select<8,1>(8);
+    p_lo.select<4,1>(0) += p_lo.select<4,1>(4);
+    p_lo.select<2,1>(0) += p_lo.select<2,1>(2);
+    return p_lo[0] + p_lo[1];
+}
+
+ESIMD_INLINE float gdn_load_fp16_scalar(const fp16* base, int64_t idx) {
+    int64_t aligned = idx & ~15;
+    int lane = (int)(idx & 15);
+    simd<fp16, 16> chunk = block_load<fp16, 16>(base + aligned);
+    simd<float, 16> chunk_f32 = chunk;
+    return chunk_f32[lane];
+}
+
+/* ---- SLM layout per WG (byte offsets) ---- */
+static constexpr int SLM_Q_LO = 0;       // 64 floats = 256 bytes
+static constexpr int SLM_Q_HI = 256;
+static constexpr int SLM_K_LO = 512;
+static constexpr int SLM_K_HI = 768;
+static constexpr int SLM_V    = 1024;    // 128 floats = 512 bytes
+// Total: 1536 bytes, allocate 2048
+
+/* ============================================================
+ * v9 KERNEL: reads from projected_states_qkvz directly.
+ * WG_SIZE=32 always. When HV>8, v-threads handle 128 elements each.
+ * ============================================================ */
+ESIMD_INLINE void gdn_conv_fused_kernel_v9(
+    const fp16* __restrict__ qkvz_ptr,
+    int64_t qkvz_stride0,
+    fp16* __restrict__ conv_state_ptr,
+    const fp16* __restrict__ conv_weight_ptr,
+    const fp16* __restrict__ conv_bias_ptr,
+    const int* __restrict__ conv_state_indices_ptr,
+    const fp16* __restrict__ A_log_ptr,
+    const fp16* __restrict__ dt_bias_ptr,
+    const fp16* __restrict__ ba_ptr,
+    int64_t ba_stride0,
+    fp16* __restrict__ ssm_state_ptr,
+    const int* __restrict__ ssm_state_indices_ptr,
+    fp16* __restrict__ output_ptr,
+    fp16* __restrict__ z_out_ptr,
+    int N, int H, int HV, int gdn_K, int gdn_V,
+    float attn_scale, int64_t conv_stride0, int64_t ssm_stride0,
+    nd_item<3>& ndi)
+{
+    slm_init<2048>();
+
+    const int seq_idx = ndi.get_group(0);
+    const int hv = ndi.get_group(1);
+    const int tid = ndi.get_local_id(2);  // 0..31
+
+    const int heads_per_group = HV / H;
+    const int i_h = hv / heads_per_group;
+    const int dim = 2 * H * gdn_K + HV * gdn_V;
+
+    // double_v: v-threads handle 128 elements each instead of 64
+    const bool double_v = (HV > (32 - 4 * H) / 2);  // true when HV > 8
+
+    const int conv_idx = conv_state_indices_ptr[seq_idx];
+    const int ssm_idx = ssm_state_indices_ptr[seq_idx];
+
+    // ---- Compute qkvz read offset and conv_state chunk_start ----
+    const int group_dim = gdn_K + gdn_K + heads_per_group * gdn_V * 2;
+
+    int qkvz_offset = 0;
+    int chunk_start = 0;
+    // hi-half offsets (only used by v-threads when double_v)
+    int qkvz_offset_hi = 0;
+    int chunk_start_hi = 0;
+
+    if (tid < 2 * H) {
+        // q region: tid 0..(2*H-1), 64 elements each
+        int q_head = tid / 2;
+        qkvz_offset = q_head * group_dim + (tid & 1) * 64;
+        chunk_start = tid * 64;
+    } else if (tid < 4 * H) {
+        // k region: tid (2*H)..(4*H-1), 64 elements each
+        int k_tid = tid - 2 * H;
+        int k_head = k_tid / 2;
+        qkvz_offset = k_head * group_dim + gdn_K + (k_tid & 1) * 64;
+        chunk_start = tid * 64;
+    } else if (double_v) {
+        // v region (double): tid (4*H)..31, 128 elements each (one full v_head)
+        int v_tid = tid - 4 * H;
+        int v_hv = v_tid;  // one thread per v_head
+        int v_group = v_hv / heads_per_group;
+        int v_lane = v_hv % heads_per_group;
+        int base = v_group * group_dim + 2 * gdn_K + v_lane * gdn_V;
+        qkvz_offset = base;
+        qkvz_offset_hi = base + 64;
+        chunk_start = 4 * H * 64 + v_tid * 128;
+        chunk_start_hi = chunk_start + 64;
+    } else {
+        // v region (original): tid (4*H)..31, 64 elements each (half v_head)
+        int v_tid = tid - 4 * H;
+        int v_hv = v_tid / 2;
+        int v_group = v_hv / heads_per_group;
+        int v_lane = v_hv % heads_per_group;
+        qkvz_offset = v_group * group_dim + 2 * gdn_K
+                     + v_lane * gdn_V + (v_tid & 1) * 64;
+        chunk_start = tid * 64;
+    }
+
+    // ---- Phase 1: Conv1d ----
+    const fp16* qkvz_row = qkvz_ptr + (int64_t)seq_idx * qkvz_stride0;
+    fp16* cstate_base = conv_state_ptr + (int64_t)conv_idx * conv_stride0;
+
+    // -- lo chunk (all threads) --
+    simd<fp16, 64> x_fp16 = block_load<fp16, 64>(qkvz_row + qkvz_offset);
+    simd<float, 64> x_f32 = x_fp16;
+
+    simd<float, 64> s0 = block_load<fp16, 64>(cstate_base + 0 * dim + chunk_start);
+    simd<float, 64> s1 = block_load<fp16, 64>(cstate_base + 1 * dim + chunk_start);
+    simd<float, 64> s2 = block_load<fp16, 64>(cstate_base + 2 * dim + chunk_start);
+
+    simd<fp16, 256> w_raw = block_load<fp16, 256>(conv_weight_ptr + (int64_t)chunk_start * 4);
+    simd<float, 64> conv_result =
+        s0 * w_raw.select<64, 4>(0) + s1 * w_raw.select<64, 4>(1) +
+        s2 * w_raw.select<64, 4>(2) + x_f32 * w_raw.select<64, 4>(3) +
+        (simd<float, 64>)block_load<fp16, 64>(conv_bias_ptr + chunk_start);
+
+    // SiLU
+    {
+        simd<float, 64> exp_neg = sycl::ext::intel::esimd::exp(-conv_result);
+        conv_result = conv_result / (1.0f + exp_neg);
+    }
+
+    // -- hi chunk (v-threads only, when double_v) --
+    simd<fp16, 64> x_fp16_hi;
+    simd<float, 64> s0_hi, s1_hi, s2_hi, conv_result_hi;
+
+    if (double_v && tid >= 4 * H) {
+        x_fp16_hi = block_load<fp16, 64>(qkvz_row + qkvz_offset_hi);
+        simd<float, 64> x_f32_hi = x_fp16_hi;
+
+        s0_hi = block_load<fp16, 64>(cstate_base + 0 * dim + chunk_start_hi);
+        s1_hi = block_load<fp16, 64>(cstate_base + 1 * dim + chunk_start_hi);
+        s2_hi = block_load<fp16, 64>(cstate_base + 2 * dim + chunk_start_hi);
+
+        simd<fp16, 256> w_raw_hi = block_load<fp16, 256>(
+            conv_weight_ptr + (int64_t)chunk_start_hi * 4);
+        conv_result_hi =
+            s0_hi * w_raw_hi.select<64, 4>(0) + s1_hi * w_raw_hi.select<64, 4>(1) +
+            s2_hi * w_raw_hi.select<64, 4>(2) + x_f32_hi * w_raw_hi.select<64, 4>(3) +
+            (simd<float, 64>)block_load<fp16, 64>(conv_bias_ptr + chunk_start_hi);
+
+        // SiLU
+        simd<float, 64> exp_neg_hi = sycl::ext::intel::esimd::exp(-conv_result_hi);
+        conv_result_hi = conv_result_hi / (1.0f + exp_neg_hi);
+    }
+
+    // ---- Store q/k/v to SLM ----
+    {
+        const int q_tid_lo = 2 * i_h;
+        if (tid == q_tid_lo)     slm_block_store<float, 64>(SLM_Q_LO, conv_result);
+        if (tid == q_tid_lo + 1) slm_block_store<float, 64>(SLM_Q_HI, conv_result);
+
+        const int k_tid_lo = 2 * H + 2 * i_h;
+        if (tid == k_tid_lo)     slm_block_store<float, 64>(SLM_K_LO, conv_result);
+        if (tid == k_tid_lo + 1) slm_block_store<float, 64>(SLM_K_HI, conv_result);
+
+        if (double_v) {
+            // One thread per v_head: tid == 4*H + hv writes both halves
+            if (tid == 4 * H + hv) {
+                slm_block_store<float, 64>(SLM_V, conv_result);
+                slm_block_store<float, 64>(SLM_V + 256, conv_result_hi);
+            }
+        } else {
+            // Two threads per v_head (original)
+            const int v_tid_lo = 4 * H + 2 * hv;
+            if (tid == v_tid_lo)     slm_block_store<float, 64>(SLM_V, conv_result);
+            if (tid == v_tid_lo + 1) slm_block_store<float, 64>(SLM_V + 256, conv_result);
+        }
+    }
+
+    barrier();
+
+    // ---- Phase 2: GDN (V/4 threads, V_PER_THREAD=4) ----
+    if (ssm_idx >= 0 && tid * 4 < gdn_V) {
+        // Load q, k from SLM
+        simd<float, 64> q_lo = slm_block_load<float, 64>(SLM_Q_LO);
+        simd<float, 64> q_hi = slm_block_load<float, 64>(SLM_Q_HI);
+        simd<float, 64> k_lo = slm_block_load<float, 64>(SLM_K_LO);
+        simd<float, 64> k_hi = slm_block_load<float, 64>(SLM_K_HI);
+
+        // L2 normalize q, k
+        float q_inv = 1.0f / esimd_sqrtf(gdn_dot128(q_lo, q_hi, q_lo, q_hi) + 1e-6f);
+        float k_inv = 1.0f / esimd_sqrtf(gdn_dot128(k_lo, k_hi, k_lo, k_hi) + 1e-6f);
+        q_lo *= q_inv * attn_scale; q_hi *= q_inv * attn_scale;
+        k_lo *= k_inv; k_hi *= k_inv;
+
+        // Load v (4 values from SLM)
+        const int vi0 = tid * 4;
+        simd<float, 4> v_f32 = slm_block_load<float, 4>(SLM_V + vi0 * (int)sizeof(float));
+
+        // Gating from projected_states_ba
+        const float A_log_val = gdn_load_fp16_scalar(A_log_ptr, hv);
+        const float dt_bias_val = gdn_load_fp16_scalar(dt_bias_ptr, hv);
+        const float neg_exp_A = -esimd_expf(A_log_val);
+
+        // ba layout: [b_grp0, a_grp0, b_grp1, a_grp1, ...]
+        const int hpg = heads_per_group;
+        const int lane = hv - i_h * hpg;
+        const int b_col = i_h * 2 * hpg + lane;
+        const int a_col = b_col + hpg;
+        float a_val = gdn_load_fp16_scalar(ba_ptr, (int64_t)seq_idx * ba_stride0 + a_col);
+        float b_val = gdn_load_fp16_scalar(ba_ptr, (int64_t)seq_idx * ba_stride0 + b_col);
+        float x_gate = a_val + dt_bias_val;
+        float sp = (x_gate > 20.0f) ? x_gate : esimd_logf(1.0f + esimd_expf(x_gate));
+        float g = neg_exp_A * sp;
+        float exp_g = esimd_expf(g);
+        float beta = 1.0f / (1.0f + esimd_expf(-b_val));
+
+        // State base for this head
+        fp16* sstate_base = ssm_state_ptr +
+            (int64_t)ssm_idx * ssm_stride0 + (int64_t)hv * gdn_V * gdn_K;
+
+        // Process 4 V-rows in one batch
+        fp16* sr0 = sstate_base + (int64_t)(vi0 + 0) * gdn_K;
+        fp16* sr1 = sstate_base + (int64_t)(vi0 + 1) * gdn_K;
+        fp16* sr2 = sstate_base + (int64_t)(vi0 + 2) * gdn_K;
+        fp16* sr3 = sstate_base + (int64_t)(vi0 + 3) * gdn_K;
+
+        simd<float, 64> h0_lo = lsc_load_state_64(sr0);
+        simd<float, 64> h0_hi = lsc_load_state_64(sr0 + 64);
+        simd<float, 64> h1_lo = lsc_load_state_64(sr1);
+        simd<float, 64> h1_hi = lsc_load_state_64(sr1 + 64);
+        simd<float, 64> h2_lo = lsc_load_state_64(sr2);
+        simd<float, 64> h2_hi = lsc_load_state_64(sr2 + 64);
+        simd<float, 64> h3_lo = lsc_load_state_64(sr3);
+        simd<float, 64> h3_hi = lsc_load_state_64(sr3 + 64);
+
+        h0_lo *= exp_g; h0_hi *= exp_g;
+        h1_lo *= exp_g; h1_hi *= exp_g;
+        h2_lo *= exp_g; h2_hi *= exp_g;
+        h3_lo *= exp_g; h3_hi *= exp_g;
+
+        float kv0 = gdn_dot128(h0_lo, h0_hi, k_lo, k_hi);
+        float kv1 = gdn_dot128(h1_lo, h1_hi, k_lo, k_hi);
+        float kv2 = gdn_dot128(h2_lo, h2_hi, k_lo, k_hi);
+        float kv3 = gdn_dot128(h3_lo, h3_hi, k_lo, k_hi);
+
+        float d0 = (v_f32[0] - kv0) * beta;
+        float d1 = (v_f32[1] - kv1) * beta;
+        float d2 = (v_f32[2] - kv2) * beta;
+        float d3 = (v_f32[3] - kv3) * beta;
+
+        h0_lo += d0 * k_lo; h0_hi += d0 * k_hi;
+        h1_lo += d1 * k_lo; h1_hi += d1 * k_hi;
+        h2_lo += d2 * k_lo; h2_hi += d2 * k_hi;
+        h3_lo += d3 * k_lo; h3_hi += d3 * k_hi;
+
+        simd<float, 4> o_acc;
+        o_acc[0] = gdn_dot128(h0_lo, h0_hi, q_lo, q_hi);
+        o_acc[1] = gdn_dot128(h1_lo, h1_hi, q_lo, q_hi);
+        o_acc[2] = gdn_dot128(h2_lo, h2_hi, q_lo, q_hi);
+        o_acc[3] = gdn_dot128(h3_lo, h3_hi, q_lo, q_hi);
+
+        lsc_store_state_64(sr0, h0_lo);
+        lsc_store_state_64(sr0 + 64, h0_hi);
+        lsc_store_state_64(sr1, h1_lo);
+        lsc_store_state_64(sr1 + 64, h1_hi);
+        lsc_store_state_64(sr2, h2_lo);
+        lsc_store_state_64(sr2 + 64, h2_hi);
+        lsc_store_state_64(sr3, h3_lo);
+        lsc_store_state_64(sr3 + 64, h3_hi);
+
+        // Store GDN output
+        fp16* out = output_ptr + (int64_t)seq_idx * HV * gdn_V + (int64_t)hv * gdn_V + vi0;
+        xmem::lsc_block_store<fp16, 4,
+            xmem::lsc_data_size::default_size,
+            xmem::cache_hint::streaming, xmem::cache_hint::write_back>(
+            out, simd<fp16, 4>(o_acc));
+    } else {
+        // ssm_idx < 0: write zeros (eliminates need for caller .zero_())
+        int vi0_z = tid * 4;
+        fp16* out = output_ptr + (int64_t)seq_idx * HV * gdn_V + (int64_t)hv * gdn_V + vi0_z;
+        xmem::lsc_block_store<fp16, 4,
+            xmem::lsc_data_size::default_size,
+            xmem::cache_hint::streaming, xmem::cache_hint::write_back>(
+            out, simd<fp16, 4>(0.0f));
+    }
+
+    // ---- Phase 3: conv_state shift (hv==0 only to avoid cross-WG race) ----
+    if (conv_idx >= 0 && hv == 0) {
+        // lo chunk (all threads)
+        block_store<fp16, 64>(cstate_base + 0 * dim + chunk_start, simd<fp16, 64>(s1));
+        block_store<fp16, 64>(cstate_base + 1 * dim + chunk_start, simd<fp16, 64>(s2));
+        block_store<fp16, 64>(cstate_base + 2 * dim + chunk_start, x_fp16);
+
+        // hi chunk (v-threads only, when double_v)
+        if (double_v && tid >= 4 * H) {
+            block_store<fp16, 64>(cstate_base + 0 * dim + chunk_start_hi, simd<fp16, 64>(s1_hi));
+            block_store<fp16, 64>(cstate_base + 1 * dim + chunk_start_hi, simd<fp16, 64>(s2_hi));
+            block_store<fp16, 64>(cstate_base + 2 * dim + chunk_start_hi, x_fp16_hi);
+        }
+    }
+
+    // ---- z extraction: v-threads copy z from qkvz to z_out ----
+    if (tid >= 4 * H) {
+        int v_tid = tid - 4 * H;
+        if (double_v) {
+            // One thread per v_head, two 64-element loads
+            int v_hv = v_tid;
+            int v_group = v_hv / heads_per_group;
+            int v_lane = v_hv % heads_per_group;
+
+            int z_base = v_group * group_dim + 2 * gdn_K
+                        + heads_per_group * gdn_V  // skip v portion
+                        + v_lane * gdn_V;
+
+            simd<fp16, 64> z_lo = block_load<fp16, 64>(qkvz_row + z_base);
+            simd<fp16, 64> z_hi = block_load<fp16, 64>(qkvz_row + z_base + 64);
+
+            fp16* z_dst = z_out_ptr + (int64_t)seq_idx * HV * gdn_V
+                        + (int64_t)v_hv * gdn_V;
+            block_store<fp16, 64>(z_dst, z_lo);
+            block_store<fp16, 64>(z_dst + 64, z_hi);
+        } else {
+            // Two threads per v_head (original)
+            int v_hv = v_tid / 2;
+            int v_half = v_tid & 1;
+            int v_group = v_hv / heads_per_group;
+            int v_lane = v_hv % heads_per_group;
+
+            int z_qkvz_offset = v_group * group_dim + 2 * gdn_K
+                               + heads_per_group * gdn_V
+                               + v_lane * gdn_V + v_half * 64;
+
+            simd<fp16, 64> z_data = block_load<fp16, 64>(qkvz_row + z_qkvz_offset);
+
+            fp16* z_dst = z_out_ptr + (int64_t)seq_idx * HV * gdn_V
+                        + (int64_t)v_hv * gdn_V + v_half * 64;
+            block_store<fp16, 64>(z_dst, z_data);
+        }
+    }
+}
+
+/* ============================================================
+ * Host Dispatcher
+ * ============================================================ */
+inline void gdn_conv_fused_host(
+    const fp16* qkvz_ptr,
+    int64_t qkvz_stride0,
+    fp16* conv_state_ptr,
+    const fp16* conv_weight_ptr,
+    const fp16* conv_bias_ptr,
+    const int* conv_state_indices_ptr,
+    const fp16* A_log_ptr,
+    const fp16* dt_bias_ptr,
+    const fp16* ba_ptr,
+    int64_t ba_stride0,
+    fp16* ssm_state_ptr,
+    const int* ssm_state_indices_ptr,
+    fp16* output_ptr,
+    fp16* z_out_ptr,
+    int N, int H, int HV, int K, int V,
+    float scale,
+    int64_t conv_stride0,
+    int64_t ssm_stride0,
+    sycl::queue& q)
+{
+    constexpr int WG_SIZE = 32;
+
+    sycl::nd_range<3> Range(
+        sycl::range<3>(N, HV, WG_SIZE),
+        sycl::range<3>(1, 1, WG_SIZE));
+
+    q.submit([&](sycl::handler& cgh) {
+        cgh.parallel_for(Range, [=](sycl::nd_item<3> ndi) SYCL_ESIMD_KERNEL {
+            gdn_conv_fused_kernel_v9(
+                qkvz_ptr, qkvz_stride0, conv_state_ptr,
+                conv_weight_ptr, conv_bias_ptr, conv_state_indices_ptr,
+                A_log_ptr, dt_bias_ptr, ba_ptr, ba_stride0,
+                ssm_state_ptr, ssm_state_indices_ptr,
+                output_ptr, z_out_ptr,
+                N, H, HV, K, V, scale, conv_stride0, ssm_stride0, ndi);
+        });
+    });
+}

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/gdn_conv_fused_seq.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/gdn_conv_fused_seq.h
@@ -1,0 +1,368 @@
+/* gdn_conv_fused_seq.h — Fused Conv1d + GDN ESIMD kernel for SEQUENTIAL qkvz layout.
+ *
+ * Variant of gdn_conv_fused.h for models where the GEMV output is in
+ * sequential [q_all | k_all | v_all | z_all] layout (e.g. Qwen3.5-35B-A3B),
+ * rather than the GQA-interleaved layout used by Qwen3-Next-80B.
+ *
+ * Sequential qkvz layout (per TP rank):
+ *   [q(H*K) | k(H*K) | v(HV*V) | z(HV*V)]
+ *   e.g. for H=4, HV=8, K=V=128: [q(512) | k(512) | v(1024) | z(1024)] = 3072
+ *
+ * Interleaved ba layout (same as 80B, produced by gather index):
+ *   [b_g0(HPG), a_g0(HPG), b_g1(HPG), a_g1(HPG), ...]
+ *
+ * Sequential ba layout (direct GEMV output):
+ *   [b_all(HV) | a_all(HV)]
+ *
+ * The kernel reads qkvz/ba at correct offsets for sequential layout.
+ * Everything else (conv1d, GDN, state update, z extraction) is identical.
+ *
+ * Thread→qkvz offset mapping for sequential layout (64 elements each):
+ *   tid 0..7:   q region → head=tid/2, offset = head*K + (tid%2)*64
+ *   tid 8..15:  k region → head=(tid-8)/2, offset = H*K + head*K + ((tid-8)%2)*64
+ *   tid 16..31: v region → vhv=(tid-16)/2, offset = 2*H*K + vhv*V + ((tid-16)%2)*64
+ *
+ * z is at offset: 2*H*K + HV*V + hv*V + half*64
+ *
+ * ba sequential layout:
+ *   b_col = hv (lane within b_all)
+ *   a_col = HV + hv (lane within a_all)
+ */
+
+#include "utils.h"
+
+namespace xmem = sycl::ext::intel::experimental::esimd;
+
+/* ---- ESIMD scalar math helpers (same as gdn_conv_fused.h) ---- */
+ESIMD_INLINE float esimd_expf_seq(float x) {
+    simd<float, 8> v(x);
+    v = sycl::ext::intel::esimd::exp(v);
+    return v[0];
+}
+ESIMD_INLINE float esimd_logf_seq(float x) {
+    simd<float, 8> v(x);
+    v = sycl::ext::intel::esimd::log(v);
+    return v[0];
+}
+ESIMD_INLINE float esimd_sqrtf_seq(float x) {
+    simd<float, 8> v(x);
+    v = sycl::ext::intel::esimd::sqrt(v);
+    return v[0];
+}
+
+/* ---- LSC load/store helpers ---- */
+ESIMD_INLINE simd<float, 64> lsc_load_state_64_seq(const fp16* ptr) {
+    return xmem::lsc_block_load<fp16, 64,
+        xmem::lsc_data_size::default_size,
+        xmem::cache_hint::streaming, xmem::cache_hint::cached>(ptr);
+}
+
+ESIMD_INLINE void lsc_store_state_64_seq(fp16* ptr, simd<float, 64> val) {
+    xmem::lsc_block_store<fp16, 64,
+        xmem::lsc_data_size::default_size,
+        xmem::cache_hint::streaming, xmem::cache_hint::write_back>(
+        ptr, simd<fp16, 64>(val));
+}
+
+/* ---- Dot product 128 (split lo/hi 64) ---- */
+ESIMD_INLINE float gdn_dot128_seq(simd<float, 64> a_lo, simd<float, 64> a_hi,
+                                   simd<float, 64> b_lo, simd<float, 64> b_hi) {
+    simd<float, 64> p_lo = a_lo * b_lo;
+    simd<float, 64> p_hi = a_hi * b_hi;
+    p_lo += p_hi;
+    p_lo.select<32,1>(0) += p_lo.select<32,1>(32);
+    p_lo.select<16,1>(0) += p_lo.select<16,1>(16);
+    p_lo.select<8,1>(0) += p_lo.select<8,1>(8);
+    p_lo.select<4,1>(0) += p_lo.select<4,1>(4);
+    p_lo.select<2,1>(0) += p_lo.select<2,1>(2);
+    return p_lo[0] + p_lo[1];
+}
+
+ESIMD_INLINE float gdn_load_fp16_scalar_seq(const fp16* base, int64_t idx) {
+    int64_t aligned = idx & ~15;
+    int lane = (int)(idx & 15);
+    simd<fp16, 16> chunk = block_load<fp16, 16>(base + aligned);
+    simd<float, 16> chunk_f32 = chunk;
+    return chunk_f32[lane];
+}
+
+/* ---- SLM layout per WG (byte offsets, same as original) ---- */
+static constexpr int SLM_Q_LO_SEQ = 0;
+static constexpr int SLM_Q_HI_SEQ = 256;
+static constexpr int SLM_K_LO_SEQ = 512;
+static constexpr int SLM_K_HI_SEQ = 768;
+static constexpr int SLM_V_SEQ    = 1024;
+
+/* ============================================================
+ * KERNEL: reads from SEQUENTIAL qkvz layout [q|k|v|z].
+ * ============================================================ */
+ESIMD_INLINE void gdn_conv_fused_seq_kernel(
+    const fp16* __restrict__ qkvz_ptr,
+    int64_t qkvz_stride0,
+    fp16* __restrict__ conv_state_ptr,
+    const fp16* __restrict__ conv_weight_ptr,
+    const fp16* __restrict__ conv_bias_ptr,
+    const int* __restrict__ conv_state_indices_ptr,
+    const fp16* __restrict__ A_log_ptr,
+    const fp16* __restrict__ dt_bias_ptr,
+    const fp16* __restrict__ ba_ptr,
+    int64_t ba_stride0,
+    fp16* __restrict__ ssm_state_ptr,
+    const int* __restrict__ ssm_state_indices_ptr,
+    fp16* __restrict__ output_ptr,
+    fp16* __restrict__ z_out_ptr,
+    int N, int H, int HV, int gdn_K, int gdn_V,
+    float attn_scale, int64_t conv_stride0, int64_t ssm_stride0,
+    nd_item<3>& ndi)
+{
+    slm_init<2048>();
+
+    const int seq_idx = ndi.get_group(0);
+    const int hv = ndi.get_group(1);
+    const int tid = ndi.get_local_id(2);  // 0..31
+
+    const int heads_per_group = HV / H;
+    const int i_h = hv / heads_per_group;
+
+    const int conv_idx = conv_state_indices_ptr[seq_idx];
+    const int ssm_idx = ssm_state_indices_ptr[seq_idx];
+
+    // ---- Sequential layout base offsets ----
+    const int q_base = 0;
+    const int k_base = H * gdn_K;
+    const int v_base = 2 * H * gdn_K;
+    const int z_base = v_base + HV * gdn_V;
+
+    // ---- Compute qkvz read offset for this thread (SEQUENTIAL layout) ----
+    int qkvz_offset;
+    if (tid < 2 * H) {
+        // q region: tid 0..(2*H-1)
+        int q_head = tid / 2;
+        qkvz_offset = q_base + q_head * gdn_K + (tid & 1) * 64;
+    } else if (tid < 4 * H) {
+        // k region: tid (2*H)..(4*H-1)
+        int k_tid = tid - 2 * H;
+        int k_head = k_tid / 2;
+        qkvz_offset = k_base + k_head * gdn_K + (k_tid & 1) * 64;
+    } else {
+        // v region: tid (4*H)..(32-1)
+        int v_tid = tid - 4 * H;
+        int v_hv = v_tid / 2;
+        qkvz_offset = v_base + v_hv * gdn_V + (v_tid & 1) * 64;
+    }
+
+    // conv_state is in mixed_qkv dim order, NOT interleaved.
+    // For sequential layout, the thread's conv_state chunk matches qkvz_offset.
+    const int chunk_start = qkvz_offset;
+
+    // ---- Phase 1: Conv1d (all 32 threads, 64 dims each) ----
+    const fp16* qkvz_row = qkvz_ptr + (int64_t)seq_idx * qkvz_stride0;
+    fp16* cstate_base = conv_state_ptr + (int64_t)conv_idx * conv_stride0;
+
+    // Read x from qkvz at mapped offset (contiguous 64 fp16)
+    simd<fp16, 64> x_fp16 = block_load<fp16, 64>(qkvz_row + qkvz_offset);
+    simd<float, 64> x_f32 = x_fp16;
+
+    // State and weight are in sequential dim order (chunk_start)
+    simd<float, 64> s0 = block_load<fp16, 64>(cstate_base + 0 * 2048 + chunk_start);
+    simd<float, 64> s1 = block_load<fp16, 64>(cstate_base + 1 * 2048 + chunk_start);
+    simd<float, 64> s2 = block_load<fp16, 64>(cstate_base + 2 * 2048 + chunk_start);
+
+    simd<fp16, 256> w_raw = block_load<fp16, 256>(conv_weight_ptr + (int64_t)chunk_start * 4);
+    simd<float, 64> w0 = w_raw.select<64, 4>(0);
+    simd<float, 64> w1 = w_raw.select<64, 4>(1);
+    simd<float, 64> w2 = w_raw.select<64, 4>(2);
+    simd<float, 64> w3 = w_raw.select<64, 4>(3);
+
+    simd<float, 64> bias = block_load<fp16, 64>(conv_bias_ptr + chunk_start);
+    simd<float, 64> conv_result = s0 * w0 + s1 * w1 + s2 * w2 + x_f32 * w3 + bias;
+
+    // SiLU
+    {
+        simd<float, 64> neg_r = -conv_result;
+        simd<float, 64> exp_neg = sycl::ext::intel::esimd::exp(neg_r);
+        simd<float, 64> sigmoid_val = 1.0f / (1.0f + exp_neg);
+        conv_result = conv_result * sigmoid_val;
+    }
+
+    // Store q/k/v to SLM (only the relevant threads)
+    {
+        const int q_tid_lo = 2 * i_h;
+        if (tid == q_tid_lo)     slm_block_store<float, 64>(SLM_Q_LO_SEQ, conv_result);
+        if (tid == q_tid_lo + 1) slm_block_store<float, 64>(SLM_Q_HI_SEQ, conv_result);
+
+        const int k_tid_lo = 2 * H + 2 * i_h;
+        if (tid == k_tid_lo)     slm_block_store<float, 64>(SLM_K_LO_SEQ, conv_result);
+        if (tid == k_tid_lo + 1) slm_block_store<float, 64>(SLM_K_HI_SEQ, conv_result);
+
+        const int v_tid_lo = 4 * H + 2 * hv;
+        if (tid == v_tid_lo)     slm_block_store<float, 64>(SLM_V_SEQ, conv_result);
+        if (tid == v_tid_lo + 1) slm_block_store<float, 64>(SLM_V_SEQ + 256, conv_result);
+    }
+
+    barrier();
+
+    // ---- Phase 2: GDN (all 32 threads, V_PER_THREAD=4) ----
+    if (ssm_idx >= 0) {
+        simd<float, 64> q_lo = slm_block_load<float, 64>(SLM_Q_LO_SEQ);
+        simd<float, 64> q_hi = slm_block_load<float, 64>(SLM_Q_HI_SEQ);
+        simd<float, 64> k_lo = slm_block_load<float, 64>(SLM_K_LO_SEQ);
+        simd<float, 64> k_hi = slm_block_load<float, 64>(SLM_K_HI_SEQ);
+
+        float q_inv = 1.0f / esimd_sqrtf_seq(gdn_dot128_seq(q_lo, q_hi, q_lo, q_hi) + 1e-6f);
+        float k_inv = 1.0f / esimd_sqrtf_seq(gdn_dot128_seq(k_lo, k_hi, k_lo, k_hi) + 1e-6f);
+        q_lo *= q_inv * attn_scale; q_hi *= q_inv * attn_scale;
+        k_lo *= k_inv; k_hi *= k_inv;
+
+        const int vi0 = tid * 4;
+        simd<float, 4> v_f32 = slm_block_load<float, 4>(SLM_V_SEQ + vi0 * (int)sizeof(float));
+
+        const float A_log_val = gdn_load_fp16_scalar_seq(A_log_ptr, hv);
+        const float dt_bias_val = gdn_load_fp16_scalar_seq(dt_bias_ptr, hv);
+        const float neg_exp_A = -esimd_expf_seq(A_log_val);
+
+        // ---- ba: SEQUENTIAL layout [b_all(HV) | a_all(HV)] ----
+        const int b_col = hv;
+        const int a_col = HV + hv;
+        float a_val = gdn_load_fp16_scalar_seq(ba_ptr, (int64_t)seq_idx * ba_stride0 + a_col);
+        float b_val = gdn_load_fp16_scalar_seq(ba_ptr, (int64_t)seq_idx * ba_stride0 + b_col);
+        float x_gate = a_val + dt_bias_val;
+        float sp = (x_gate > 20.0f) ? x_gate : esimd_logf_seq(1.0f + esimd_expf_seq(x_gate));
+        float g = neg_exp_A * sp;
+        float exp_g = esimd_expf_seq(g);
+        float beta = 1.0f / (1.0f + esimd_expf_seq(-b_val));
+
+        fp16* sstate_base = ssm_state_ptr +
+            (int64_t)ssm_idx * ssm_stride0 + (int64_t)hv * gdn_V * gdn_K;
+
+        fp16* sr0 = sstate_base + (int64_t)(vi0 + 0) * gdn_K;
+        fp16* sr1 = sstate_base + (int64_t)(vi0 + 1) * gdn_K;
+        fp16* sr2 = sstate_base + (int64_t)(vi0 + 2) * gdn_K;
+        fp16* sr3 = sstate_base + (int64_t)(vi0 + 3) * gdn_K;
+
+        simd<float, 64> h0_lo = lsc_load_state_64_seq(sr0);
+        simd<float, 64> h0_hi = lsc_load_state_64_seq(sr0 + 64);
+        simd<float, 64> h1_lo = lsc_load_state_64_seq(sr1);
+        simd<float, 64> h1_hi = lsc_load_state_64_seq(sr1 + 64);
+        simd<float, 64> h2_lo = lsc_load_state_64_seq(sr2);
+        simd<float, 64> h2_hi = lsc_load_state_64_seq(sr2 + 64);
+        simd<float, 64> h3_lo = lsc_load_state_64_seq(sr3);
+        simd<float, 64> h3_hi = lsc_load_state_64_seq(sr3 + 64);
+
+        h0_lo *= exp_g; h0_hi *= exp_g;
+        h1_lo *= exp_g; h1_hi *= exp_g;
+        h2_lo *= exp_g; h2_hi *= exp_g;
+        h3_lo *= exp_g; h3_hi *= exp_g;
+
+        float kv0 = gdn_dot128_seq(h0_lo, h0_hi, k_lo, k_hi);
+        float kv1 = gdn_dot128_seq(h1_lo, h1_hi, k_lo, k_hi);
+        float kv2 = gdn_dot128_seq(h2_lo, h2_hi, k_lo, k_hi);
+        float kv3 = gdn_dot128_seq(h3_lo, h3_hi, k_lo, k_hi);
+
+        float d0 = (v_f32[0] - kv0) * beta;
+        float d1 = (v_f32[1] - kv1) * beta;
+        float d2 = (v_f32[2] - kv2) * beta;
+        float d3 = (v_f32[3] - kv3) * beta;
+
+        h0_lo += d0 * k_lo; h0_hi += d0 * k_hi;
+        h1_lo += d1 * k_lo; h1_hi += d1 * k_hi;
+        h2_lo += d2 * k_lo; h2_hi += d2 * k_hi;
+        h3_lo += d3 * k_lo; h3_hi += d3 * k_hi;
+
+        simd<float, 4> o_acc;
+        o_acc[0] = gdn_dot128_seq(h0_lo, h0_hi, q_lo, q_hi);
+        o_acc[1] = gdn_dot128_seq(h1_lo, h1_hi, q_lo, q_hi);
+        o_acc[2] = gdn_dot128_seq(h2_lo, h2_hi, q_lo, q_hi);
+        o_acc[3] = gdn_dot128_seq(h3_lo, h3_hi, q_lo, q_hi);
+
+        lsc_store_state_64_seq(sr0, h0_lo);
+        lsc_store_state_64_seq(sr0 + 64, h0_hi);
+        lsc_store_state_64_seq(sr1, h1_lo);
+        lsc_store_state_64_seq(sr1 + 64, h1_hi);
+        lsc_store_state_64_seq(sr2, h2_lo);
+        lsc_store_state_64_seq(sr2 + 64, h2_hi);
+        lsc_store_state_64_seq(sr3, h3_lo);
+        lsc_store_state_64_seq(sr3 + 64, h3_hi);
+
+        fp16* out = output_ptr + (int64_t)seq_idx * HV * gdn_V + (int64_t)hv * gdn_V + vi0;
+        xmem::lsc_block_store<fp16, 4,
+            xmem::lsc_data_size::default_size,
+            xmem::cache_hint::streaming, xmem::cache_hint::write_back>(
+            out, simd<fp16, 4>(o_acc));
+    } else {
+        int vi0_z = tid * 4;
+        fp16* out = output_ptr + (int64_t)seq_idx * HV * gdn_V + (int64_t)hv * gdn_V + vi0_z;
+        xmem::lsc_block_store<fp16, 4,
+            xmem::lsc_data_size::default_size,
+            xmem::cache_hint::streaming, xmem::cache_hint::write_back>(
+            out, simd<fp16, 4>(0.0f));
+    }
+
+    // ---- Phase 3: conv_state shift + z extraction ----
+    if (conv_idx >= 0) {
+        simd<float, 64> s1_copy = block_load<fp16, 64>(cstate_base + 1 * 2048 + chunk_start);
+        simd<float, 64> s2_copy = block_load<fp16, 64>(cstate_base + 2 * 2048 + chunk_start);
+        block_store<fp16, 64>(cstate_base + 0 * 2048 + chunk_start, simd<fp16, 64>(s1_copy));
+        block_store<fp16, 64>(cstate_base + 1 * 2048 + chunk_start, simd<fp16, 64>(s2_copy));
+        block_store<fp16, 64>(cstate_base + 2 * 2048 + chunk_start, x_fp16);
+    }
+
+    // ---- z extraction: v-threads copy z from SEQUENTIAL qkvz to z_out ----
+    if (tid >= 4 * H) {
+        int v_tid = tid - 4 * H;
+        int v_hv = v_tid / 2;
+        int v_half = v_tid & 1;
+
+        // z in sequential layout: z_base + hv*V + half*64
+        int z_qkvz_offset = z_base + v_hv * gdn_V + v_half * 64;
+
+        simd<fp16, 64> z_data = block_load<fp16, 64>(qkvz_row + z_qkvz_offset);
+
+        fp16* z_dst = z_out_ptr + (int64_t)seq_idx * HV * gdn_V
+                    + (int64_t)v_hv * gdn_V + v_half * 64;
+        block_store<fp16, 64>(z_dst, z_data);
+    }
+}
+
+/* ============================================================
+ * Host Dispatcher
+ * ============================================================ */
+inline void gdn_conv_fused_seq_host(
+    const fp16* qkvz_ptr,
+    int64_t qkvz_stride0,
+    fp16* conv_state_ptr,
+    const fp16* conv_weight_ptr,
+    const fp16* conv_bias_ptr,
+    const int* conv_state_indices_ptr,
+    const fp16* A_log_ptr,
+    const fp16* dt_bias_ptr,
+    const fp16* ba_ptr,
+    int64_t ba_stride0,
+    fp16* ssm_state_ptr,
+    const int* ssm_state_indices_ptr,
+    fp16* output_ptr,
+    fp16* z_out_ptr,
+    int N, int H, int HV, int K, int V,
+    float scale,
+    int64_t conv_stride0,
+    int64_t ssm_stride0,
+    sycl::queue& q)
+{
+    constexpr int WG_SIZE = 32;
+
+    sycl::nd_range<3> Range(
+        sycl::range<3>(N, HV, WG_SIZE),
+        sycl::range<3>(1, 1, WG_SIZE));
+
+    q.submit([&](sycl::handler& cgh) {
+        cgh.parallel_for(Range, [=](sycl::nd_item<3> ndi) SYCL_ESIMD_KERNEL {
+            gdn_conv_fused_seq_kernel(
+                qkvz_ptr, qkvz_stride0, conv_state_ptr,
+                conv_weight_ptr, conv_bias_ptr, conv_state_indices_ptr,
+                A_log_ptr, dt_bias_ptr, ba_ptr, ba_stride0,
+                ssm_state_ptr, ssm_state_indices_ptr,
+                output_ptr, z_out_ptr,
+                N, H, HV, K, V, scale, conv_stride0, ssm_stride0, ndi);
+        });
+    });
+}

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/moe_ops.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/moe_ops.h
@@ -1,0 +1,676 @@
+#pragma once
+#include <sycl/sycl.hpp>
+#include <sycl/ext/intel/esimd.hpp>
+#include <sycl/ext/intel/experimental/esimd/memory.hpp>
+
+#include <vector>
+#include <algorithm>
+#include <numeric>
+#include <cmath>
+
+using namespace sycl::ext::intel::esimd;
+using namespace sycl;
+using fp16 = sycl::half;
+
+namespace xesimd = sycl::ext::intel::experimental::esimd;
+namespace esimd_math = sycl::ext::intel::esimd;
+
+// Helper: horizontal sum of simd vector
+template<typename T, int N>
+SYCL_ESIMD_FUNCTION inline T h_sum(simd<T, N> v) {
+    if constexpr (N == 1) return v[0];
+    else {
+        auto lo = v.template select<N/2, 1>(0);
+        auto hi = v.template select<N/2, 1>(N/2);
+        simd<T, N/2> sum = lo + hi;
+        return h_sum<T, N/2>(sum);
+    }
+}
+
+// Helper: horizontal max of simd vector
+template<typename T, int N>
+SYCL_ESIMD_FUNCTION inline T h_max(simd<T, N> v) {
+    if constexpr (N == 1) {
+        T r = v[0];
+        return r;
+    } else if constexpr (N == 2) {
+        T a = v[0], b = v[1];
+        return (a > b) ? a : b;
+    } else {
+        simd<T, N/2> lo = v.template select<N/2, 1>(0);
+        simd<T, N/2> hi = v.template select<N/2, 1>(N/2);
+        simd<T, N/2> mx = esimd_math::max<T, N/2>(lo, hi);
+        return h_max<T, N/2>(mx);
+    }
+}
+
+// Helper: horizontal min of simd vector
+template<typename T, int N>
+SYCL_ESIMD_FUNCTION inline T h_min(simd<T, N> v) {
+    if constexpr (N == 1) {
+        T r = v[0];
+        return r;
+    } else if constexpr (N == 2) {
+        T a = v[0], b = v[1];
+        return (a < b) ? a : b;
+    } else {
+        simd<T, N/2> lo = v.template select<N/2, 1>(0);
+        simd<T, N/2> hi = v.template select<N/2, 1>(N/2);
+        simd<T, N/2> mn = esimd_math::min<T, N/2>(lo, hi);
+        return h_min<T, N/2>(mn);
+    }
+}
+
+// ============================================================================
+// MoE Auxiliary Ops: TopK, Scatter, SiLU_and_Mul, Gather
+//
+// These surround the FP8 MoE GEMM to form the full MoE forward pass:
+//   TopK → Scatter → gate_up_GEMM → SiLU_and_Mul → down_GEMM → Gather
+// ============================================================================
+
+// ======================== TopK V2 Kernel (configurable experts/topk) ========================
+// Uses h_max + >= comparison + integer-index zeroing to avoid float == bugs.
+// No C arrays of simd types — uses flat simd<float, NUM_EXPERTS> to avoid spill issues.
+
+// Argmax + zero: uses h_max for value, integer bit-cast for matching.
+// The bit-cast comparison bypasses -ffast-math float comparison issues.
+template<int C>
+SYCL_ESIMD_FUNCTION inline void chunk_argmax_and_zero(
+    simd<float, C>& vals, int base_idx,
+    float& out_val, int32_t& out_idx)
+{
+    float mx = h_max<float, C>(vals);
+
+    // Bit-cast float max to int32 for exact bit-pattern comparison
+    // This is immune to -ffast-math reordering of float comparisons
+    union { float f; int32_t i; } mx_bits;
+    mx_bits.f = mx;
+
+    simd<int32_t, C> vals_as_int = vals.template bit_cast_view<int32_t>().read();
+    simd_mask<C> mask = (vals_as_int == mx_bits.i);
+
+    // Pick lowest index among matches
+    simd<int32_t, C> cand(999999);
+    cand.merge(simd<int32_t, C>(base_idx, 1), mask);
+    int32_t found_idx = h_min<int32_t, C>(cand);
+
+    out_val = mx;
+    out_idx = found_idx;
+
+    // Zero exactly one element by integer index (always exact)
+    int local_pos = found_idx - base_idx;
+    simd_mask<C> zero_mask = (simd<int32_t, C>(0, 1) == local_pos);
+    vals.merge(simd<float, C>(-1.0f), zero_mask);
+}
+
+template<int NUM_EXPERTS, int TOPK>
+struct MoE_TopK_V2_Kernel {
+    const fp16* router_logits;   // [T, NUM_EXPERTS]
+    fp16* top_values;            // [T, TOPK]
+    int32_t* top_indices;        // [T, TOPK]
+    int T;
+
+    void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+        static_assert(NUM_EXPERTS % 64 == 0, "NUM_EXPERTS must be multiple of 64");
+        static_assert(NUM_EXPERTS <= 512, "NUM_EXPERTS must be <= 512");
+        static_assert(TOPK <= 16, "TOPK must be <= 16");
+        constexpr int C = 64;  // chunk size
+
+        int row = item.get_group(0);
+        if (row >= T) return;
+
+        const fp16* row_ptr = router_logits + (size_t)row * NUM_EXPERTS;
+        constexpr int N_CHUNKS = NUM_EXPERTS / C;
+
+        // ── Load into C array of simd chunks ──
+        simd<float, C> probs[N_CHUNKS];
+        #pragma unroll
+        for (int c = 0; c < N_CHUNKS; c++) {
+            simd<fp16, C> raw = block_load<fp16, C>(row_ptr + c * C);
+            probs[c] = simd<float, C>(raw);
+        }
+
+        // ── Softmax: global max ──
+        float row_max = h_max<float, C>(probs[0]);
+        #pragma unroll
+        for (int c = 1; c < N_CHUNKS; c++) {
+            float m = h_max<float, C>(probs[c]);
+            if (m > row_max) row_max = m;
+        }
+
+        // ── Softmax: exp(x - max) + sum ──
+        float total = 0.0f;
+        #pragma unroll
+        for (int c = 0; c < N_CHUNKS; c++) {
+            probs[c] -= row_max;
+            probs[c] = esimd_math::exp<float, C>(probs[c]);
+            total += h_sum<float, C>(probs[c]);
+        }
+
+        // ── Softmax: normalize ──
+        float inv = 1.0f / total;
+        #pragma unroll
+        for (int c = 0; c < N_CHUNKS; c++) probs[c] *= inv;
+
+        // ── TopK selection: TOPK rounds ──
+        float   tv[16];
+        int32_t ti[16];
+
+        #pragma unroll
+        for (int k = 0; k < TOPK; k++) {
+            // Find which chunk has the global max
+            float bv = -1.0f;
+            int   bc = 0;
+            #pragma unroll
+            for (int c = 0; c < N_CHUNKS; c++) {
+                float m = h_max<float, C>(probs[c]);
+                if (m > bv) { bv = m; bc = c; }
+            }
+
+            // Argmax + zero within winning chunk
+            float fv; int32_t fi;
+            chunk_argmax_and_zero<C>(probs[bc], bc * C, fv, fi);
+
+            tv[k] = fv;
+            ti[k] = fi;
+        }
+
+        // ── Normalize top-K ──
+        float top_sum = 0.0f;
+        #pragma unroll
+        for (int k = 0; k < TOPK; k++) top_sum += tv[k];
+        float inv_top = 1.0f / top_sum;
+        #pragma unroll
+        for (int k = 0; k < TOPK; k++) tv[k] *= inv_top;
+
+        // ── Store ──
+        fp16* vp = top_values + (size_t)row * TOPK;
+        int32_t* ip = top_indices + (size_t)row * TOPK;
+
+        // block_store first 8
+        if constexpr (TOPK >= 8) {
+            simd<fp16, 8> sv8;
+            simd<int32_t, 8> si8;
+            #pragma unroll
+            for (int i = 0; i < 8; i++) { sv8[i] = (fp16)tv[i]; si8[i] = ti[i]; }
+            block_store<fp16, 8>(vp, sv8);
+            block_store<int32_t, 8>(ip, si8);
+        }
+        // Store remainder individually
+        if constexpr (TOPK > 8) {
+            #pragma unroll
+            for (int i = 8; i < TOPK; i++) {
+                simd<fp16, 1> sv((fp16)tv[i]);
+                simd<int32_t, 1> si(ti[i]);
+                block_store<fp16, 1>(vp + i, sv);
+                block_store<int32_t, 1>(ip + i, si);
+            }
+        }
+        if constexpr (TOPK < 8) {
+            #pragma unroll
+            for (int i = 0; i < TOPK; i++) {
+                simd<fp16, 1> sv((fp16)tv[i]);
+                simd<int32_t, 1> si(ti[i]);
+                block_store<fp16, 1>(vp + i, sv);
+                block_store<int32_t, 1>(ip + i, si);
+            }
+        }
+    }
+};
+
+template<int NUM_EXPERTS, int TOPK>
+inline void moe_topk_v2_host(
+    const fp16* logits, fp16* values, int32_t* indices,
+    int T, sycl::queue& q)
+{
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(
+            sycl::nd_range<1>({(size_t)T}, {1}),
+            MoE_TopK_V2_Kernel<NUM_EXPERTS, TOPK>{logits, values, indices, T});
+    });
+}
+
+// ======================== CPU Preprocessing ========================
+
+// Build sorted_token_ids from router_indices.
+// sorted_token_ids[dest_pos] = t * topk + k, grouped by expert.
+// expert_idx[e] = start offset of expert e's tokens in sorted array.
+inline void build_sorted_token_ids(
+    const int32_t* router_indices,  // [T, topk]
+    int32_t* sorted_token_ids,      // [T*topk] output
+    uint32_t* expert_idx,           // [num_experts+1] output
+    int T, int topk, int num_experts)
+{
+    std::vector<int> count(num_experts, 0);
+    for (int t = 0; t < T; t++)
+        for (int k = 0; k < topk; k++)
+            count[router_indices[t * topk + k]]++;
+
+    expert_idx[0] = 0;
+    for (int e = 0; e < num_experts; e++)
+        expert_idx[e + 1] = expert_idx[e] + count[e];
+
+    std::vector<int> pos(num_experts);
+    for (int e = 0; e < num_experts; e++) pos[e] = expert_idx[e];
+    for (int t = 0; t < T; t++)
+        for (int k = 0; k < topk; k++) {
+            int e = router_indices[t * topk + k];
+            sorted_token_ids[pos[e]++] = t * topk + k;
+        }
+}
+
+// Build reverse map: topk_ids[t*topk + k] = dest_pos in scattered array.
+inline void build_topk_ids(
+    const int32_t* sorted_token_ids,
+    int32_t* topk_ids,   // [T*topk] output
+    int total, int topk)
+{
+    for (int i = 0; i < total; i++) {
+        topk_ids[sorted_token_ids[i]] = i;
+    }
+}
+
+// ======================== TopK Kernel ========================
+// Fused softmax + top-8 + normalize.
+// Input: router_logits [T, num_experts] fp16
+// Output: top_values [T, topk] fp16, top_indices [T, topk] int32
+
+struct MoE_TopK_Kernel {
+    const fp16* router_logits;  // [T, 128]
+    fp16* top_values;           // [T, 8]
+    int32_t* top_indices;       // [T, 8]
+    int T;
+
+    void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+        constexpr int NUM_EXPERTS = 128;
+        constexpr int TOPK = 8;
+
+        int row = item.get_group(0);
+        if (row >= T) return;
+
+        // Load 128 fp16 → fp32
+        simd<fp16, 64> raw_lo = block_load<fp16, 64>(router_logits + row * NUM_EXPERTS);
+        simd<fp16, 64> raw_hi = block_load<fp16, 64>(router_logits + row * NUM_EXPERTS + 64);
+        simd<float, 64> logits_lo(raw_lo);
+        simd<float, 64> logits_hi(raw_hi);
+
+        // Softmax step 1: find max
+        float max_lo = h_max<float, 64>(logits_lo);
+        float max_hi = h_max<float, 64>(logits_hi);
+        float row_max = (max_lo > max_hi) ? max_lo : max_hi;
+
+        // Softmax step 2: exp(x - max)
+        logits_lo -= row_max;
+        logits_hi -= row_max;
+        simd<float, 64> probs_lo = esimd_math::exp<float, 64>(logits_lo);
+        simd<float, 64> probs_hi = esimd_math::exp<float, 64>(logits_hi);
+
+        // Softmax step 3: normalize
+        float sum_lo = h_sum<float, 64>(probs_lo);
+        float sum_hi = h_sum<float, 64>(probs_hi);
+        float inv_sum = 1.0f / (sum_lo + sum_hi);
+        probs_lo *= inv_sum;
+        probs_hi *= inv_sum;
+
+        // Index vectors for vectorized TopK — iota (no scalar writes)
+        simd<int32_t, 64> idx_lo(0, 1);     // {0, 1, 2, ..., 63}
+        simd<int32_t, 64> idx_hi(64, 1);    // {64, 65, ..., 127}
+
+        simd<float, TOPK> top_vals;
+        simd<int32_t, TOPK> top_idx;
+
+        // TopK: 8 rounds — bit-cast comparison to bypass -ffast-math
+        #pragma unroll
+        for (int k = 0; k < TOPK; k++) {
+            float mx_lo = h_max<float, 64>(probs_lo);
+            float mx_hi = h_max<float, 64>(probs_hi);
+
+            if (mx_lo >= mx_hi) {
+                top_vals[k] = mx_lo;
+                // Bit-cast comparison: immune to -ffast-math
+                union { float f; int32_t i; } mx_bits;
+                mx_bits.f = mx_lo;
+                simd<int32_t, 64> lo_bits = probs_lo.template bit_cast_view<int32_t>().read();
+                simd_mask<64> mask = (lo_bits == mx_bits.i);
+                simd<int32_t, 64> cand = 999;
+                cand.merge(idx_lo, mask);
+                top_idx[k] = h_min<int32_t, 64>(cand);
+                // Zero exactly one element by integer index
+                int local_pos = top_idx[k];
+                simd_mask<64> zmask = (idx_lo == local_pos);
+                probs_lo.merge(simd<float, 64>(-1.0f), zmask);
+            } else {
+                top_vals[k] = mx_hi;
+                union { float f; int32_t i; } mx_bits;
+                mx_bits.f = mx_hi;
+                simd<int32_t, 64> hi_bits = probs_hi.template bit_cast_view<int32_t>().read();
+                simd_mask<64> mask = (hi_bits == mx_bits.i);
+                simd<int32_t, 64> cand = 999;
+                cand.merge(idx_hi, mask);
+                top_idx[k] = h_min<int32_t, 64>(cand);
+                int local_pos = top_idx[k];
+                simd_mask<64> zmask = (idx_hi == local_pos);
+                probs_hi.merge(simd<float, 64>(-1.0f), zmask);
+            }
+        }
+
+        // Normalize top-8
+        float top_sum = h_sum<float, TOPK>(top_vals);
+        top_vals *= (1.0f / top_sum);
+
+        // Store
+        simd<fp16, TOPK> out_vals = convert<fp16, float, TOPK>(top_vals);
+        block_store<fp16, TOPK>(top_values + row * TOPK, out_vals);
+        block_store<int32_t, TOPK>(top_indices + row * TOPK, top_idx);
+    }
+};
+
+inline void moe_topk_host(
+    const fp16* logits, fp16* values, int32_t* indices,
+    int T, sycl::queue& q)
+{
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(
+            sycl::nd_range<1>({(size_t)T}, {1}),
+            MoE_TopK_Kernel{logits, values, indices, T});
+    });
+}
+
+// ======================== Scatter Kernel ========================
+// Reorder hidden_states [T, K] → scattered [T*topk, K] by expert grouping.
+// Also scatter router weights.
+
+struct MoE_Scatter_Kernel {
+    const fp16* hidden_states;      // [T, K]
+    const fp16* router_top_value;   // [T, topk]
+    const int32_t* sorted_token_ids; // [T*topk]
+    fp16* scattered_hidden;         // [T*topk, K]
+    fp16* scattered_weights;        // [T*topk]
+    int K, topk;
+
+    void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+        int dest_pos = item.get_group(0);
+
+        simd<int32_t, 1> enc = block_load<int32_t, 1>(sorted_token_ids + dest_pos);
+        int encoded = enc[0];
+        int src_row = encoded / topk;
+        int slot    = encoded % topk;
+
+        // Copy K fp16 in chunks of 128
+        for (int off = 0; off < K; off += 128) {
+            simd<fp16, 128> v = block_load<fp16, 128>(
+                hidden_states + (size_t)src_row * K + off);
+            block_store<fp16, 128>(
+                scattered_hidden + (size_t)dest_pos * K + off, v);
+        }
+
+        // Scatter weight
+        simd<fp16, 1> wv = block_load<fp16, 1>(router_top_value + src_row * topk + slot);
+        block_store<fp16, 1>(scattered_weights + dest_pos, wv);
+    }
+};
+
+inline void moe_scatter_host(
+    const fp16* hidden, const fp16* top_values,
+    const int32_t* sorted_ids,
+    fp16* scattered_hidden, fp16* scattered_weights,
+    int K, int topk, int total_expanded,
+    sycl::queue& q)
+{
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(
+            sycl::nd_range<1>({(size_t)total_expanded}, {1}),
+            MoE_Scatter_Kernel{hidden, top_values, sorted_ids,
+                               scattered_hidden, scattered_weights,
+                               K, topk});
+    });
+}
+
+// ======================== Fused Scatter (GPU-only, no CPU preprocessing) ========================
+// Replaces CPU build_sorted_token_ids + old Scatter kernel.
+// Uses atomic counting (IPEX pattern) to build expert grouping entirely on GPU.
+//
+// Phase 1 (Init):  Per-token, atomic_add on expert counts → per-slot offset
+// Phase 2 (Prefix): Prefix-sum counts → expert_start[0..num_experts]
+// Phase 3 (Copy):  Per-token, copy hidden + weights + build topk_ids reverse map
+
+struct MoE_Scatter_Init_Kernel {
+    const int32_t* top_indices;         // [T, topk]
+    int32_t* experts_token_count;       // [num_experts] — zero-initialized
+    int32_t* token_to_scatter_offset;   // [T*topk] output
+    int T, topk;
+
+    void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+        int t = item.get_group(0);
+        if (t >= T) return;
+
+        // Process each top-k slot individually (supports any topk value)
+        for (int k = 0; k < topk; k++) {
+            int expert_id = *(top_indices + (size_t)t * topk + k);
+
+            simd<uint32_t, 1> byte_off((uint32_t)expert_id * (uint32_t)sizeof(int32_t));
+            simd<int32_t, 1> val(1);
+            simd<int32_t, 1> old = atomic_update<atomic_op::add>(
+                experts_token_count, byte_off, val, simd_mask<1>(1));
+
+            *(token_to_scatter_offset + (size_t)t * topk + k) = old[0];
+        }
+    }
+};
+
+struct MoE_Scatter_Prefix_Kernel {
+    const int32_t* experts_token_count; // [num_experts]
+    uint32_t* expert_start;             // [num_experts+1] output
+    int32_t* max_tokens_out;            // [1] output
+    int num_experts;
+
+    void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+        uint32_t running_sum = 0;
+        int32_t max_count = 0;
+
+        for (int base = 0; base < num_experts; base += 32) {
+            simd<int32_t, 32> counts = block_load<int32_t, 32>(
+                experts_token_count + base);
+            #pragma unroll
+            for (int i = 0; i < 32; i++) {
+                int32_t c = counts[i];
+                if (c > max_count) max_count = c;
+                simd<uint32_t, 1> val = running_sum;
+                block_store<uint32_t, 1>(expert_start + base + i, val);
+                running_sum += (uint32_t)c;
+            }
+        }
+        simd<uint32_t, 1> total_val = running_sum;
+        block_store<uint32_t, 1>(expert_start + num_experts, total_val);
+        simd<int32_t, 1> max_val = max_count;
+        block_store<int32_t, 1>(max_tokens_out, max_val);
+    }
+};
+
+struct MoE_Scatter_Copy_Kernel {
+    const fp16* hidden_states;          // [T, K]
+    const fp16* top_values;             // [T, topk] — routing weights
+    const int32_t* top_indices;         // [T, topk] — expert IDs
+    const int32_t* token_to_scatter_offset; // [T*topk]
+    const uint32_t* expert_start;       // [num_experts+1]
+    fp16* scattered_hidden;             // [T*topk, K]
+    fp16* scattered_weights;            // [T*topk]
+    int32_t* topk_ids;                  // [T*topk] output — reverse map for Gather
+    int K, topk;
+
+    void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+        int t = item.get_group(0);
+
+        for (int k = 0; k < topk; k++) {
+            int expert_id = *(top_indices + (size_t)t * topk + k);
+            int offset = *(token_to_scatter_offset + (size_t)t * topk + k);
+
+            simd<uint32_t, 1> es = block_load<uint32_t, 1>(expert_start + expert_id);
+            int dp = (int)es[0] + offset;
+
+            // Copy hidden states
+            for (int off = 0; off < K; off += 128) {
+                simd<fp16, 128> v = block_load<fp16, 128>(
+                    hidden_states + (size_t)t * K + off);
+                block_store<fp16, 128>(
+                    scattered_hidden + (size_t)dp * K + off, v);
+            }
+
+            // Scatter weight
+            fp16 w = *(top_values + (size_t)t * topk + k);
+            simd<fp16, 1> wv;
+            wv[0] = w;
+            block_store<fp16, 1>(scattered_weights + dp, wv);
+
+            // Build reverse map
+            simd<int32_t, 1> dp_val;
+            dp_val[0] = dp;
+            block_store<int32_t, 1>(topk_ids + (size_t)t * topk + k, dp_val);
+        }
+    }
+};
+
+inline void moe_scatter_fused_host(
+    const fp16* hidden, const fp16* top_values, const int32_t* top_indices,
+    fp16* scattered_hidden, fp16* scattered_weights,
+    int32_t* topk_ids, uint32_t* expert_start, int32_t* max_tokens_out,
+    int32_t* experts_token_count, int32_t* token_to_scatter_offset,
+    int K, int topk, int T, int num_experts,
+    sycl::queue& q)
+{
+    // Zero-initialize expert counts
+    q.memset(experts_token_count, 0, num_experts * sizeof(int32_t));
+
+    // Kernel 1: Atomic counting — T WGs
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(
+            sycl::nd_range<1>({(size_t)T}, {1}),
+            MoE_Scatter_Init_Kernel{top_indices, experts_token_count,
+                                     token_to_scatter_offset, T, topk});
+    });
+
+    // Kernel 2: Prefix-sum — 1 WG, 1 thread
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(
+            sycl::nd_range<1>({1}, {1}),
+            MoE_Scatter_Prefix_Kernel{experts_token_count, expert_start,
+                                       max_tokens_out, num_experts});
+    });
+
+    // Kernel 3: Copy + build topk_ids — T WGs
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(
+            sycl::nd_range<1>({(size_t)T}, {1}),
+            MoE_Scatter_Copy_Kernel{hidden, top_values, top_indices,
+                                     token_to_scatter_offset, expert_start,
+                                     scattered_hidden, scattered_weights,
+                                     topk_ids, K, topk});
+    });
+}
+
+// ======================== SiLU_and_Mul Kernel ========================
+// Input: [rows, N_gate_up] fp16, first N_half is gate, second N_half is up.
+// Output: [rows, N_half] fp16 = SiLU(gate) * up
+// N_gate_up = 384, N_half = 192 for Qwen3-Next TP4.
+
+struct MoE_SiLU_Mul_Kernel {
+    const fp16* input;   // [rows, N_gate_up]
+    fp16* output;        // [rows, N_half]
+    int N_gate_up;       // 384
+    int N_half;          // 192
+    int total_rows;
+
+    void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+        int row = item.get_group(0);
+        if (row >= total_rows) return;
+
+        const fp16* row_in = input + (size_t)row * N_gate_up;
+        fp16* row_out = output + (size_t)row * N_half;
+
+        // Process in chunks of 64 (192 = 3 × 64)
+        for (int off = 0; off < N_half; off += 64) {
+            simd<fp16, 64> gate_h = block_load<fp16, 64>(row_in + off);
+            simd<fp16, 64> up_h   = block_load<fp16, 64>(row_in + N_half + off);
+
+            simd<float, 64> gate = convert<float, fp16, 64>(gate_h);
+            simd<float, 64> up   = convert<float, fp16, 64>(up_h);
+
+            // SiLU(x) = x * sigmoid(x) = x / (1 + exp(-x))
+            simd<float, 64> neg_gate = -gate;
+            simd<float, 64> exp_neg = esimd_math::exp<float, 64>(neg_gate);
+            simd<float, 64> sigmoid = 1.0f / (1.0f + exp_neg);
+            simd<float, 64> silu = gate * sigmoid;
+            simd<float, 64> result = silu * up;
+
+            simd<fp16, 64> out = convert<fp16, float, 64>(result);
+            block_store<fp16, 64>(row_out + off, out);
+        }
+    }
+};
+
+inline void moe_silu_mul_host(
+    const fp16* input, fp16* output,
+    int N_gate_up, int N_half, int total_rows,
+    sycl::queue& q)
+{
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(
+            sycl::nd_range<1>({(size_t)total_rows}, {1}),
+            MoE_SiLU_Mul_Kernel{input, output, N_gate_up, N_half, total_rows});
+    });
+}
+
+// ======================== Gather Kernel ========================
+// Weighted reduce: moe_output [T*topk, K] → final_hidden [T, K]
+// For each token t: final[t] = sum_k(moe_out[topk_ids[t,k]] * weight[topk_ids[t,k]])
+
+struct MoE_Gather_Kernel {
+    const fp16* moe_output;         // [T*topk, K]
+    const int32_t* topk_ids;        // [T, topk] → positions in scattered array
+    const fp16* scattered_weights;  // [T*topk]
+    fp16* final_hidden;             // [T, K]
+    int K, topk;
+
+    void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+        int t = item.get_group(0);
+        constexpr int CHUNK = 128;
+        constexpr int MAX_TOPK = 32;
+
+        // Load positions and weights (scalar loop, supports any topk)
+        int ids[MAX_TOPK];
+        float wts[MAX_TOPK];
+        for (int k = 0; k < topk; k++) {
+            ids[k] = *(topk_ids + (size_t)t * topk + k);
+            simd<fp16, 1> wv = block_load<fp16, 1>(scattered_weights + ids[k]);
+            fp16 w_scalar = wv[0];
+            wts[k] = (float)w_scalar;
+        }
+
+        // Iterate K chunks: accumulate topk experts per chunk, store immediately
+        for (int off = 0; off < K; off += CHUNK) {
+            simd<float, CHUNK> acc = 0.0f;
+            for (int k = 0; k < topk; k++) {
+                float wk = wts[k];
+                simd<fp16, CHUNK> row = block_load<fp16, CHUNK>(
+                    moe_output + (size_t)ids[k] * K + off);
+                acc += convert<float, fp16, CHUNK>(row) * wk;
+            }
+            simd<fp16, CHUNK> out = convert<fp16, float, CHUNK>(acc);
+            block_store<fp16, CHUNK>(final_hidden + (size_t)t * K + off, out);
+        }
+    }
+};
+
+inline void moe_gather_host(
+    const fp16* moe_output, const int32_t* topk_ids,
+    const fp16* scattered_weights, fp16* final_hidden,
+    int K, int topk, int T,
+    sycl::queue& q)
+{
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(
+            sycl::nd_range<1>({(size_t)T}, {1}),
+            MoE_Gather_Kernel{moe_output, topk_ids, scattered_weights,
+                              final_hidden, K, topk});
+    });
+}

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/norm_gemv_fused.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/norm_gemv_fused.h
@@ -1,0 +1,150 @@
+/* norm_gemv_fused.h — Fused RMSNormGated + FP8 GEMV for GDN out_proj.
+ *
+ * Combines two operations into a single kernel submit:
+ *   1. RMSNormGated: y = rmsnorm(x) * weight * silu(z), per-head (V dims each)
+ *   2. GEMV: output = y_flat @ dequant(gemv_weight^T) * scale
+ *
+ * Designed for GDN decode path where:
+ *   x (core_attn_out): [HV, V] fp16   (e.g. [8, 128])
+ *   z (z_out):          [HV, V] fp16
+ *   norm_weight:         [V] fp16       (shared across heads)
+ *   gemv_weight:         [N, K] FP8     (K = HV*V, e.g. [2048, 1024])
+ *   gemv_scale:          [1] float32
+ *   output:              [N] fp16
+ *
+ * Each work-group computes one output element:
+ *   1. Load x, z for current K-chunk (one head = V=128 elements)
+ *   2. Compute RMSNorm + SiLU gate → normed[V]
+ *   3. Load weight row chunk, FMA into accumulator
+ *   4. Repeat for all HV heads
+ *   5. Reduce accumulator → output
+ *
+ * The norm inputs (x, z, norm_w) are read by all WGs but stay in L3
+ * cache after the first WG reads them (total 2*HV*V*2 + V*2 ≈ 4.25KB).
+ *
+ * Saves: 1 kernel launch + Python overhead of norm (torch.empty, reshape,
+ * Triton dispatch) per GDN layer. 48 layers × ~50us = ~2.4ms.
+ */
+
+#pragma once
+#include "utils.h"
+
+template<int VL>
+SYCL_ESIMD_FUNCTION inline simd<float, VL> fp8_dequant_norm(
+    simd<uint8_t, VL> raw, int fp8_mode) {
+    simd<uint16_t, VL> u16 = convert<uint16_t>(raw);
+    simd<uint16_t, VL> fp8_sign = (u16 >> 7) & 1;
+    simd<uint16_t, VL> fp16_bits;
+
+    if (fp8_mode == 0) {
+        simd<uint16_t, VL> fp8_exp  = (u16 >> 3) & 0xF;
+        simd<uint16_t, VL> fp8_mant = u16 & 0x7;
+        fp16_bits = (fp8_sign << 15) | ((fp8_exp + 8) << 10) | (fp8_mant << 7);
+        fp16_bits.merge(fp8_sign << 15, fp8_exp == 0);
+    } else {
+        simd<uint16_t, VL> fp8_exp  = (u16 >> 2) & 0x1F;
+        simd<uint16_t, VL> fp8_mant = u16 & 0x3;
+        fp16_bits = (fp8_sign << 15) | (fp8_exp << 10) | (fp8_mant << 8);
+        fp16_bits.merge(fp8_sign << 15, fp8_exp == 0);
+    }
+
+    simd<fp16, VL> wh = fp16_bits.template bit_cast_view<fp16>().read();
+    return simd<float, VL>(wh);
+}
+
+/* Hierarchical reduction for simd<float, 128> → scalar */
+ESIMD_INLINE float reduce128(simd<float, 128> v) {
+    v.select<64,1>(0) += v.select<64,1>(64);
+    v.select<32,1>(0) += v.select<32,1>(32);
+    v.select<16,1>(0) += v.select<16,1>(16);
+    v.select<8,1>(0)  += v.select<8,1>(8);
+    v.select<4,1>(0)  += v.select<4,1>(4);
+    v.select<2,1>(0)  += v.select<2,1>(2);
+    return v[0] + v[1];
+}
+
+/* ================================================================
+ * Kernel: Fused RMSNormGated + FP8 GEMV (per-tensor scale)
+ * Grid: N work-groups, 1 thread each (same as GEMV_fp8_pert_kernel)
+ * ================================================================ */
+struct NormGEMV_fp8_pert_kernel {
+    const fp16*    x_ptr;        // [HV, V] core_attn_out
+    const fp16*    z_ptr;        // [HV, V] z_out
+    const fp16*    norm_w_ptr;   // [V] norm weight
+    const uint8_t* gemv_weight;  // [N, K] FP8, K = HV * V
+    const float*   gemv_scale;   // [1] per-tensor scale
+    fp16*          output;       // [N]
+    int N;
+    int HV;      // number of value heads (per TP)
+    int V;       // head_v_dim (128)
+    float eps;
+    int fp8_mode; // 0=E4M3, 1=E5M2
+
+    void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+        int n = item.get_group(0);
+        if (n >= N) return;
+
+        const int K = HV * V;
+
+        // Pre-load norm weight [V=128] — shared across all heads, reused HV times
+        simd<float, 128> norm_w = block_load<fp16, 128>(norm_w_ptr);
+
+        simd<float, 128> acc = 0.0f;
+
+        for (int h = 0; h < HV; h++) {
+            const int offset = h * V;
+
+            // Load x and z for this head
+            simd<float, 128> x_f = block_load<fp16, 128>(x_ptr + offset);
+            simd<float, 128> z_f = block_load<fp16, 128>(z_ptr + offset);
+
+            // RMSNorm: rms = sqrt(mean(x^2) + eps)
+            simd<float, 128> x_sq = x_f * x_f;
+            float mean_sq = reduce128(x_sq) * (1.0f / V);
+            float inv_rms = sycl::ext::intel::esimd::rsqrt(
+                simd<float, 8>(mean_sq + eps))[0];
+
+            // Normalize: normed = x * inv_rms * weight
+            simd<float, 128> normed = x_f * inv_rms * norm_w;
+
+            // Gate: silu(z) = z * sigmoid(z)
+            simd<float, 128> neg_z = -z_f;
+            simd<float, 128> exp_neg_z = sycl::ext::intel::esimd::exp(neg_z);
+            simd<float, 128> silu_z = z_f / (1.0f + exp_neg_z);
+            normed *= silu_z;
+
+            // GEMV: accumulate dot product with weight row
+            simd<uint8_t, 128> w_raw = block_load<uint8_t, 128>(
+                gemv_weight + (size_t)n * K + offset);
+            simd<float, 128> w_f = fp8_dequant_norm<128>(w_raw, fp8_mode);
+            acc += normed * w_f;
+        }
+
+        // Final reduction and scale
+        float dot = reduce128(acc) * *gemv_scale;
+        output[n] = fp16(dot);
+    }
+};
+
+/* Host dispatcher */
+inline void norm_gemv_fp8_pert_host(
+    const fp16* x_ptr,
+    const fp16* z_ptr,
+    const fp16* norm_w_ptr,
+    const uint8_t* gemv_weight,
+    const float* gemv_scale,
+    fp16* output,
+    int N, int HV, int V,
+    float eps,
+    int fp8_mode,
+    sycl::queue& q)
+{
+    q.submit([&](sycl::handler& cgh) {
+        cgh.parallel_for(
+            sycl::nd_range<1>(N, 1),
+            NormGEMV_fp8_pert_kernel{
+                x_ptr, z_ptr, norm_w_ptr,
+                gemv_weight, gemv_scale, output,
+                N, HV, V, eps, fp8_mode});
+    });
+}

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/qkv_split_norm_rope.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/qkv_split_norm_rope.h
@@ -1,0 +1,261 @@
+#pragma once
+#include "utils.h"
+#include <cmath>
+
+// Fused QKV Split + RMSNorm + RoPE kernel
+// Adapted from qkv.split/qkv.split.h for project conventions.
+//
+// Operations per head:
+//   Q heads: RMSNorm(weight+1.0, eps=1e-6) → RoPE(theta=10M)
+//   K heads: RMSNorm(weight+1.0, eps=1e-6) → RoPE(theta=10M)
+//   G heads (gating): copy only
+//   V heads: copy only
+//
+// Work decomposition: 2D dispatch (totalHeads, nTokens), one WG per (head, token)
+//   With gating:    totalHeads = 2*qHead + 2*kvHead  (Q,G interleaved)
+//   Without gating: totalHeads = qHead + 2*kvHead
+
+#define QKV_LOCATION_Q 0
+#define QKV_LOCATION_G 1
+#define QKV_LOCATION_K 2
+#define QKV_LOCATION_V 3
+
+ESIMD_INLINE void qkv_split_norm_rope_kernel(
+    uint8_t* qkvState,
+    uint8_t* qState,
+    uint8_t* gateState,
+    uint8_t* kState,
+    uint8_t* vState,
+    uint8_t* normWq,
+    uint8_t* normWk,
+    uint32_t* ropePos,
+    fp16* ropeCosSinCache,  // [max_pos, rotaryDim] fp16 — first half cos, second half sin
+    uint32_t ntoks,
+    uint32_t hiddenDim,
+    uint32_t headDim,
+    uint32_t qHead,
+    uint32_t kvHead,
+    uint32_t rotaryDim,
+    sycl::nd_item<2>& ndi) {
+
+    constexpr float eps = 1e-6f;
+    uint32_t rotaryHalf = rotaryDim / 2;
+
+    int32_t headIdx = ndi.get_group(0);
+    int32_t tokIdx  = ndi.get_group(1);
+
+    uint32_t outHead = headIdx;
+    uint32_t hdimQkv  = headDim * (qHead + 2 * kvHead);
+    uint32_t hdimQgkv = headDim * (2 * qHead + 2 * kvHead);
+    uint32_t outputGate = (hiddenDim == hdimQgkv) ? 1 : 0;
+    uint32_t whereAmI = QKV_LOCATION_Q;
+
+    uint32_t inputOffset = tokIdx * hiddenDim + headIdx * headDim;
+    uint32_t outputOffset;
+
+    uint32_t i32RopeCoord = ropePos[tokIdx];
+    float fp32RopeCoord = (float)i32RopeCoord;
+
+    simd<fp16, 256> activation;
+
+    if (headDim != 256) {
+        return;
+    }
+
+    // Load 256 fp16 from QKV buffer
+    activation = block_load<fp16, 256>((fp16*)qkvState + inputOffset);
+
+    // Determine which output this head maps to
+    if (outputGate == 1) {
+        // With gating: heads are [Q0,G0, Q1,G1, ..., K0, K1, ..., V0, V1, ...]
+        if ((uint32_t)headIdx < 2 * qHead) {
+            whereAmI = headIdx & 0x1;  // 0=Q, 1=G
+            outHead = headIdx >> 1;
+        } else if ((uint32_t)headIdx < (2 * qHead + kvHead)) {
+            whereAmI = QKV_LOCATION_K;
+            outHead = headIdx - 2 * qHead;
+        } else {
+            whereAmI = QKV_LOCATION_V;
+            outHead = headIdx - 2 * qHead - kvHead;
+        }
+    } else {
+        // Without gating: heads are [Q0, Q1, ..., K0, K1, ..., V0, V1, ...]
+        if ((uint32_t)headIdx < qHead) {
+            whereAmI = QKV_LOCATION_Q;
+            outHead = headIdx;
+        } else if ((uint32_t)headIdx < (qHead + kvHead)) {
+            whereAmI = QKV_LOCATION_K;
+            outHead = headIdx - qHead;
+        } else {
+            whereAmI = QKV_LOCATION_V;
+            outHead = headIdx - qHead - kvHead;
+        }
+    }
+
+    if (whereAmI == QKV_LOCATION_Q) {
+        // RMSNorm + partial RoPE for Q
+        simd<fp16, 256> fp16RmsWeights;
+        simd<float, 256> fp32RmsWeights;
+        simd<float, 256> outputTemp;
+
+        outputOffset = qHead * headDim * tokIdx + outHead * headDim;
+        outputTemp = activation;
+        simd<float, 256> outputSq = outputTemp * outputTemp;
+
+        // RMSNorm: x * (weight + 1.0) / rms
+        fp16RmsWeights = block_load<fp16, 256>((fp16*)normWq);
+        float acc = sycl::ext::intel::esimd::detail::sum<float, float, 256>(outputSq) / (float)headDim;
+        float scale = __ESIMD_NS::rsqrt(acc + eps);
+        fp32RmsWeights = fp16RmsWeights + 1.0f;
+        outputTemp = outputTemp * fp32RmsWeights;
+        outputTemp.select<256, 1>(0) = outputTemp.select<256, 1>(0) * scale;
+
+        // RoPE: read from rotary_emb.cos_sin_cache [max_pos, rotaryDim]
+        // Layout: [cos(rotaryHalf), sin(rotaryHalf)] per row
+        {
+            uint32_t rH = rotaryDim / 2;
+            // Row offset in fp16 elements: position * rotaryDim
+            uint32_t row_offset = i32RopeCoord * rotaryDim;
+            if (rotaryDim == 64) {
+                // Load 64 fp16: [cos(32), sin(32)]
+                simd<fp16, 64> cs16;
+                cs16.select<32, 1>(0) = block_load<fp16, 32>(ropeCosSinCache + row_offset);
+                cs16.select<32, 1>(32) = block_load<fp16, 32>(ropeCosSinCache + row_offset + 32);
+                simd<float, 32> pcos = cs16.select<32, 1>(0);
+                simd<float, 32> psin = cs16.select<32, 1>(32);
+
+                simd<float, 32> x1 = outputTemp.select<32, 1>(0);
+                simd<float, 32> x2 = outputTemp.select<32, 1>(32);
+                outputTemp.select<32, 1>(0)  = x1 * pcos - x2 * psin;
+                outputTemp.select<32, 1>(32) = x2 * pcos + x1 * psin;
+            } else {
+                // Full rotation: load 256 fp16
+                simd<float, 128> fcos, fsin;
+#pragma unroll
+                for (int kk = 0; kk < 4; kk++) {
+                    simd<fp16, 32> c16 = block_load<fp16, 32>(ropeCosSinCache + row_offset + 32 * kk);
+                    fcos.select<32, 1>(32 * kk) = c16;
+                }
+#pragma unroll
+                for (int kk = 0; kk < 4; kk++) {
+                    simd<fp16, 32> s16 = block_load<fp16, 32>(ropeCosSinCache + row_offset + 128 + 32 * kk);
+                    fsin.select<32, 1>(32 * kk) = s16;
+                }
+
+                simd<float, 128> x1 = outputTemp.select<128, 1>(0);
+                simd<float, 128> x2 = outputTemp.select<128, 1>(128);
+                outputTemp.select<128, 1>(0)   = x1 * fcos - x2 * fsin;
+                outputTemp.select<128, 1>(128) = x2 * fcos + x1 * fsin;
+            }
+        }
+
+        activation = outputTemp;
+        block_store<fp16, 256>((fp16*)qState + outputOffset, activation);
+    }
+    else if (whereAmI == QKV_LOCATION_G) {
+        // Gate: sigmoid(x) = 1 / (1 + e^(-x))
+        outputOffset = qHead * headDim * tokIdx + outHead * headDim;
+        simd<float, 256> gateTemp = activation;
+        gateTemp = 1.0f / (1.0f + exp<float, 256>(-gateTemp));
+        activation = gateTemp;
+        block_store<fp16, 256>((fp16*)gateState + outputOffset, activation);
+    }
+    else if (whereAmI == QKV_LOCATION_K) {
+        // RMSNorm + partial RoPE for K
+        simd<fp16, 256> fp16RmsWeights;
+        simd<float, 256> fp32RmsWeights;
+        simd<float, 256> outputTemp;
+
+        outputOffset = kvHead * headDim * tokIdx + outHead * headDim;
+        outputTemp = activation;
+        simd<float, 256> kOutputSq = outputTemp * outputTemp;
+
+        fp16RmsWeights = block_load<fp16, 256>((fp16*)normWk);
+        float acc = sycl::ext::intel::esimd::detail::sum<float, float, 256>(kOutputSq) / (float)headDim;
+        float scale = __ESIMD_NS::rsqrt(acc + eps);
+        fp32RmsWeights = fp16RmsWeights + 1.0f;
+        outputTemp = outputTemp * fp32RmsWeights;
+        outputTemp.select<256, 1>(0) = outputTemp.select<256, 1>(0) * scale;
+
+        // RoPE: read from cos_sin_cache (same as Q)
+        {
+            uint32_t krow_offset = i32RopeCoord * rotaryDim;
+            if (rotaryDim == 64) {
+                simd<fp16, 64> kcs16;
+                kcs16.select<32, 1>(0) = block_load<fp16, 32>(ropeCosSinCache + krow_offset);
+                kcs16.select<32, 1>(32) = block_load<fp16, 32>(ropeCosSinCache + krow_offset + 32);
+                simd<float, 32> kpcos = kcs16.select<32, 1>(0);
+                simd<float, 32> kpsin = kcs16.select<32, 1>(32);
+
+                simd<float, 32> kx1 = outputTemp.select<32, 1>(0);
+                simd<float, 32> kx2 = outputTemp.select<32, 1>(32);
+                outputTemp.select<32, 1>(0)  = kx1 * kpcos - kx2 * kpsin;
+                outputTemp.select<32, 1>(32) = kx2 * kpcos + kx1 * kpsin;
+            } else {
+                simd<float, 128> kfcos, kfsin;
+#pragma unroll
+                for (int kk = 0; kk < 4; kk++) {
+                    simd<fp16, 32> kc16 = block_load<fp16, 32>(ropeCosSinCache + krow_offset + 32 * kk);
+                    kfcos.select<32, 1>(32 * kk) = kc16;
+                }
+#pragma unroll
+                for (int kk = 0; kk < 4; kk++) {
+                    simd<fp16, 32> ks16 = block_load<fp16, 32>(ropeCosSinCache + krow_offset + 128 + 32 * kk);
+                    kfsin.select<32, 1>(32 * kk) = ks16;
+                }
+
+                simd<float, 128> kx1 = outputTemp.select<128, 1>(0);
+                simd<float, 128> kx2 = outputTemp.select<128, 1>(128);
+                outputTemp.select<128, 1>(0)   = kx1 * kfcos - kx2 * kfsin;
+                outputTemp.select<128, 1>(128) = kx2 * kfcos + kx1 * kfsin;
+            }
+        }
+
+        activation = outputTemp;
+        block_store<fp16, 256>((fp16*)kState + outputOffset, activation);
+    }
+    else if (whereAmI == QKV_LOCATION_V) {
+        // V: copy only
+        outputOffset = kvHead * headDim * tokIdx + outHead * headDim;
+        block_store<fp16, 256>((fp16*)vState + outputOffset, activation);
+    }
+}
+
+// Host dispatcher: submits the 2D kernel to the SYCL queue
+inline void qkv_split_norm_rope_host(
+    uint8_t* qkvState,
+    uint8_t* qState,
+    uint8_t* gateState,
+    uint8_t* kState,
+    uint8_t* vState,
+    uint8_t* normWq,
+    uint8_t* normWk,
+    uint32_t* ropePos,
+    fp16* ropeCosSinCache,
+    uint32_t ntoks,
+    uint32_t hiddenDim,
+    uint32_t qHead,
+    uint32_t kvHead,
+    bool attnOutputGate,
+    uint32_t rotaryDim,
+    sycl::queue& q) {
+
+    constexpr uint32_t headDim = 256;
+    uint32_t totalHeads = attnOutputGate
+        ? (2 * qHead + 2 * kvHead)
+        : (qHead + 2 * kvHead);
+
+    sycl::range<2> globalRange(totalHeads, ntoks);
+    sycl::range<2> localRange(1, 1);
+
+    q.submit([&](sycl::handler& cgh) {
+        cgh.parallel_for(
+            sycl::nd_range<2>(globalRange, localRange),
+            [=](sycl::nd_item<2> ndi) SYCL_ESIMD_KERNEL {
+                qkv_split_norm_rope_kernel(
+                    qkvState, qState, gateState, kState, vState,
+                    normWq, normWk, ropePos, ropeCosSinCache,
+                    ntoks, hiddenDim, headDim, qHead, kvHead, rotaryDim, ndi);
+            });
+    });
+}

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/resadd_norm_gemv2_fused.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/resadd_norm_gemv2_fused.h
@@ -1,0 +1,136 @@
+/* resadd_norm_gemv2_fused.h — Fused ResidualAdd + RMSNorm + 2-matrix FP8 GEMV.
+ *
+ * Single-pass: load hidden+residual, compute add, accumulate sum_sq,
+ * normalize, GEMV — all without storing intermediate arrays.
+ *
+ * Key insight: we need sum_sq (from pass 1) before normalizing (pass 2).
+ * But storing all chunks needs too many registers for large K.
+ * Solution: TWO loops over global memory. Pass 1 reads h+r for sum_sq only.
+ * Pass 2 re-reads h+r (from L3), normalizes, does GEMV.
+ * Residual write-back is done by Python caller (residual.add_(hidden)).
+ *
+ * Grid: (N0 + N1) WGs, 1 thread each.
+ */
+
+#pragma once
+#include "utils.h"
+
+template<int VL>
+SYCL_ESIMD_FUNCTION inline simd<float, VL> fp8_dequant_rng2(
+    simd<uint8_t, VL> raw, int fp8_mode) {
+    simd<uint16_t, VL> u16 = convert<uint16_t>(raw);
+    simd<uint16_t, VL> fp8_sign = (u16 >> 7) & 1;
+    simd<uint16_t, VL> fp16_bits;
+    if (fp8_mode == 0) {
+        simd<uint16_t, VL> fp8_exp  = (u16 >> 3) & 0xF;
+        simd<uint16_t, VL> fp8_mant = u16 & 0x7;
+        fp16_bits = (fp8_sign << 15) | ((fp8_exp + 8) << 10) | (fp8_mant << 7);
+        fp16_bits.merge(fp8_sign << 15, fp8_exp == 0);
+    } else {
+        simd<uint16_t, VL> fp8_exp  = (u16 >> 2) & 0x1F;
+        simd<uint16_t, VL> fp8_mant = u16 & 0x3;
+        fp16_bits = (fp8_sign << 15) | (fp8_exp << 10) | (fp8_mant << 8);
+        fp16_bits.merge(fp8_sign << 15, fp8_exp == 0);
+    }
+    simd<fp16, VL> wh = fp16_bits.template bit_cast_view<fp16>().read();
+    return simd<float, VL>(wh);
+}
+
+struct ResAddNormGEMV2_fp8_pert_kernel {
+    const fp16*    hidden_ptr;   // [1, K] — read-only
+    const fp16*    residual_ptr; // [1, K] — read-only (caller updates separately)
+    const fp16*    norm_w_ptr;   // [K]
+    const uint8_t* w0_ptr;       // [N0, K] FP8
+    const float*   s0_ptr;       // [1]
+    fp16*          o0_ptr;       // [1, N0]
+    const uint8_t* w1_ptr;       // [N1, K] FP8
+    const float*   s1_ptr;       // [1]
+    fp16*          o1_ptr;       // [1, N1]
+    int N0, N1, K;
+    float eps;
+    int fp8_mode;
+
+    void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+        int gid = item.get_group(0);
+        int total_N = N0 + N1;
+        if (gid >= total_N) return;
+
+        int mat_idx = (gid < N0) ? 0 : 1;
+        int local_n = (mat_idx == 0) ? gid : gid - N0;
+
+        constexpr int VL = 512;
+        int n_chunks = K / VL;
+
+        // Pass 1: compute sum_sq for RMS
+        float sum_sq = 0.0f;
+        for (int c = 0; c < n_chunks; c++) {
+            int offset = c * VL;
+            simd<float, VL> h = block_load<fp16, VL>(hidden_ptr + offset);
+            simd<float, VL> r = block_load<fp16, VL>(residual_ptr + offset);
+            simd<float, VL> added = h + r;
+
+            simd<float, VL> sq = added * added;
+            sq.select<256,1>(0) += sq.select<256,1>(256);
+            sq.select<128,1>(0) += sq.select<128,1>(128);
+            sq.select<64,1>(0) += sq.select<64,1>(64);
+            sq.select<32,1>(0) += sq.select<32,1>(32);
+            sq.select<16,1>(0) += sq.select<16,1>(16);
+            sq.select<8,1>(0) += sq.select<8,1>(8);
+            sq.select<4,1>(0) += sq.select<4,1>(4);
+            sq.select<2,1>(0) += sq.select<2,1>(2);
+            sum_sq += (float)sq[0] + (float)sq[1];
+        }
+
+        float inv_rms = sycl::ext::intel::esimd::rsqrt(
+            simd<float, 8>(sum_sq / (float)K + eps))[0];
+
+        // Pass 2: re-load h+r (L3 cache hit), normalize, GEMV
+        const uint8_t* w_ptr = (mat_idx == 0) ? w0_ptr : w1_ptr;
+        const float* s_ptr = (mat_idx == 0) ? s0_ptr : s1_ptr;
+        fp16* o_ptr = (mat_idx == 0) ? o0_ptr : o1_ptr;
+
+        simd<float, VL> acc = 0.0f;
+        for (int c = 0; c < n_chunks; c++) {
+            int offset = c * VL;
+
+            simd<float, VL> h = block_load<fp16, VL>(hidden_ptr + offset);
+            simd<float, VL> r = block_load<fp16, VL>(residual_ptr + offset);
+            simd<float, VL> nw = block_load<fp16, VL>(norm_w_ptr + offset);
+            simd<float, VL> normed = (h + r) * inv_rms * nw;
+
+            simd<uint8_t, VL> w_raw = block_load<uint8_t, VL>(
+                w_ptr + (size_t)local_n * K + offset);
+            simd<float, VL> w_f = fp8_dequant_rng2<VL>(w_raw, fp8_mode);
+            acc += normed * w_f;
+        }
+
+        acc.select<256,1>(0) += acc.select<256,1>(256);
+        acc.select<128,1>(0) += acc.select<128,1>(128);
+        acc.select<64,1>(0) += acc.select<64,1>(64);
+        acc.select<32,1>(0) += acc.select<32,1>(32);
+        acc.select<16,1>(0) += acc.select<16,1>(16);
+        acc.select<8,1>(0) += acc.select<8,1>(8);
+        acc.select<4,1>(0) += acc.select<4,1>(4);
+        acc.select<2,1>(0) += acc.select<2,1>(2);
+        float dot = ((float)acc[0] + (float)acc[1]) * *s_ptr;
+        o_ptr[local_n] = fp16(dot);
+    }
+};
+
+inline void resadd_norm_gemv2_fp8_pert_host(
+    const fp16* hidden_ptr, const fp16* residual_ptr, const fp16* norm_w_ptr,
+    const uint8_t* w0, const float* s0, fp16* o0,
+    const uint8_t* w1, const float* s1, fp16* o1,
+    int N0, int N1, int K, float eps, int fp8_mode,
+    sycl::queue& q)
+{
+    int total_N = N0 + N1;
+    q.submit([&](sycl::handler& cgh) {
+        cgh.parallel_for(
+            sycl::nd_range<1>(total_N, 1),
+            ResAddNormGEMV2_fp8_pert_kernel{
+                hidden_ptr, residual_ptr, norm_w_ptr,
+                w0, s0, o0, w1, s1, o1,
+                N0, N1, K, eps, fp8_mode});
+    });
+}

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/resadd_norm_gemv_fused.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/resadd_norm_gemv_fused.h
@@ -1,0 +1,184 @@
+/* resadd_norm_gemv_fused.h — Fused ResidualAdd + RMSNorm + FP8 GEMV.
+ *
+ * Combines three operations into a single kernel:
+ *   1. Residual add: residual = hidden_states + residual  (in-place)
+ *   2. RMSNorm (Gemma-style): normed = residual / rms(residual) * weight
+ *      where weight is pre-adjusted (w+1.0 already applied by caller)
+ *   3. GEMV: output = normed @ dequant(gemv_weight^T) * scale
+ *
+ * Designed for Qwen3-Next post_attention_layernorm + MoE router:
+ *   hidden_states: [1, K] fp16   (K=2048)
+ *   residual:      [1, K] fp16   (updated in-place)
+ *   norm_weight:   [K] fp16      (Gemma _gemma_w = original_w + 1.0)
+ *   gemv_weight:   [N, K] FP8    (N=512 for router)
+ *   gemv_scale:    [1] float32
+ *   output:        [1, N] fp16
+ *
+ * Grid: N work-groups, 1 thread each.
+ * Each WG redundantly computes residual_add + norm (data in L3 cache).
+ * Only WG 0 writes the updated residual back to global memory.
+ *
+ * For K=2048 with VL=512: 4 loop iterations for norm, then 4 for GEMV.
+ * Interleaved approach: compute norm chunk + GEMV chunk per iteration.
+ */
+
+#pragma once
+#include "utils.h"
+
+template<int VL>
+SYCL_ESIMD_FUNCTION inline simd<float, VL> fp8_dequant_rng(
+    simd<uint8_t, VL> raw, int fp8_mode) {
+    simd<uint16_t, VL> u16 = convert<uint16_t>(raw);
+    simd<uint16_t, VL> fp8_sign = (u16 >> 7) & 1;
+    simd<uint16_t, VL> fp16_bits;
+
+    if (fp8_mode == 0) {
+        simd<uint16_t, VL> fp8_exp  = (u16 >> 3) & 0xF;
+        simd<uint16_t, VL> fp8_mant = u16 & 0x7;
+        fp16_bits = (fp8_sign << 15) | ((fp8_exp + 8) << 10) | (fp8_mant << 7);
+        fp16_bits.merge(fp8_sign << 15, fp8_exp == 0);
+    } else {
+        simd<uint16_t, VL> fp8_exp  = (u16 >> 2) & 0x1F;
+        simd<uint16_t, VL> fp8_mant = u16 & 0x3;
+        fp16_bits = (fp8_sign << 15) | (fp8_exp << 10) | (fp8_mant << 8);
+        fp16_bits.merge(fp8_sign << 15, fp8_exp == 0);
+    }
+
+    simd<fp16, VL> wh = fp16_bits.template bit_cast_view<fp16>().read();
+    return simd<float, VL>(wh);
+}
+
+/* ================================================================
+ * Kernel: Fused ResidualAdd + RMSNorm + FP8 GEMV (per-tensor scale)
+ *
+ * Two-pass approach:
+ *   Pass 1: Load hidden+residual, compute residual_add, accumulate
+ *           sum-of-squares for RMS, store normed chunks to registers.
+ *   Pass 2 (fused with pass 1 second half): GEMV dot product.
+ *
+ * Since we need the full RMS before normalizing, we do:
+ *   Loop 1 (K/VL iters): load h+r, add, compute partial sum_sq
+ *   Reduce sum_sq → inv_rms
+ *   Loop 2 (K/VL iters): normalize stored residual, load weight, FMA
+ * ================================================================ */
+struct ResAddNormGEMV_fp8_pert_kernel {
+    fp16*          hidden_ptr;   // [1, K] — input (read-only for this kernel)
+    fp16*          residual_ptr; // [1, K] — updated in-place
+    const fp16*    norm_w_ptr;   // [K] — Gemma norm weight (w+1.0)
+    const uint8_t* gemv_weight;  // [N, K] FP8
+    const float*   gemv_scale;   // [1]
+    fp16*          output;       // [1, N] — router logits
+    fp16*          normed_out;   // [1, K] — normed hidden_states (for MoE experts)
+    int N, K;
+    float eps;
+    int fp8_mode;
+
+    void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+        int n = item.get_group(0);
+        if (n >= N) return;
+
+        // Pass 1: residual_add + accumulate sum_sq
+        // Store the added residual in register arrays for reuse in pass 2.
+        // For K=2048, VL=512: 4 chunks, 4 * 512 * 4 bytes = 8KB registers.
+        // Fits in standard GRF (256 regs × 64 bytes = 16KB).
+
+        float sum_sq = 0.0f;
+
+        // We store residual chunks in a small register-file buffer.
+        // Since VL=512 and K/VL is small (4), unroll explicitly.
+        constexpr int VL = 512;
+        constexpr int MAX_CHUNKS = 8;  // supports up to K=4096
+        simd<float, VL> res_chunks[MAX_CHUNKS];
+        int n_chunks = K / VL;
+
+        for (int c = 0; c < n_chunks; c++) {
+            int offset = c * VL;
+            simd<float, VL> h = block_load<fp16, VL>(hidden_ptr + offset);
+            simd<float, VL> r = block_load<fp16, VL>(residual_ptr + offset);
+
+            // Residual add
+            simd<float, VL> added = h + r;
+            res_chunks[c] = added;
+
+            // Write back residual (only WG 0 to avoid redundant writes)
+            if (n == 0) {
+                block_store<fp16, VL>(residual_ptr + offset, simd<fp16, VL>(added));
+            }
+
+            // Accumulate sum of squares for RMS
+            simd<float, VL> sq = added * added;
+            // Hierarchical reduction within VL=512
+            sq.select<256,1>(0) += sq.select<256,1>(256);
+            sq.select<128,1>(0) += sq.select<128,1>(128);
+            sq.select<64,1>(0) += sq.select<64,1>(64);
+            sq.select<32,1>(0) += sq.select<32,1>(32);
+            sq.select<16,1>(0) += sq.select<16,1>(16);
+            sq.select<8,1>(0) += sq.select<8,1>(8);
+            sq.select<4,1>(0) += sq.select<4,1>(4);
+            sq.select<2,1>(0) += sq.select<2,1>(2);
+            sum_sq += (float)sq[0] + (float)sq[1];
+        }
+
+        // Compute inverse RMS
+        float inv_rms = sycl::ext::intel::esimd::rsqrt(
+            simd<float, 8>(sum_sq / (float)K + eps))[0];
+
+        // Pass 2: normalize + GEMV
+        simd<float, VL> acc = 0.0f;
+
+        for (int c = 0; c < n_chunks; c++) {
+            int offset = c * VL;
+
+            // Normalize: normed = residual * inv_rms * weight
+            simd<float, VL> nw = block_load<fp16, VL>(norm_w_ptr + offset);
+            simd<float, VL> normed = res_chunks[c] * inv_rms * nw;
+
+            // Write normed hidden_states (only WG 0)
+            if (n == 0) {
+                block_store<fp16, VL>(normed_out + offset, simd<fp16, VL>(normed));
+            }
+
+            // GEMV: accumulate dot product
+            simd<uint8_t, VL> w_raw = block_load<uint8_t, VL>(
+                gemv_weight + (size_t)n * K + offset);
+            simd<float, VL> w_f = fp8_dequant_rng<VL>(w_raw, fp8_mode);
+            acc += normed * w_f;
+        }
+
+        // Final reduction
+        acc.select<256,1>(0) += acc.select<256,1>(256);
+        acc.select<128,1>(0) += acc.select<128,1>(128);
+        acc.select<64,1>(0) += acc.select<64,1>(64);
+        acc.select<32,1>(0) += acc.select<32,1>(32);
+        acc.select<16,1>(0) += acc.select<16,1>(16);
+        acc.select<8,1>(0) += acc.select<8,1>(8);
+        acc.select<4,1>(0) += acc.select<4,1>(4);
+        acc.select<2,1>(0) += acc.select<2,1>(2);
+        float dot = ((float)acc[0] + (float)acc[1]) * *gemv_scale;
+        output[n] = fp16(dot);
+    }
+};
+
+/* Host dispatcher */
+inline void resadd_norm_gemv_fp8_pert_host(
+    fp16* hidden_ptr,
+    fp16* residual_ptr,
+    const fp16* norm_w_ptr,
+    const uint8_t* gemv_weight,
+    const float* gemv_scale,
+    fp16* output,
+    fp16* normed_out,
+    int N, int K,
+    float eps,
+    int fp8_mode,
+    sycl::queue& q)
+{
+    q.submit([&](sycl::handler& cgh) {
+        cgh.parallel_for(
+            sycl::nd_range<1>(N, 1),
+            ResAddNormGEMV_fp8_pert_kernel{
+                hidden_ptr, residual_ptr, norm_w_ptr,
+                gemv_weight, gemv_scale, output, normed_out,
+                N, K, eps, fp8_mode});
+    });
+}

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/utils.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/utils.h
@@ -1,0 +1,6 @@
+#include <sycl/sycl.hpp>
+#include <sycl/ext/intel/esimd.hpp>
+
+using namespace sycl::ext::intel::esimd;
+using fp16 = sycl::half;
+using namespace sycl;

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/torch_extension.cc
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/torch_extension.cc
@@ -1,0 +1,78 @@
+#include <ATen/core/dispatch/Dispatcher.h>
+#include <torch/all.h>
+#include <torch/library.h>
+#include <Python.h>
+
+#include "kernel_ops.h"
+
+TORCH_LIBRARY(custom_esimd_kernels_vllm, m) {
+  m.def("esimd_gemv_fp8_pern(Tensor input, Tensor weight, Tensor weight_scale, "
+        "Tensor output, int N, int K) -> Tensor");
+  m.impl("esimd_gemv_fp8_pern", torch::kXPU, &esimd_gemv_fp8_pern);
+
+  m.def("esimd_gemv_fp8_pern_fused2(Tensor input, "
+        "Tensor w0, Tensor s0, Tensor o0, int N0, "
+        "Tensor w1, Tensor s1, Tensor o1, int N1, "
+        "int K) -> Tensor");
+  m.impl("esimd_gemv_fp8_pern_fused2", torch::kXPU, &esimd_gemv_fp8_pern_fused2);
+
+  m.def("esimd_gemv_fp8_pern_fused3(Tensor input, "
+        "Tensor w0, Tensor s0, Tensor o0, int N0, "
+        "Tensor w1, Tensor s1, Tensor o1, int N1, "
+        "Tensor w2, Tensor s2, Tensor o2, int N2, "
+        "int K) -> Tensor");
+  m.impl("esimd_gemv_fp8_pern_fused3", torch::kXPU, &esimd_gemv_fp8_pern_fused3);
+
+  // Per-tensor scale variants (N/K inferred from weight shape)
+  m.def("esimd_gemv_fp8_pert(Tensor input, Tensor weight, Tensor weight_scale, "
+        "Tensor output) -> Tensor");
+  m.impl("esimd_gemv_fp8_pert", torch::kXPU, &esimd_gemv_fp8_pert);
+
+  m.def("esimd_gemv_fp8_pert_fused2(Tensor input, "
+        "Tensor w0, Tensor s0, Tensor o0, "
+        "Tensor w1, Tensor s1, Tensor o1) -> Tensor");
+  m.impl("esimd_gemv_fp8_pert_fused2", torch::kXPU, &esimd_gemv_fp8_pert_fused2);
+
+  m.def("esimd_gemv_fp8_pert_fused3(Tensor input, "
+        "Tensor w0, Tensor s0, Tensor o0, "
+        "Tensor w1, Tensor s1, Tensor o1, "
+        "Tensor w2, Tensor s2, Tensor o2) -> Tensor");
+  m.impl("esimd_gemv_fp8_pert_fused3", torch::kXPU, &esimd_gemv_fp8_pert_fused3);
+
+  // Fused QKV Split + RMSNorm + RoPE
+  m.def("esimd_qkv_split_norm_rope(Tensor qkv_state, "
+        "Tensor q_out, Tensor gate_out, Tensor k_out, Tensor v_out, "
+        "Tensor norm_wq, Tensor norm_wk, Tensor positions, "
+        "int q_heads, int kv_heads, bool attn_output_gate, "
+        "int rotary_dim, Tensor cos_sin_cache) -> Tensor");
+  m.impl("esimd_qkv_split_norm_rope", torch::kXPU, &esimd_qkv_split_norm_rope);
+
+  // Fused ResidualAdd + RMSNorm + FP8 GEMV (post_attn_norm + router)
+  m.def("esimd_resadd_norm_gemv_fp8_pert(Tensor hidden_states, Tensor residual, "
+        "Tensor norm_weight, Tensor gemv_weight, Tensor gemv_scale, "
+        "Tensor output, Tensor normed_out, float eps) -> Tensor");
+  m.impl("esimd_resadd_norm_gemv_fp8_pert", torch::kXPU, &esimd_resadd_norm_gemv_fp8_pert);
+
+  // Fused ResidualAdd + RMSNorm + 2-matrix FP8 GEMV (input_norm + GDN in_proj)
+  m.def("esimd_resadd_norm_gemv2_fp8_pert(Tensor hidden_states, Tensor residual, "
+        "Tensor norm_weight, "
+        "Tensor w0, Tensor s0, Tensor o0, "
+        "Tensor w1, Tensor s1, Tensor o1, "
+        "float eps) -> Tensor");
+  m.impl("esimd_resadd_norm_gemv2_fp8_pert", torch::kXPU, &esimd_resadd_norm_gemv2_fp8_pert);
+
+  // Fused RMSNormGated + FP8 GEMV (out_proj for GDN layers)
+  m.def("esimd_norm_gemv_fp8_pert(Tensor x, Tensor z, Tensor norm_weight, "
+        "Tensor gemv_weight, Tensor gemv_scale, Tensor output, "
+        "int HV, int V, float eps) -> Tensor");
+  m.impl("esimd_norm_gemv_fp8_pert", torch::kXPU, &esimd_norm_gemv_fp8_pert);
+
+  m.def("esimd_fused_add_rms_norm(Tensor hidden_states, Tensor residual, "
+        "Tensor weight, float eps) -> Tensor");
+  m.impl("esimd_fused_add_rms_norm", torch::kXPU, &esimd_fused_add_rms_norm);
+}
+
+PyMODINIT_FUNC PyInit_custom_esimd_kernels() {
+    static struct PyModuleDef module = {PyModuleDef_HEAD_INIT, "custom_esimd_kernels", nullptr, 0, nullptr};
+    return PyModule_Create(&module);
+}

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/torch_extension_gemm.cc
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/torch_extension_gemm.cc
@@ -1,0 +1,24 @@
+/* torch_extension_gemm.cc — Op registration for FP8 GEMM (M>1) ESIMD kernels.
+ * Uses TORCH_LIBRARY_FRAGMENT to add ops to the existing library namespace.
+ */
+#include <ATen/core/dispatch/Dispatcher.h>
+#include <torch/all.h>
+#include <torch/library.h>
+#include <Python.h>
+
+#include "kernel_ops.h"
+
+TORCH_LIBRARY_FRAGMENT(custom_esimd_kernels_vllm, m) {
+  // FP8 GEMM per-tensor scale: input [M, K] fp16, weight [N, K] fp8, output [M, N] fp16
+  // Auto-dispatches based on M: GEMV for M<=3, DPAS for M>=2 (E4M3), WS fallback
+  m.def("esimd_gemm_fp8_pert(Tensor input, Tensor weight, Tensor weight_scale, "
+        "Tensor output) -> Tensor");
+  m.impl("esimd_gemm_fp8_pert", torch::kXPU, &esimd_gemm_fp8_pert);
+}
+
+PyMODINIT_FUNC PyInit_custom_esimd_kernels_gemm() {
+    static struct PyModuleDef module = {
+        PyModuleDef_HEAD_INIT, "custom_esimd_kernels_gemm", nullptr, 0, nullptr
+    };
+    return PyModule_Create(&module);
+}

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/torch_extension_lgrf.cc
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/torch_extension_lgrf.cc
@@ -1,0 +1,40 @@
+/* torch_extension_lgrf.cc — Op registration for doubleGRF ESIMD kernels.
+ * Uses TORCH_LIBRARY_FRAGMENT to add ops to the existing library namespace.
+ */
+#include <ATen/core/dispatch/Dispatcher.h>
+#include <torch/all.h>
+#include <torch/library.h>
+#include <Python.h>
+
+#include "kernel_ops.h"
+
+TORCH_LIBRARY_FRAGMENT(custom_esimd_kernels_vllm, m) {
+  m.def("esimd_gdn_conv_fused(Tensor qkvz, "
+        "Tensor conv_state, Tensor conv_weight, Tensor conv_bias, "
+        "Tensor conv_state_indices, "
+        "Tensor A_log, Tensor dt_bias, "
+        "Tensor ba, "
+        "Tensor ssm_state, Tensor ssm_state_indices, "
+        "Tensor output, Tensor z_out, "
+        "int N, int H, int HV, int K, int V, "
+        "float scale) -> Tensor");
+  m.impl("esimd_gdn_conv_fused", torch::kXPU, &esimd_gdn_conv_fused);
+
+  m.def("esimd_gdn_conv_fused_seq(Tensor qkvz, "
+        "Tensor conv_state, Tensor conv_weight, Tensor conv_bias, "
+        "Tensor conv_state_indices, "
+        "Tensor A_log, Tensor dt_bias, "
+        "Tensor ba, "
+        "Tensor ssm_state, Tensor ssm_state_indices, "
+        "Tensor output, Tensor z_out, "
+        "int N, int H, int HV, int K, int V, "
+        "float scale) -> Tensor");
+  m.impl("esimd_gdn_conv_fused_seq", torch::kXPU, &esimd_gdn_conv_fused_seq);
+}
+
+PyMODINIT_FUNC PyInit_custom_esimd_kernels_lgrf() {
+    static struct PyModuleDef module = {
+        PyModuleDef_HEAD_INIT, "custom_esimd_kernels_lgrf", nullptr, 0, nullptr
+    };
+    return PyModule_Create(&module);
+}

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/torch_extension_moe.cc
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/torch_extension_moe.cc
@@ -1,0 +1,55 @@
+/* torch_extension_moe.cc — Op registration for MoE ESIMD kernels (standard GRF).
+ * Uses TORCH_LIBRARY_FRAGMENT to add ops to the existing library namespace.
+ */
+#include <ATen/core/dispatch/Dispatcher.h>
+#include <torch/all.h>
+#include <torch/library.h>
+#include <Python.h>
+
+#include "kernel_ops.h"
+
+TORCH_LIBRARY_FRAGMENT(custom_esimd_kernels_vllm, m) {
+  // MoE ops — compiled without doubleGRF for 2× occupancy
+  m.def("esimd_moe_topk(Tensor router_logits, Tensor top_values, "
+        "Tensor top_indices, int T) -> Tensor");
+  m.impl("esimd_moe_topk", torch::kXPU, &esimd_moe_topk);
+
+  m.def("esimd_moe_scatter(Tensor hidden_states, Tensor router_top_value, "
+        "Tensor sorted_token_ids, "
+        "Tensor scattered_hidden, Tensor scattered_weights, "
+        "int K, int topk, int total_expanded) -> Tensor");
+  m.impl("esimd_moe_scatter", torch::kXPU, &esimd_moe_scatter);
+
+  m.def("esimd_moe_scatter_fused(Tensor hidden_states, Tensor top_values, "
+        "Tensor top_indices, "
+        "Tensor scattered_hidden, Tensor scattered_weights, "
+        "Tensor topk_ids, Tensor expert_start, Tensor max_tokens_out, "
+        "int K, int topk, int T, int num_experts) -> Tensor");
+  m.impl("esimd_moe_scatter_fused", torch::kXPU, &esimd_moe_scatter_fused);
+
+  m.def("esimd_moe_silu_mul(Tensor input, Tensor output, "
+        "int N_gate_up, int N_half, int total_rows) -> Tensor");
+  m.impl("esimd_moe_silu_mul", torch::kXPU, &esimd_moe_silu_mul);
+
+  m.def("esimd_moe_gather(Tensor moe_output, Tensor topk_ids, "
+        "Tensor scattered_weights, Tensor final_hidden, "
+        "int K, int topk, int T) -> Tensor");
+  m.impl("esimd_moe_gather", torch::kXPU, &esimd_moe_gather);
+
+  m.def("esimd_moe_gemm_fp8(Tensor input, Tensor weight, Tensor scale, "
+        "Tensor output, Tensor expert_idx, "
+        "int N, int K, int num_experts, int max_tokens_per_expert) -> Tensor");
+  m.impl("esimd_moe_gemm_fp8", torch::kXPU, &esimd_moe_gemm_fp8);
+
+  m.def("esimd_moe_gemm_fp8_pert(Tensor input, Tensor weight, Tensor scale, "
+        "Tensor output, Tensor expert_idx, "
+        "int N, int K, int num_experts, int max_tokens_per_expert) -> Tensor");
+  m.impl("esimd_moe_gemm_fp8_pert", torch::kXPU, &esimd_moe_gemm_fp8_pert);
+}
+
+PyMODINIT_FUNC PyInit_custom_esimd_kernels_moe() {
+    static struct PyModuleDef module = {
+        PyModuleDef_HEAD_INIT, "custom_esimd_kernels_moe", nullptr, 0, nullptr
+    };
+    return PyModule_Create(&module);
+}

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/torch_extension_topk_v2.cc
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/torch_extension_topk_v2.cc
@@ -1,0 +1,23 @@
+/* torch_extension_topk_v2.cc — Standalone registration for TopK V2 */
+#include <ATen/core/dispatch/Dispatcher.h>
+#include <torch/all.h>
+#include <torch/library.h>
+#include <Python.h>
+
+// Forward declaration
+at::Tensor esimd_moe_topk_v2(
+    at::Tensor router_logits, at::Tensor top_values, at::Tensor top_indices,
+    int64_t T, int64_t num_experts, int64_t topk);
+
+TORCH_LIBRARY(esimd_topk_v2, m) {
+  m.def("topk_v2(Tensor router_logits, Tensor top_values, "
+        "Tensor top_indices, int T, int num_experts, int topk) -> Tensor");
+  m.impl("topk_v2", torch::kXPU, &esimd_moe_topk_v2);
+}
+
+PyMODINIT_FUNC PyInit_esimd_topk_v2() {
+    static struct PyModuleDef module = {
+        PyModuleDef_HEAD_INIT, "esimd_topk_v2", nullptr, 0, nullptr
+    };
+    return PyModule_Create(&module);
+}

--- a/vllm/custom-esimd-kernels-vllm/esimd_build_extention.py
+++ b/vllm/custom-esimd-kernels-vllm/esimd_build_extention.py
@@ -1,0 +1,2911 @@
+# mypy: allow-untyped-defs
+import copy
+import glob
+import importlib
+import importlib.abc
+import os
+import re
+import shlex
+import shutil
+import setuptools
+import subprocess
+import sys
+import sysconfig
+import warnings
+import collections
+from pathlib import Path
+import errno
+
+import torch
+import torch._appdirs
+# from .file_baton import FileBaton
+# from ._cpp_extension_versioner import ExtensionVersioner
+# from .hipify import hipify_python
+# from .hipify.hipify_python import GeneratedFileCleaner
+from typing import Optional, Union
+from torch.torch_version import TorchVersion, Version
+
+from setuptools.command.build_ext import build_ext
+
+IS_WINDOWS = sys.platform == 'win32'
+IS_MACOS = sys.platform.startswith('darwin')
+IS_LINUX = sys.platform.startswith('linux')
+LIB_EXT = '.pyd' if IS_WINDOWS else '.so'
+EXEC_EXT = '.exe' if IS_WINDOWS else ''
+CLIB_PREFIX = '' if IS_WINDOWS else 'lib'
+CLIB_EXT = '.dll' if IS_WINDOWS else '.so'
+SHARED_FLAG = '/DLL' if IS_WINDOWS else '-shared'
+
+_HERE = os.path.abspath(__file__)
+_TORCH_PATH = os.path.dirname(os.path.dirname(_HERE))
+TORCH_LIB_PATH = os.path.join(_TORCH_PATH, 'lib')
+
+
+SUBPROCESS_DECODE_ARGS = ('oem',) if IS_WINDOWS else ()
+MINIMUM_GCC_VERSION = (5, 0, 0)
+MINIMUM_MSVC_VERSION = (19, 0, 24215)
+
+VersionRange = tuple[tuple[int, ...], tuple[int, ...]]
+VersionMap = dict[str, VersionRange]
+# The following values were taken from the following GitHub gist that
+# summarizes the minimum valid major versions of g++/clang++ for each supported
+# CUDA version: https://gist.github.com/ax3l/9489132
+# Or from include/crt/host_config.h in the CUDA SDK
+# The second value is the exclusive(!) upper bound, i.e. min <= version < max
+CUDA_GCC_VERSIONS: VersionMap = {
+    '11.0': (MINIMUM_GCC_VERSION, (10, 0)),
+    '11.1': (MINIMUM_GCC_VERSION, (11, 0)),
+    '11.2': (MINIMUM_GCC_VERSION, (11, 0)),
+    '11.3': (MINIMUM_GCC_VERSION, (11, 0)),
+    '11.4': ((6, 0, 0), (12, 0)),
+    '11.5': ((6, 0, 0), (12, 0)),
+    '11.6': ((6, 0, 0), (12, 0)),
+    '11.7': ((6, 0, 0), (12, 0)),
+}
+
+MINIMUM_CLANG_VERSION = (3, 3, 0)
+CUDA_CLANG_VERSIONS: VersionMap = {
+    '11.1': (MINIMUM_CLANG_VERSION, (11, 0)),
+    '11.2': (MINIMUM_CLANG_VERSION, (12, 0)),
+    '11.3': (MINIMUM_CLANG_VERSION, (12, 0)),
+    '11.4': (MINIMUM_CLANG_VERSION, (13, 0)),
+    '11.5': (MINIMUM_CLANG_VERSION, (13, 0)),
+    '11.6': (MINIMUM_CLANG_VERSION, (14, 0)),
+    '11.7': (MINIMUM_CLANG_VERSION, (14, 0)),
+}
+
+__all__ = ["get_default_build_root", "check_compiler_ok_for_platform", "get_compiler_abi_compatibility_and_version", "BuildExtension",
+           "CppExtension", "CUDAExtension", "SyclExtension", "include_paths", "library_paths", "load", "load_inline", "is_ninja_available",
+           "verify_ninja_availability", "remove_extension_h_precompiler_headers", "get_cxx_compiler", "check_compiler_is_gcc"]
+# Taken directly from python stdlib < 3.9
+# See https://github.com/pytorch/pytorch/issues/48617
+def _nt_quote_args(args: Optional[list[str]]) -> list[str]:
+    """Quote command-line arguments for DOS/Windows conventions.
+
+    Just wraps every argument which contains blanks in double quotes, and
+    returns a new argument list.
+    """
+    # Cover None-type
+    if not args:
+        return []
+    return [f'"{arg}"' if ' ' in arg else arg for arg in args]
+
+def _find_cuda_home() -> Optional[str]:
+    """Find the CUDA install path."""
+    # Guess #1
+    cuda_home = os.environ.get('CUDA_HOME') or os.environ.get('CUDA_PATH')
+    if cuda_home is None:
+        # Guess #2
+        nvcc_path = shutil.which("nvcc")
+        if nvcc_path is not None:
+            cuda_home = os.path.dirname(os.path.dirname(nvcc_path))
+        else:
+            # Guess #3
+            if IS_WINDOWS:
+                cuda_homes = glob.glob(
+                    'C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v*.*')
+                if len(cuda_homes) == 0:
+                    cuda_home = ''
+                else:
+                    cuda_home = cuda_homes[0]
+            else:
+                cuda_home = '/usr/local/cuda'
+            if not os.path.exists(cuda_home):
+                cuda_home = None
+    if cuda_home and not torch.cuda.is_available():
+        print(f"No CUDA runtime is found, using CUDA_HOME='{cuda_home}'",
+              file=sys.stderr)
+    return cuda_home
+
+def _find_rocm_home() -> Optional[str]:
+    """Find the ROCm install path."""
+    # Guess #1
+    rocm_home = os.environ.get('ROCM_HOME') or os.environ.get('ROCM_PATH')
+    if rocm_home is None:
+        # Guess #2
+        hipcc_path = shutil.which('hipcc')
+        if hipcc_path is not None:
+            rocm_home = os.path.dirname(os.path.dirname(
+                os.path.realpath(hipcc_path)))
+            # can be either <ROCM_HOME>/hip/bin/hipcc or <ROCM_HOME>/bin/hipcc
+            if os.path.basename(rocm_home) == 'hip':
+                rocm_home = os.path.dirname(rocm_home)
+        else:
+            # Guess #3
+            fallback_path = '/opt/rocm'
+            if os.path.exists(fallback_path):
+                rocm_home = fallback_path
+    if rocm_home and torch.version.hip is None:
+        print(f"No ROCm runtime is found, using ROCM_HOME='{rocm_home}'",
+              file=sys.stderr)
+    return rocm_home
+
+def _find_sycl_home() -> Optional[str]:
+    sycl_home = None
+    icpx_path = shutil.which('icpx')
+    # Guess 1: for source code build developer/user, we'll have icpx in PATH,
+    # which will tell us the SYCL_HOME location.
+    if icpx_path is not None:
+        sycl_home = os.path.dirname(os.path.dirname(
+            os.path.realpath(icpx_path)))
+
+    # Guess 2: for users install Pytorch with XPU support, the sycl runtime is
+    # inside intel-sycl-rt, which is automatically installed via pip dependency.
+    else:
+        try:
+            files = importlib.metadata.files('intel-sycl-rt') or []
+            for f in files:
+                if f.name == "libsycl.so":
+                    sycl_home = os.path.dirname(Path(f.locate()).parent.resolve())
+                    break
+        except importlib.metadata.PackageNotFoundError:
+            print("Trying to find SYCL_HOME from intel-sycl-rt package, but it is not installed.",
+                  file=sys.stderr)
+    return sycl_home
+
+def _join_rocm_home(*paths) -> str:
+    """
+    Join paths with ROCM_HOME, or raises an error if it ROCM_HOME is not set.
+
+    This is basically a lazy way of raising an error for missing $ROCM_HOME
+    only once we need to get any ROCm-specific path.
+    """
+    if ROCM_HOME is None:
+        raise OSError('ROCM_HOME environment variable is not set. '
+                      'Please set it to your ROCm install root.')
+    elif IS_WINDOWS:
+        raise OSError('Building PyTorch extensions using '
+                      'ROCm and Windows is not supported.')
+    return os.path.join(ROCM_HOME, *paths)
+
+def _join_sycl_home(*paths) -> str:
+    """
+    Join paths with SYCL_HOME, or raises an error if it SYCL_HOME is not found.
+
+    This is basically a lazy way of raising an error for missing SYCL_HOME
+    only once we need to get any SYCL-specific path.
+    """
+    if SYCL_HOME is None:
+        raise OSError('SYCL runtime is not dected. Please setup the pytorch '
+                      'prerequisites for Intel GPU following the instruction in '
+                      'https://github.com/pytorch/pytorch?tab=readme-ov-file#intel-gpu-support '
+                      'or install intel-sycl-rt via pip.')
+
+    return os.path.join(SYCL_HOME, *paths)
+
+
+
+ABI_INCOMPATIBILITY_WARNING = '''
+
+                               !! WARNING !!
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+Your compiler ({}) may be ABI-incompatible with PyTorch!
+Please use a compiler that is ABI-compatible with GCC 5.0 and above.
+See https://gcc.gnu.org/onlinedocs/libstdc++/manual/abi.html.
+
+See https://gist.github.com/goldsborough/d466f43e8ffc948ff92de7486c5216d6
+for instructions on how to install GCC 5 or higher.
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+                              !! WARNING !!
+'''
+WRONG_COMPILER_WARNING = '''
+
+                               !! WARNING !!
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+Your compiler ({user_compiler}) is not compatible with the compiler Pytorch was
+built with for this platform, which is {pytorch_compiler} on {platform}. Please
+use {pytorch_compiler} to to compile your extension. Alternatively, you may
+compile PyTorch from source using {user_compiler}, and then you can also use
+{user_compiler} to compile your extension.
+
+See https://github.com/pytorch/pytorch/blob/master/CONTRIBUTING.md for help
+with compiling PyTorch from source.
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+                              !! WARNING !!
+'''
+CUDA_MISMATCH_MESSAGE = '''
+The detected CUDA version ({0}) mismatches the version that was used to compile
+PyTorch ({1}). Please make sure to use the same CUDA versions.
+'''
+CUDA_MISMATCH_WARN = "The detected CUDA version ({0}) has a minor version mismatch with the version that was used to compile PyTorch ({1}). Most likely this shouldn't be a problem."
+CUDA_NOT_FOUND_MESSAGE = '''
+CUDA was not found on the system, please set the CUDA_HOME or the CUDA_PATH
+environment variable or add NVCC to your system PATH. The extension compilation will fail.
+'''
+ROCM_HOME = _find_rocm_home()
+HIP_HOME = _join_rocm_home('hip') if ROCM_HOME else None
+IS_HIP_EXTENSION = True if ((ROCM_HOME is not None) and (torch.version.hip is not None)) else False
+ROCM_VERSION = None
+if torch.version.hip is not None:
+    ROCM_VERSION = tuple(int(v) for v in torch.version.hip.split('.')[:2])
+
+CUDA_HOME = _find_cuda_home() if torch.cuda._is_compiled() else None
+CUDNN_HOME = os.environ.get('CUDNN_HOME') or os.environ.get('CUDNN_PATH')
+SYCL_HOME = _find_sycl_home() if torch.xpu._is_compiled() else None
+
+# PyTorch releases have the version pattern major.minor.patch, whereas when
+# PyTorch is built from source, we append the git commit hash, which gives
+# it the below pattern.
+BUILT_FROM_SOURCE_VERSION_PATTERN = re.compile(r'\d+\.\d+\.\d+\w+\+\w+')
+
+COMMON_MSVC_FLAGS = ['/MD', '/wd4819', '/wd4251', '/wd4244', '/wd4267', '/wd4275', '/wd4018', '/wd4190', '/wd4624', '/wd4067', '/wd4068', '/EHsc']
+
+MSVC_IGNORE_CUDAFE_WARNINGS = [
+    'base_class_has_different_dll_interface',
+    'field_without_dll_interface',
+    'dll_interface_conflict_none_assumed',
+    'dll_interface_conflict_dllexport_assumed'
+]
+
+COMMON_NVCC_FLAGS = [
+    '-D__CUDA_NO_HALF_OPERATORS__',
+    '-D__CUDA_NO_HALF_CONVERSIONS__',
+    '-D__CUDA_NO_BFLOAT16_CONVERSIONS__',
+    '-D__CUDA_NO_HALF2_OPERATORS__',
+    '--expt-relaxed-constexpr'
+]
+
+COMMON_HIP_FLAGS = [
+    '-fPIC',
+    '-D__HIP_PLATFORM_AMD__=1',
+    '-DUSE_ROCM=1',
+    '-DHIPBLAS_V2',
+]
+
+COMMON_HIPCC_FLAGS = [
+    '-DCUDA_HAS_FP16=1',
+    '-D__HIP_NO_HALF_OPERATORS__=1',
+    '-D__HIP_NO_HALF_CONVERSIONS__=1',
+]
+
+_COMMON_SYCL_FLAGS = [
+    '-fsycl',
+    '-fsycl-targets=spir64_gen,spir64',
+]
+
+def _get_sycl_arch_list():
+    if 'TORCH_XPU_ARCH_LIST' in os.environ:
+        return os.environ.get('TORCH_XPU_ARCH_LIST')
+    arch_list = torch.xpu.get_arch_list()
+    # Dropping dg2-* archs since they lack hardware support for fp64 and require
+    # special consideration from the user. If needed these platforms can
+    # be requested thru TORCH_XPU_ARCH_LIST environment variable.
+    arch_list = [x for x in arch_list if not x.startswith('dg2-')]
+    return ','.join(arch_list)
+
+_SYCL_DLINK_FLAGS = [
+    *_COMMON_SYCL_FLAGS,
+    '-fsycl-link',
+    '--offload-compress',
+    f'-Xs "-device {_get_sycl_arch_list()}"',
+]
+
+# JIT_EXTENSION_VERSIONER = ExtensionVersioner()
+
+PLAT_TO_VCVARS = {
+    'win32' : 'x86',
+    'win-amd64' : 'x86_amd64',
+}
+
+min_supported_cpython = "0x03090000"  # Python 3.9 hexcode
+
+def get_cxx_compiler():
+    if IS_WINDOWS:
+        compiler = os.environ.get('CXX', 'cl')
+    else:
+        compiler = os.environ.get('CXX', 'c++')
+    return compiler
+
+def _is_binary_build() -> bool:
+    return not BUILT_FROM_SOURCE_VERSION_PATTERN.match(torch.version.__version__)
+
+
+def _accepted_compilers_for_platform() -> list[str]:
+    # gnu-c++ and gnu-cc are the conda gcc compilers
+    return ['clang++', 'clang'] if IS_MACOS else ['g++', 'gcc', 'gnu-c++', 'gnu-cc', 'clang++', 'clang']
+
+def _maybe_write(filename, new_content):
+    r'''
+    Equivalent to writing the content into the file but will not touch the file
+    if it already had the right content (to avoid triggering recompile).
+    '''
+    if os.path.exists(filename):
+        with open(filename) as f:
+            content = f.read()
+
+        if content == new_content:
+            # The file already contains the right thing!
+            return
+
+    with open(filename, 'w') as source_file:
+        source_file.write(new_content)
+
+def get_default_build_root() -> str:
+    """
+    Return the path to the root folder under which extensions will built.
+
+    For each extension module built, there will be one folder underneath the
+    folder returned by this function. For example, if ``p`` is the path
+    returned by this function and ``ext`` the name of an extension, the build
+    folder for the extension will be ``p/ext``.
+
+    This directory is **user-specific** so that multiple users on the same
+    machine won't meet permission issues.
+    """
+    return os.path.realpath(torch._appdirs.user_cache_dir(appname='torch_extensions'))
+
+
+def check_compiler_ok_for_platform(compiler: str) -> bool:
+    """
+    Verify that the compiler is the expected one for the current platform.
+
+    Args:
+        compiler (str): The compiler executable to check.
+
+    Returns:
+        True if the compiler is gcc/g++ on Linux or clang/clang++ on macOS,
+        and always True for Windows.
+    """
+    if IS_WINDOWS:
+        return True
+    compiler_path = shutil.which(compiler)
+    if compiler_path is None:
+        return False
+    # Use os.path.realpath to resolve any symlinks, in particular from 'c++' to e.g. 'g++'.
+    compiler_path = os.path.realpath(compiler_path)
+    # Check the compiler name
+    if any(name in compiler_path for name in _accepted_compilers_for_platform()):
+        return True
+    # If compiler wrapper is used try to infer the actual compiler by invoking it with -v flag
+    env = os.environ.copy()
+    env['LC_ALL'] = 'C'  # Don't localize output
+    version_string = subprocess.check_output([compiler, '-v'], stderr=subprocess.STDOUT, env=env).decode(*SUBPROCESS_DECODE_ARGS)
+    if IS_LINUX:
+        # Check for 'gcc' or 'g++' for sccache wrapper
+        pattern = re.compile("^COLLECT_GCC=(.*)$", re.MULTILINE)
+        results = re.findall(pattern, version_string)
+        if len(results) != 1:
+            # Clang is also a supported compiler on Linux
+            # Though on Ubuntu it's sometimes called "Ubuntu clang version"
+            return 'clang version' in version_string
+        compiler_path = os.path.realpath(results[0].strip())
+        # On RHEL/CentOS c++ is a gcc compiler wrapper
+        if os.path.basename(compiler_path) == 'c++' and 'gcc version' in version_string:
+            return True
+        return any(name in compiler_path for name in _accepted_compilers_for_platform())
+    if IS_MACOS:
+        # Check for 'clang' or 'clang++'
+        return version_string.startswith("Apple clang")
+    return False
+
+
+def get_compiler_abi_compatibility_and_version(compiler) -> tuple[bool, TorchVersion]:
+    """
+    Determine if the given compiler is ABI-compatible with PyTorch alongside its version.
+
+    Args:
+        compiler (str): The compiler executable name to check (e.g. ``g++``).
+            Must be executable in a shell process.
+
+    Returns:
+        A tuple that contains a boolean that defines if the compiler is (likely) ABI-incompatible with PyTorch,
+        followed by a `TorchVersion` string that contains the compiler version separated by dots.
+    """
+    if not _is_binary_build():
+        return (True, TorchVersion('0.0.0'))
+    if os.environ.get('TORCH_DONT_CHECK_COMPILER_ABI') in ['ON', '1', 'YES', 'TRUE', 'Y']:
+        return (True, TorchVersion('0.0.0'))
+
+    # First check if the compiler is one of the expected ones for the particular platform.
+    if not check_compiler_ok_for_platform(compiler):
+        warnings.warn(WRONG_COMPILER_WARNING.format(
+            user_compiler=compiler,
+            pytorch_compiler=_accepted_compilers_for_platform()[0],
+            platform=sys.platform))
+        return (False, TorchVersion('0.0.0'))
+
+    if IS_MACOS:
+        # There is no particular minimum version we need for clang, so we're good here.
+        return (True, TorchVersion('0.0.0'))
+    try:
+        if IS_LINUX:
+            minimum_required_version = MINIMUM_GCC_VERSION
+            versionstr = subprocess.check_output([compiler, '-dumpfullversion', '-dumpversion'])
+            version = versionstr.decode(*SUBPROCESS_DECODE_ARGS).strip().split('.')
+        else:
+            minimum_required_version = MINIMUM_MSVC_VERSION
+            compiler_info = subprocess.check_output(compiler, stderr=subprocess.STDOUT)
+            match = re.search(r'(\d+)\.(\d+)\.(\d+)', compiler_info.decode(*SUBPROCESS_DECODE_ARGS).strip())
+            version = ['0', '0', '0'] if match is None else list(match.groups())
+    except Exception:
+        _, error, _ = sys.exc_info()
+        warnings.warn(f'Error checking compiler version for {compiler}: {error}')
+        return (False, TorchVersion('0.0.0'))
+
+    if tuple(map(int, version)) >= minimum_required_version:
+        return (True, TorchVersion('.'.join(version)))
+
+    compiler = f'{compiler} {".".join(version)}'
+    warnings.warn(ABI_INCOMPATIBILITY_WARNING.format(compiler))
+
+    return (False, TorchVersion('.'.join(version)))
+
+
+def _check_cuda_version(compiler_name: str, compiler_version: TorchVersion) -> None:
+    if not CUDA_HOME:
+        raise RuntimeError(CUDA_NOT_FOUND_MESSAGE)
+
+    nvcc = os.path.join(CUDA_HOME, 'bin', 'nvcc')
+    cuda_version_str = subprocess.check_output([nvcc, '--version']).strip().decode(*SUBPROCESS_DECODE_ARGS)
+    cuda_version = re.search(r'release (\d+[.]\d+)', cuda_version_str)
+    if cuda_version is None:
+        return
+
+    cuda_str_version = cuda_version.group(1)
+    cuda_ver = Version(cuda_str_version)
+    if torch.version.cuda is None:
+        return
+
+    torch_cuda_version = Version(torch.version.cuda)
+    if cuda_ver != torch_cuda_version:
+        # major/minor attributes are only available in setuptools>=49.4.0
+        if getattr(cuda_ver, "major", None) is None:
+            raise ValueError("setuptools>=49.4.0 is required")
+        if cuda_ver.major != torch_cuda_version.major:
+            raise RuntimeError(CUDA_MISMATCH_MESSAGE.format(cuda_str_version, torch.version.cuda))
+        warnings.warn(CUDA_MISMATCH_WARN.format(cuda_str_version, torch.version.cuda))
+
+    if not (sys.platform.startswith('linux') and
+            os.environ.get('TORCH_DONT_CHECK_COMPILER_ABI') not in ['ON', '1', 'YES', 'TRUE', 'Y'] and
+            _is_binary_build()):
+        return
+
+    cuda_compiler_bounds: VersionMap = CUDA_CLANG_VERSIONS if compiler_name.startswith('clang') else CUDA_GCC_VERSIONS
+
+    if cuda_str_version not in cuda_compiler_bounds:
+        warnings.warn(f'There are no {compiler_name} version bounds defined for CUDA version {cuda_str_version}')
+    else:
+        min_compiler_version, max_excl_compiler_version = cuda_compiler_bounds[cuda_str_version]
+        # Special case for 11.4.0, which has lower compiler bounds than 11.4.1
+        if "V11.4.48" in cuda_version_str and cuda_compiler_bounds == CUDA_GCC_VERSIONS:
+            max_excl_compiler_version = (11, 0)
+        min_compiler_version_str = '.'.join(map(str, min_compiler_version))
+        max_excl_compiler_version_str = '.'.join(map(str, max_excl_compiler_version))
+
+        version_bound_str = f'>={min_compiler_version_str}, <{max_excl_compiler_version_str}'
+
+        if compiler_version < TorchVersion(min_compiler_version_str):
+            raise RuntimeError(
+                f'The current installed version of {compiler_name} ({compiler_version}) is less '
+                f'than the minimum required version by CUDA {cuda_str_version} ({min_compiler_version_str}). '
+                f'Please make sure to use an adequate version of {compiler_name} ({version_bound_str}).'
+            )
+        if compiler_version >= TorchVersion(max_excl_compiler_version_str):
+            raise RuntimeError(
+                f'The current installed version of {compiler_name} ({compiler_version}) is greater '
+                f'than the maximum required version by CUDA {cuda_str_version}. '
+                f'Please make sure to use an adequate version of {compiler_name} ({version_bound_str}).'
+            )
+
+
+def _append_sycl_std_if_no_std_present(cflags):
+    if not any(flag.startswith('-sycl-std=') for flag in cflags):
+        cflags.append('-sycl-std=2020')
+
+
+def _wrap_sycl_host_flags(cflags):
+    host_cxx = get_cxx_compiler()
+    host_cflags = [
+        f'-fsycl-host-compiler={host_cxx}',
+        shlex.quote(f'-fsycl-host-compiler-options={cflags}'),
+    ]
+    return host_cflags
+
+
+class BuildExtension(build_ext):
+    """
+    A custom :mod:`setuptools` build extension .
+
+    This :class:`setuptools.build_ext` subclass takes care of passing the
+    minimum required compiler flags (e.g. ``-std=c++17``) as well as mixed
+    C++/CUDA/SYCL compilation (and support for CUDA/SYCL files in general).
+
+    When using :class:`BuildExtension`, it is allowed to supply a dictionary
+    for ``extra_compile_args`` (rather than the usual list) that maps from
+    languages/compilers (the only expected values are ``cxx``, ``nvcc`` or
+    ``sycl``) to a list of additional compiler flags to supply to the compiler.
+    This makes it possible to supply different flags to the C++, CUDA and SYCL
+    compiler during mixed compilation.
+
+    ``use_ninja`` (bool): If ``use_ninja`` is ``True`` (default), then we
+    attempt to build using the Ninja backend. Ninja greatly speeds up
+    compilation compared to the standard ``setuptools.build_ext``.
+    Fallbacks to the standard distutils backend if Ninja is not available.
+
+    .. note::
+        By default, the Ninja backend uses #CPUS + 2 workers to build the
+        extension. This may use up too many resources on some systems. One
+        can control the number of workers by setting the `MAX_JOBS` environment
+        variable to a non-negative number.
+    """
+
+    @classmethod
+    def with_options(cls, **options):
+        """Return a subclass with alternative constructor that extends any original keyword arguments to the original constructor with the given options."""
+        class cls_with_options(cls):  # type: ignore[misc, valid-type]
+            def __init__(self, *args, **kwargs):
+                kwargs.update(options)
+                super().__init__(*args, **kwargs)
+
+        return cls_with_options
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.no_python_abi_suffix = kwargs.get("no_python_abi_suffix", False)
+
+        self.use_ninja = kwargs.get('use_ninja', True)
+        if self.use_ninja:
+            # Test if we can use ninja. Fallback otherwise.
+            msg = ('Attempted to use ninja as the BuildExtension backend but '
+                   '{}. Falling back to using the slow distutils backend.')
+            if not is_ninja_available():
+                warnings.warn(msg.format('we could not find ninja.'))
+                self.use_ninja = False
+
+    def finalize_options(self) -> None:
+        super().finalize_options()
+        if self.use_ninja:
+            self.force = True
+
+    def build_extensions(self) -> None:
+        compiler_name, compiler_version = self._check_abi()
+
+        cuda_ext = False
+        sycl_ext = False
+        extension_iter = iter(self.extensions)
+        extension = next(extension_iter, None)
+        while not (cuda_ext and sycl_ext) and extension:
+            for source in extension.sources:
+                _, ext = os.path.splitext(source)
+                if ext == '.cu':
+                    cuda_ext = True
+                elif ext == '.sycl':
+                    sycl_ext = True
+
+                # This check accounts on a case when cuda and sycl sources
+                # are mixed in the same extension. We can stop checking
+                # sources if both are found or there is no more sources.
+                if cuda_ext and sycl_ext:
+                    break
+
+            extension = next(extension_iter, None)
+
+        if sycl_ext:
+            assert self.use_ninja, "ninja is required to build sycl extensions."
+
+        if cuda_ext and not IS_HIP_EXTENSION:
+            _check_cuda_version(compiler_name, compiler_version)
+
+        for extension in self.extensions:
+            # Ensure at least an empty list of flags for 'cxx', 'nvcc' and 'sycl' when
+            # extra_compile_args is a dict. Otherwise, default torch flags do
+            # not get passed. Necessary when only one of 'cxx', 'nvcc' or 'sycl' is
+            # passed to extra_compile_args in CUDAExtension or SyclExtension, i.e.
+            #   CUDAExtension(..., extra_compile_args={'cxx': [...]})
+            # or
+            #   CUDAExtension(..., extra_compile_args={'nvcc': [...]})
+            if isinstance(extension.extra_compile_args, dict):
+                for ext in ['cxx', 'nvcc', 'sycl']:
+                    if ext not in extension.extra_compile_args:
+                        extension.extra_compile_args[ext] = []
+
+            self._add_compile_flag(extension, '-DTORCH_API_INCLUDE_EXTENSION_H')
+
+            if IS_HIP_EXTENSION:
+                self._hipify_compile_flags(extension)
+
+            if extension.py_limited_api:
+                # compile any extension that has passed in py_limited_api to the
+                # Extension constructor with the Py_LIMITED_API flag set to our
+                # min supported CPython version.
+                # See https://docs.python.org/3/c-api/stable.html#c.Py_LIMITED_API
+                self._add_compile_flag(extension, f'-DPy_LIMITED_API={min_supported_cpython}')
+            else:
+                # pybind11 is not CPython API stable so don't add these flags used when
+                # compiling pybind11 when pybind11 is not even used. otherwise, the build
+                # logs are confusing.
+                # See note [Pybind11 ABI constants]
+                for name in ["COMPILER_TYPE", "STDLIB", "BUILD_ABI"]:
+                    val = getattr(torch._C, f"_PYBIND11_{name}", "")
+                    if val is not None and not IS_WINDOWS:
+                        self._add_compile_flag(extension, f'-DPYBIND11_{name}="{val}"')
+            self._define_torch_extension_name(extension)
+            self._add_gnu_cpp_abi_flag(extension)
+
+            if 'nvcc_dlink' in extension.extra_compile_args:
+                assert self.use_ninja, f"With dlink=True, ninja is required to build cuda extension {extension.name}."
+
+        # Register .cu, .cuh, .hip, .mm and .sycl as valid source extensions.
+        # NOTE: At the moment .sycl is not a standard extension for SYCL supported
+        # by compiler. Here we introduce a torch level convention that SYCL sources
+        # should have .sycl file extension.
+        self.compiler.src_extensions += ['.cu', '.cuh', '.hip', '.sycl']
+        if torch.backends.mps.is_built():
+            self.compiler.src_extensions += ['.mm']
+        # Save the original _compile method for later.
+        if self.compiler.compiler_type == 'msvc':
+            self.compiler._cpp_extensions += ['.cu', '.cuh']
+            original_compile = self.compiler.compile
+            original_spawn = self.compiler.spawn
+        else:
+            original_compile = self.compiler._compile
+
+        def append_std17_if_no_std_present(cflags) -> None:
+            # NVCC does not allow multiple -std to be passed, so we avoid
+            # overriding the option if the user explicitly passed it.
+            cpp_format_prefix = '/{}:' if self.compiler.compiler_type == 'msvc' else '-{}='
+            cpp_flag_prefix = cpp_format_prefix.format('std')
+            cpp_flag = cpp_flag_prefix + 'c++17'
+            if not any(flag.startswith(cpp_flag_prefix) for flag in cflags):
+                cflags.append(cpp_flag)
+
+        def unix_cuda_flags(cflags):
+            cflags = (COMMON_NVCC_FLAGS +
+                      ['--compiler-options', "'-fPIC'"] +
+                      cflags + _get_cuda_arch_flags(cflags))
+
+            # NVCC does not allow multiple -ccbin/--compiler-bindir to be passed, so we avoid
+            # overriding the option if the user explicitly passed it.
+            _ccbin = os.getenv("CC")
+            if (
+                _ccbin is not None
+                and not any(flag.startswith(('-ccbin', '--compiler-bindir')) for flag in cflags)
+            ):
+                cflags.extend(['-ccbin', _ccbin])
+
+            return cflags
+
+        def convert_to_absolute_paths_inplace(paths):
+            # Helper function. See Note [Absolute include_dirs]
+            if paths is not None:
+                for i in range(len(paths)):
+                    if not os.path.isabs(paths[i]):
+                        paths[i] = os.path.abspath(paths[i])
+
+        def unix_wrap_single_compile(obj, src, ext, cc_args, extra_postargs, pp_opts) -> None:
+            # Copy before we make any modifications.
+            cflags = copy.deepcopy(extra_postargs)
+            try:
+                original_compiler = self.compiler.compiler_so
+                if _is_cuda_file(src):
+                    nvcc = [_join_rocm_home('bin', 'hipcc') if IS_HIP_EXTENSION else _join_cuda_home('bin', 'nvcc')]
+                    self.compiler.set_executable('compiler_so', nvcc)
+                    if isinstance(cflags, dict):
+                        cflags = cflags['nvcc']
+                    if IS_HIP_EXTENSION:
+                        cflags = COMMON_HIPCC_FLAGS + cflags + _get_rocm_arch_flags(cflags)
+                    else:
+                        cflags = unix_cuda_flags(cflags)
+                elif isinstance(cflags, dict):
+                    cflags = cflags['cxx']
+                if IS_HIP_EXTENSION:
+                    cflags = COMMON_HIP_FLAGS + cflags
+                append_std17_if_no_std_present(cflags)
+
+                original_compile(obj, src, ext, cc_args, cflags, pp_opts)
+            finally:
+                # Put the original compiler back in place.
+                self.compiler.set_executable('compiler_so', original_compiler)
+
+        def unix_wrap_ninja_compile(sources,
+                                    output_dir=None,
+                                    macros=None,
+                                    include_dirs=None,
+                                    debug=0,
+                                    extra_preargs=None,
+                                    extra_postargs=None,
+                                    depends=None):
+            r"""Compiles sources by outputting a ninja file and running it."""
+            # NB: I copied some lines from self.compiler (which is an instance
+            # of distutils.UnixCCompiler). See the following link.
+            # https://github.com/python/cpython/blob/f03a8f8d5001963ad5b5b28dbd95497e9cc15596/Lib/distutils/ccompiler.py#L564-L567
+            # This can be fragile, but a lot of other repos also do this
+            # (see https://github.com/search?q=_setup_compile&type=Code)
+            # so it is probably OK; we'll also get CI signal if/when
+            # we update our python version (which is when distutils can be
+            # upgraded)
+
+            # Use absolute path for output_dir so that the object file paths
+            # (`objects`) get generated with absolute paths.
+            output_dir = os.path.abspath(output_dir)
+
+            # See Note [Absolute include_dirs]
+            convert_to_absolute_paths_inplace(self.compiler.include_dirs)
+
+            _, objects, extra_postargs, pp_opts, _ = \
+                self.compiler._setup_compile(output_dir, macros,
+                                             include_dirs, sources,
+                                             depends, extra_postargs)
+            common_cflags = self.compiler._get_cc_args(pp_opts, debug, extra_preargs)
+            extra_cc_cflags = self.compiler.compiler_so[1:]
+            with_cuda = any(map(_is_cuda_file, sources))
+            with_sycl = any(map(_is_sycl_file, sources))
+
+            # extra_postargs can be either:
+            # - a dict mapping cxx/nvcc/sycl to extra flags
+            # - a list of extra flags.
+            if isinstance(extra_postargs, dict):
+                post_cflags = extra_postargs['cxx']
+            else:
+                post_cflags = list(extra_postargs)
+            if IS_HIP_EXTENSION:
+                post_cflags = COMMON_HIP_FLAGS + post_cflags
+            append_std17_if_no_std_present(post_cflags)
+
+            cuda_post_cflags = None
+            cuda_cflags = None
+            if with_cuda:
+                cuda_cflags = common_cflags
+                if isinstance(extra_postargs, dict):
+                    cuda_post_cflags = extra_postargs['nvcc']
+                else:
+                    cuda_post_cflags = list(extra_postargs)
+                if IS_HIP_EXTENSION:
+                    cuda_post_cflags = cuda_post_cflags + _get_rocm_arch_flags(cuda_post_cflags)
+                    cuda_post_cflags = COMMON_HIP_FLAGS + COMMON_HIPCC_FLAGS + cuda_post_cflags
+                else:
+                    cuda_post_cflags = unix_cuda_flags(cuda_post_cflags)
+                append_std17_if_no_std_present(cuda_post_cflags)
+                cuda_cflags = [shlex.quote(f) for f in cuda_cflags]
+                cuda_post_cflags = [shlex.quote(f) for f in cuda_post_cflags]
+
+            if isinstance(extra_postargs, dict) and 'nvcc_dlink' in extra_postargs:
+                cuda_dlink_post_cflags = unix_cuda_flags(extra_postargs['nvcc_dlink'])
+            else:
+                cuda_dlink_post_cflags = None
+
+            sycl_post_cflags = None
+            sycl_cflags = None
+            sycl_dlink_post_cflags = None
+            if with_sycl:
+                sycl_cflags = extra_cc_cflags + common_cflags + _COMMON_SYCL_FLAGS
+                if isinstance(extra_postargs, dict):
+                    sycl_post_cflags = extra_postargs['sycl']
+                else:
+                    sycl_post_cflags = list(extra_postargs)
+                append_std17_if_no_std_present(sycl_cflags)
+                _append_sycl_std_if_no_std_present(sycl_cflags)
+                host_cflags = extra_cc_cflags + common_cflags + post_cflags
+                append_std17_if_no_std_present(host_cflags)
+                # escaping quoted arguments to pass them thru SYCL compiler
+                host_cflags = [item.replace('"', '\\\\"') for item in host_cflags]
+                host_cflags = ' '.join(host_cflags)
+                # Note the order: shlex.quote sycl_flags first, _wrap_sycl_host_flags
+                # second. Reason is that sycl host flags are quoted, space containing
+                # strings passed to SYCL compiler.
+                sycl_cflags = [shlex.quote(f) for f in sycl_cflags]
+                # sycl_cflags += _wrap_sycl_host_flags(host_cflags)
+                sycl_dlink_post_cflags = list(_SYCL_DLINK_FLAGS)
+                # Propagate -doubleGRF from extension compile flags to dlink
+                if any('doubleGRF' in f for f in sycl_post_cflags):
+                    sycl_dlink_post_cflags = [
+                        f.replace(f'-device {_get_sycl_arch_list()}"',
+                                  f'-device {_get_sycl_arch_list()} -options -doubleGRF"')
+                        if '-Xs' in f and '-device' in f else f
+                        for f in sycl_dlink_post_cflags
+                    ]
+                sycl_post_cflags = [shlex.quote(f) for f in sycl_post_cflags]
+
+            _write_ninja_file_and_compile_objects(
+                sources=sources,
+                objects=objects,
+                cflags=[shlex.quote(f) for f in extra_cc_cflags + common_cflags],
+                post_cflags=[shlex.quote(f) for f in post_cflags],
+                cuda_cflags=cuda_cflags,
+                cuda_post_cflags=cuda_post_cflags,
+                cuda_dlink_post_cflags=cuda_dlink_post_cflags,
+                sycl_cflags=sycl_cflags,
+                sycl_post_cflags=sycl_post_cflags,
+                sycl_dlink_post_cflags=sycl_dlink_post_cflags,
+                build_directory=output_dir,
+                verbose=True,
+                with_cuda=with_cuda,
+                with_sycl=with_sycl)
+
+            # Return *all* object filenames, not just the ones we just built.
+            return objects
+
+        def win_cuda_flags(cflags):
+            return (COMMON_NVCC_FLAGS +
+                    cflags + _get_cuda_arch_flags(cflags))
+
+        def win_wrap_single_compile(sources,
+                                    output_dir=None,
+                                    macros=None,
+                                    include_dirs=None,
+                                    debug=0,
+                                    extra_preargs=None,
+                                    extra_postargs=None,
+                                    depends=None):
+
+            self.cflags = copy.deepcopy(extra_postargs)
+            extra_postargs = None
+
+            def spawn(cmd):
+                # Using regex to match src, obj and include files
+                src_regex = re.compile('/T(p|c)(.*)')
+                src_list = [
+                    m.group(2) for m in (src_regex.match(elem) for elem in cmd)
+                    if m
+                ]
+
+                obj_regex = re.compile('/Fo(.*)')
+                obj_list = [
+                    m.group(1) for m in (obj_regex.match(elem) for elem in cmd)
+                    if m
+                ]
+
+                include_regex = re.compile(r'((\-|\/)I.*)')
+                include_list = [
+                    m.group(1)
+                    for m in (include_regex.match(elem) for elem in cmd) if m
+                ]
+
+                if len(src_list) >= 1 and len(obj_list) >= 1:
+                    src = src_list[0]
+                    obj = obj_list[0]
+                    if _is_cuda_file(src):
+                        nvcc = _join_cuda_home('bin', 'nvcc')
+                        if isinstance(self.cflags, dict):
+                            cflags = self.cflags['nvcc']
+                        elif isinstance(self.cflags, list):
+                            cflags = self.cflags
+                        else:
+                            cflags = []
+
+                        cflags = win_cuda_flags(cflags) + ['-std=c++17', '--use-local-env']
+                        for flag in COMMON_MSVC_FLAGS:
+                            cflags = ['-Xcompiler', flag] + cflags
+                        for ignore_warning in MSVC_IGNORE_CUDAFE_WARNINGS:
+                            cflags = ['-Xcudafe', '--diag_suppress=' + ignore_warning] + cflags
+                        cmd = [nvcc, '-c', src, '-o', obj] + include_list + cflags
+                    elif isinstance(self.cflags, dict):
+                        cflags = COMMON_MSVC_FLAGS + self.cflags['cxx']
+                        append_std17_if_no_std_present(cflags)
+                        cmd += cflags
+                    elif isinstance(self.cflags, list):
+                        cflags = COMMON_MSVC_FLAGS + self.cflags
+                        append_std17_if_no_std_present(cflags)
+                        cmd += cflags
+
+                return original_spawn(cmd)
+
+            try:
+                self.compiler.spawn = spawn
+                return original_compile(sources, output_dir, macros,
+                                        include_dirs, debug, extra_preargs,
+                                        extra_postargs, depends)
+            finally:
+                self.compiler.spawn = original_spawn
+
+        def win_wrap_ninja_compile(sources,
+                                   output_dir=None,
+                                   macros=None,
+                                   include_dirs=None,
+                                   debug=0,
+                                   extra_preargs=None,
+                                   extra_postargs=None,
+                                   depends=None):
+
+            if not self.compiler.initialized:
+                self.compiler.initialize()
+            output_dir = os.path.abspath(output_dir)
+
+            # Note [Absolute include_dirs]
+            # Convert relative path in self.compiler.include_dirs to absolute path if any.
+            # For ninja build, the build location is not local, but instead, the build happens
+            # in a script-created build folder. Thus, relative paths lose their correctness.
+            # To be consistent with jit extension, we allow user to enter relative include_dirs
+            # in setuptools.setup, and we convert the relative path to absolute path here.
+            convert_to_absolute_paths_inplace(self.compiler.include_dirs)
+
+            _, objects, extra_postargs, pp_opts, _ = \
+                self.compiler._setup_compile(output_dir, macros,
+                                             include_dirs, sources,
+                                             depends, extra_postargs)
+            common_cflags = extra_preargs or []
+            cflags = []
+            if debug:
+                cflags.extend(self.compiler.compile_options_debug)
+            else:
+                cflags.extend(self.compiler.compile_options)
+            common_cflags.extend(COMMON_MSVC_FLAGS)
+            cflags = cflags + common_cflags + pp_opts
+            with_cuda = any(map(_is_cuda_file, sources))
+
+            # extra_postargs can be either:
+            # - a dict mapping cxx/nvcc to extra flags
+            # - a list of extra flags.
+            if isinstance(extra_postargs, dict):
+                post_cflags = extra_postargs['cxx']
+            else:
+                post_cflags = list(extra_postargs)
+            append_std17_if_no_std_present(post_cflags)
+
+            cuda_post_cflags = None
+            cuda_cflags = None
+            if with_cuda:
+                cuda_cflags = ['-std=c++17', '--use-local-env']
+                for common_cflag in common_cflags:
+                    cuda_cflags.append('-Xcompiler')
+                    cuda_cflags.append(common_cflag)
+                for ignore_warning in MSVC_IGNORE_CUDAFE_WARNINGS:
+                    cuda_cflags.append('-Xcudafe')
+                    cuda_cflags.append('--diag_suppress=' + ignore_warning)
+                cuda_cflags.extend(pp_opts)
+                if isinstance(extra_postargs, dict):
+                    cuda_post_cflags = extra_postargs['nvcc']
+                else:
+                    cuda_post_cflags = list(extra_postargs)
+                cuda_post_cflags = win_cuda_flags(cuda_post_cflags)
+
+            cflags = _nt_quote_args(cflags)
+            post_cflags = _nt_quote_args(post_cflags)
+            if with_cuda:
+                cuda_cflags = _nt_quote_args(cuda_cflags)
+                cuda_post_cflags = _nt_quote_args(cuda_post_cflags)
+            if isinstance(extra_postargs, dict) and 'nvcc_dlink' in extra_postargs:
+                cuda_dlink_post_cflags = win_cuda_flags(extra_postargs['nvcc_dlink'])
+            else:
+                cuda_dlink_post_cflags = None
+
+            _write_ninja_file_and_compile_objects(
+                sources=sources,
+                objects=objects,
+                cflags=cflags,
+                post_cflags=post_cflags,
+                cuda_cflags=cuda_cflags,
+                cuda_post_cflags=cuda_post_cflags,
+                cuda_dlink_post_cflags=cuda_dlink_post_cflags,
+                sycl_cflags=None,
+                sycl_post_cflags=None,
+                sycl_dlink_post_cflags=None,
+                build_directory=output_dir,
+                verbose=True,
+                with_cuda=with_cuda,
+                with_sycl=False)
+
+            # Return *all* object filenames, not just the ones we just built.
+            return objects
+
+        # Monkey-patch the _compile or compile method.
+        # https://github.com/python/cpython/blob/dc0284ee8f7a270b6005467f26d8e5773d76e959/Lib/distutils/ccompiler.py#L511
+        if self.compiler.compiler_type == 'msvc':
+            if self.use_ninja:
+                self.compiler.compile = win_wrap_ninja_compile
+            else:
+                self.compiler.compile = win_wrap_single_compile
+        else:
+            if self.use_ninja:
+                self.compiler.compile = unix_wrap_ninja_compile
+            else:
+                self.compiler._compile = unix_wrap_single_compile
+
+        build_ext.build_extensions(self)
+
+    def get_ext_filename(self, ext_name):
+        # Get the original shared library name. For Python 3, this name will be
+        # suffixed with "<SOABI>.so", where <SOABI> will be something like
+        # cpython-37m-x86_64-linux-gnu.
+        ext_filename = super().get_ext_filename(ext_name)
+        # If `no_python_abi_suffix` is `True`, we omit the Python 3 ABI
+        # component. This makes building shared libraries with setuptools that
+        # aren't Python modules nicer.
+        if self.no_python_abi_suffix:
+            # The parts will be e.g. ["my_extension", "cpython-37m-x86_64-linux-gnu", "so"].
+            ext_filename_parts = ext_filename.split('.')
+            # Omit the second to last element.
+            without_abi = ext_filename_parts[:-2] + ext_filename_parts[-1:]
+            ext_filename = '.'.join(without_abi)
+        return ext_filename
+
+    def _check_abi(self) -> tuple[str, TorchVersion]:
+        # On some platforms, like Windows, compiler_cxx is not available.
+        if hasattr(self.compiler, 'compiler_cxx'):
+            compiler = self.compiler.compiler_cxx[0]
+        else:
+            compiler = get_cxx_compiler()
+        _, version = get_compiler_abi_compatibility_and_version(compiler)
+        # Warn user if VC env is activated but `DISTUILS_USE_SDK` is not set.
+        if IS_WINDOWS and 'VSCMD_ARG_TGT_ARCH' in os.environ and 'DISTUTILS_USE_SDK' not in os.environ:
+            msg = ('It seems that the VC environment is activated but DISTUTILS_USE_SDK is not set.'
+                   'This may lead to multiple activations of the VC env.'
+                   'Please set `DISTUTILS_USE_SDK=1` and try again.')
+            raise UserWarning(msg)
+        return compiler, version
+
+    def _add_compile_flag(self, extension, flag):
+        extension.extra_compile_args = copy.deepcopy(extension.extra_compile_args)
+        if isinstance(extension.extra_compile_args, dict):
+            for args in extension.extra_compile_args.values():
+                args.append(flag)
+        else:
+            extension.extra_compile_args.append(flag)
+
+    # Simple hipify, replace the first occurrence of CUDA with HIP
+    # in flags starting with "-" and containing "CUDA", but exclude -I flags
+    def _hipify_compile_flags(self, extension):
+        if isinstance(extension.extra_compile_args, dict) and 'nvcc' in extension.extra_compile_args:
+            modified_flags = []
+            for flag in extension.extra_compile_args['nvcc']:
+                if flag.startswith("-") and "CUDA" in flag and not flag.startswith("-I"):
+                    # check/split flag into flag and value
+                    parts = flag.split("=", 1)
+                    if len(parts) == 2:
+                        flag_part, value_part = parts
+                        # replace fist instance of "CUDA" with "HIP" only in the flag and not flag value
+                        modified_flag_part = flag_part.replace("CUDA", "HIP", 1)
+                        modified_flag = f"{modified_flag_part}={value_part}"
+                    else:
+                        # replace fist instance of "CUDA" with "HIP" in flag
+                        modified_flag = flag.replace("CUDA", "HIP", 1)
+                    modified_flags.append(modified_flag)
+                    print(f'Modified flag: {flag} -> {modified_flag}', file=sys.stderr)
+                else:
+                    modified_flags.append(flag)
+            extension.extra_compile_args['nvcc'] = modified_flags
+
+    def _define_torch_extension_name(self, extension):
+        # pybind11 doesn't support dots in the names
+        # so in order to support extensions in the packages
+        # like torch._C, we take the last part of the string
+        # as the library name
+        names = extension.name.split('.')
+        name = names[-1]
+        define = f'-DTORCH_EXTENSION_NAME={name}'
+        self._add_compile_flag(extension, define)
+
+    def _add_gnu_cpp_abi_flag(self, extension):
+        # use the same CXX ABI as what PyTorch was compiled with
+        self._add_compile_flag(extension, '-D_GLIBCXX_USE_CXX11_ABI=' + str(int(torch._C._GLIBCXX_USE_CXX11_ABI)))
+
+
+def CppExtension(name, sources, *args, **kwargs):
+    """
+    Create a :class:`setuptools.Extension` for C++.
+
+    Convenience method that creates a :class:`setuptools.Extension` with the
+    bare minimum (but often sufficient) arguments to build a C++ extension.
+
+    All arguments are forwarded to the :class:`setuptools.Extension`
+    constructor. Full list arguments can be found at
+    https://setuptools.pypa.io/en/latest/userguide/ext_modules.html#extension-api-reference
+
+    .. warning::
+        The PyTorch python API (as provided in libtorch_python) cannot be built
+        with the flag ``py_limited_api=True``.  When this flag is passed, it is
+        the user's responsibility in their library to not use APIs from
+        libtorch_python (in particular pytorch/python bindings) and to only use
+        APIs from libtorch (aten objects, operators and the dispatcher). For
+        example, to give access to custom ops from python, the library should
+        register the ops through the dispatcher.
+
+        Contrary to CPython setuptools, who does not define -DPy_LIMITED_API
+        as a compile flag when py_limited_api is specified as an option for
+        the "bdist_wheel" command in ``setup``, PyTorch does! We will specify
+        -DPy_LIMITED_API=min_supported_cpython to best enforce consistency,
+        safety, and sanity in order to encourage best practices. To target a
+        different version, set min_supported_cpython to the hexcode of the
+        CPython version of choice.
+
+    Example:
+        >>> # xdoctest: +SKIP
+        >>> # xdoctest: +REQUIRES(env:TORCH_DOCTEST_CPP_EXT)
+        >>> from setuptools import setup
+        >>> from torch.utils.cpp_extension import BuildExtension, CppExtension
+        >>> setup(
+        ...     name='extension',
+        ...     ext_modules=[
+        ...         CppExtension(
+        ...             name='extension',
+        ...             sources=['extension.cpp'],
+        ...             extra_compile_args=['-g'],
+        ...             extra_link_args=['-Wl,--no-as-needed', '-lm'])
+        ...     ],
+        ...     cmdclass={
+        ...         'build_ext': BuildExtension
+        ...     })
+    """
+    include_dirs = kwargs.get('include_dirs', [])
+    include_dirs += include_paths()
+    kwargs['include_dirs'] = include_dirs
+
+    library_dirs = kwargs.get('library_dirs', [])
+    library_dirs += library_paths()
+    kwargs['library_dirs'] = library_dirs
+
+    libraries = kwargs.get('libraries', [])
+    libraries.append('c10')
+    libraries.append('torch')
+    libraries.append('torch_cpu')
+    if not kwargs.get('py_limited_api', False):
+        # torch_python uses more than the python limited api
+        libraries.append('torch_python')
+    if IS_WINDOWS:
+        libraries.append("sleef")
+
+    kwargs['libraries'] = libraries
+
+    kwargs['language'] = 'c++'
+    return setuptools.Extension(name, sources, *args, **kwargs)
+
+
+def CUDAExtension(name, sources, *args, **kwargs):
+    """
+    Create a :class:`setuptools.Extension` for CUDA/C++.
+
+    Convenience method that creates a :class:`setuptools.Extension` with the
+    bare minimum (but often sufficient) arguments to build a CUDA/C++
+    extension. This includes the CUDA include path, library path and runtime
+    library.
+
+    All arguments are forwarded to the :class:`setuptools.Extension`
+    constructor. Full list arguments can be found at
+    https://setuptools.pypa.io/en/latest/userguide/ext_modules.html#extension-api-reference
+
+    .. warning::
+        The PyTorch python API (as provided in libtorch_python) cannot be built
+        with the flag ``py_limited_api=True``.  When this flag is passed, it is
+        the user's responsibility in their library to not use APIs from
+        libtorch_python (in particular pytorch/python bindings) and to only use
+        APIs from libtorch (aten objects, operators and the dispatcher). For
+        example, to give access to custom ops from python, the library should
+        register the ops through the dispatcher.
+
+        Contrary to CPython setuptools, who does not define -DPy_LIMITED_API
+        as a compile flag when py_limited_api is specified as an option for
+        the "bdist_wheel" command in ``setup``, PyTorch does! We will specify
+        -DPy_LIMITED_API=min_supported_cpython to best enforce consistency,
+        safety, and sanity in order to encourage best practices. To target a
+        different version, set min_supported_cpython to the hexcode of the
+        CPython version of choice.
+
+    Example:
+        >>> # xdoctest: +SKIP
+        >>> # xdoctest: +REQUIRES(env:TORCH_DOCTEST_CPP_EXT)
+        >>> from setuptools import setup
+        >>> from torch.utils.cpp_extension import BuildExtension, CUDAExtension
+        >>> setup(
+        ...     name='cuda_extension',
+        ...     ext_modules=[
+        ...         CUDAExtension(
+        ...                 name='cuda_extension',
+        ...                 sources=['extension.cpp', 'extension_kernel.cu'],
+        ...                 extra_compile_args={'cxx': ['-g'],
+        ...                                     'nvcc': ['-O2']},
+        ...                 extra_link_args=['-Wl,--no-as-needed', '-lcuda'])
+        ...     ],
+        ...     cmdclass={
+        ...         'build_ext': BuildExtension
+        ...     })
+
+    Compute capabilities:
+
+    By default the extension will be compiled to run on all archs of the cards visible during the
+    building process of the extension, plus PTX. If down the road a new card is installed the
+    extension may need to be recompiled. If a visible card has a compute capability (CC) that's
+    newer than the newest version for which your nvcc can build fully-compiled binaries, PyTorch
+    will make nvcc fall back to building kernels with the newest version of PTX your nvcc does
+    support (see below for details on PTX).
+
+    You can override the default behavior using `TORCH_CUDA_ARCH_LIST` to explicitly specify which
+    CCs you want the extension to support:
+
+    ``TORCH_CUDA_ARCH_LIST="6.1 8.6" python build_my_extension.py``
+    ``TORCH_CUDA_ARCH_LIST="5.2 6.0 6.1 7.0 7.5 8.0 8.6+PTX" python build_my_extension.py``
+
+    The +PTX option causes extension kernel binaries to include PTX instructions for the specified
+    CC. PTX is an intermediate representation that allows kernels to runtime-compile for any CC >=
+    the specified CC (for example, 8.6+PTX generates PTX that can runtime-compile for any GPU with
+    CC >= 8.6). This improves your binary's forward compatibility. However, relying on older PTX to
+    provide forward compat by runtime-compiling for newer CCs can modestly reduce performance on
+    those newer CCs. If you know exact CC(s) of the GPUs you want to target, you're always better
+    off specifying them individually. For example, if you want your extension to run on 8.0 and 8.6,
+    "8.0+PTX" would work functionally because it includes PTX that can runtime-compile for 8.6, but
+    "8.0 8.6" would be better.
+
+    Note that while it's possible to include all supported archs, the more archs get included the
+    slower the building process will be, as it will build a separate kernel image for each arch.
+
+    Note that CUDA-11.5 nvcc will hit internal compiler error while parsing torch/extension.h on Windows.
+    To workaround the issue, move python binding logic to pure C++ file.
+
+    Example use:
+        #include <ATen/ATen.h>
+        at::Tensor SigmoidAlphaBlendForwardCuda(....)
+
+    Instead of:
+        #include <torch/extension.h>
+        torch::Tensor SigmoidAlphaBlendForwardCuda(...)
+
+    Currently open issue for nvcc bug: https://github.com/pytorch/pytorch/issues/69460
+    Complete workaround code example: https://github.com/facebookresearch/pytorch3d/commit/cb170ac024a949f1f9614ffe6af1c38d972f7d48
+
+    Relocatable device code linking:
+
+    If you want to reference device symbols across compilation units (across object files),
+    the object files need to be built with `relocatable device code` (-rdc=true or -dc).
+    An exception to this rule is "dynamic parallelism" (nested kernel launches)  which is not used a lot anymore.
+    `Relocatable device code` is less optimized so it needs to be used only on object files that need it.
+    Using `-dlto` (Device Link Time Optimization) at the device code compilation step and `dlink` step
+    helps reduce the protentional perf degradation of `-rdc`.
+    Note that it needs to be used at both steps to be useful.
+
+    If you have `rdc` objects you need to have an extra `-dlink` (device linking) step before the CPU symbol linking step.
+    There is also a case where `-dlink` is used without `-rdc`:
+    when an extension is linked against a static lib containing rdc-compiled objects
+    like the [NVSHMEM library](https://developer.nvidia.com/nvshmem).
+
+    Note: Ninja is required to build a CUDA Extension with RDC linking.
+
+    Example:
+        >>> # xdoctest: +SKIP
+        >>> # xdoctest: +REQUIRES(env:TORCH_DOCTEST_CPP_EXT)
+        >>> CUDAExtension(
+        ...        name='cuda_extension',
+        ...        sources=['extension.cpp', 'extension_kernel.cu'],
+        ...        dlink=True,
+        ...        dlink_libraries=["dlink_lib"],
+        ...        extra_compile_args={'cxx': ['-g'],
+        ...                            'nvcc': ['-O2', '-rdc=true']})
+    """
+    library_dirs = kwargs.get('library_dirs', [])
+    library_dirs += library_paths(device_type="cuda")
+    kwargs['library_dirs'] = library_dirs
+
+    libraries = kwargs.get('libraries', [])
+    libraries.append('c10')
+    libraries.append('torch')
+    libraries.append('torch_cpu')
+    if not kwargs.get('py_limited_api', False):
+        # torch_python uses more than the python limited api
+        libraries.append('torch_python')
+    if IS_HIP_EXTENSION:
+        libraries.append('amdhip64')
+        libraries.append('c10_hip')
+        libraries.append('torch_hip')
+    else:
+        libraries.append('cudart')
+        libraries.append('c10_cuda')
+        libraries.append('torch_cuda')
+    kwargs['libraries'] = libraries
+
+    include_dirs = kwargs.get('include_dirs', [])
+
+    if IS_HIP_EXTENSION:
+        build_dir = os.getcwd()
+        hipify_result = hipify_python.hipify(
+            project_directory=build_dir,
+            output_directory=build_dir,
+            header_include_dirs=include_dirs,
+            includes=[os.path.join(build_dir, '*')],  # limit scope to build_dir only
+            extra_files=[os.path.abspath(s) for s in sources],
+            show_detailed=True,
+            is_pytorch_extension=True,
+            hipify_extra_files_only=True,  # don't hipify everything in includes path
+        )
+
+        hipified_sources = set()
+        for source in sources:
+            s_abs = os.path.abspath(source)
+            hipified_s_abs = (hipify_result[s_abs].hipified_path if (s_abs in hipify_result and
+                              hipify_result[s_abs].hipified_path is not None) else s_abs)
+            # setup() arguments must *always* be /-separated paths relative to the setup.py directory,
+            # *never* absolute paths
+            hipified_sources.add(os.path.relpath(hipified_s_abs, build_dir))
+
+        sources = list(hipified_sources)
+
+    include_dirs += include_paths(device_type="cuda")
+    kwargs['include_dirs'] = include_dirs
+
+    kwargs['language'] = 'c++'
+
+    dlink_libraries = kwargs.get('dlink_libraries', [])
+    dlink = kwargs.get('dlink', False) or dlink_libraries
+    if dlink:
+        extra_compile_args = kwargs.get('extra_compile_args', {})
+
+        extra_compile_args_dlink = extra_compile_args.get('nvcc_dlink', [])
+        extra_compile_args_dlink += ['-dlink']
+        extra_compile_args_dlink += [f'-L{x}' for x in library_dirs]
+        extra_compile_args_dlink += [f'-l{x}' for x in dlink_libraries]
+
+        if (torch.version.cuda is not None) and TorchVersion(torch.version.cuda) >= '11.2':
+            extra_compile_args_dlink += ['-dlto']   # Device Link Time Optimization started from cuda 11.2
+
+        extra_compile_args['nvcc_dlink'] = extra_compile_args_dlink
+
+        kwargs['extra_compile_args'] = extra_compile_args
+
+    return setuptools.Extension(name, sources, *args, **kwargs)
+
+
+def SyclExtension(name, sources, *args, **kwargs):
+    r"""
+    Creates a :class:`setuptools.Extension` for SYCL/C++.
+
+    Convenience method that creates a :class:`setuptools.Extension` with the
+    bare minimum (but often sufficient) arguments to build a SYCL/C++
+    extension.
+
+    All arguments are forwarded to the :class:`setuptools.Extension`
+    constructor.
+
+    .. warning::
+        The PyTorch python API (as provided in libtorch_python) cannot be built
+        with the flag ``py_limited_api=True``.  When this flag is passed, it is
+        the user's responsibility in their library to not use APIs from
+        libtorch_python (in particular pytorch/python bindings) and to only use
+        APIs from libtorch (aten objects, operators and the dispatcher). For
+        example, to give access to custom ops from python, the library should
+        register the ops through the dispatcher.
+
+        Contrary to CPython setuptools, who does not define -DPy_LIMITED_API
+        as a compile flag when py_limited_api is specified as an option for
+        the "bdist_wheel" command in ``setup``, PyTorch does! We will specify
+        -DPy_LIMITED_API=min_supported_cpython to best enforce consistency,
+        safety, and sanity in order to encourage best practices. To target a
+        different version, set min_supported_cpython to the hexcode of the
+        CPython version of choice.
+
+    Example:
+        >>> # xdoctest: +SKIP
+        >>> # xdoctest: +REQUIRES(env:TORCH_DOCTEST_CPP_EXT)
+        >>> from torch.utils.cpp_extension import BuildExtension, SyclExtension
+        >>> setup(
+        ...     name='xpu_extension',
+        ...     ext_modules=[
+        ...     SyclExtension(
+        ...                 name='xpu_extension',
+        ...                 sources=['extension.cpp', 'extension_kernel.cpp'],
+        ...                 extra_compile_args={'cxx': ['-g', '-std=c++20', '-fPIC']})
+        ...     ],
+        ...     cmdclass={
+        ...         'build_ext': BuildExtension
+        ...     })
+
+    By default the extension will be compiled to run on all archs of the cards visible during the
+    building process of the extension. If down the road a new card is installed the
+    extension may need to be recompiled. You can override the default behavior using
+    `TORCH_XPU_ARCH_LIST` to explicitly specify which device architectures you want the extension
+    to support:
+
+    ``TORCH_XPU_ARCH_LIST="pvc,xe-lpg" python build_my_extension.py``
+
+    Note that while it's possible to include all supported archs, the more archs get included the
+    slower the building process will be, as it will build a separate kernel image for each arch.
+
+    Note: Ninja is required to build SyclExtension.
+    """
+    library_dirs = kwargs.get("library_dirs", [])
+    library_dirs += library_paths()
+    kwargs["library_dirs"] = library_dirs
+
+    libraries = kwargs.get("libraries", [])
+    libraries.append("c10")
+    libraries.append("c10_xpu")
+    libraries.append("torch")
+    libraries.append("torch_cpu")
+    if not kwargs.get('py_limited_api', False):
+        # torch_python uses more than the python limited api
+        libraries.append("torch_python")
+    libraries.append("torch_xpu")
+    kwargs["libraries"] = libraries
+
+    include_dirs = kwargs.get("include_dirs", [])
+    include_dirs += include_paths()
+    kwargs["include_dirs"] = include_dirs
+
+    kwargs["language"] = "c++"
+
+    return setuptools.Extension(name, sources, *args, **kwargs)
+
+def include_paths(device_type: str = "cpu") -> list[str]:
+    """
+    Get the include paths required to build a C++ or CUDA or SYCL extension.
+
+    Args:
+        device_type: Defaults to "cpu".
+    Returns:
+        A list of include path strings.
+    """
+    lib_include = os.path.join(_TORCH_PATH, 'include')
+    paths = [
+        lib_include,
+        # Remove this once torch/torch.h is officially no longer supported for C++ extensions.
+        os.path.join(lib_include, 'torch', 'csrc', 'api', 'include'),
+    ]
+    if device_type == "cuda" and IS_HIP_EXTENSION:
+        paths.append(os.path.join(lib_include, 'THH'))
+        paths.append(_join_rocm_home('include'))
+    elif device_type == "cuda":
+        cuda_home_include = _join_cuda_home('include')
+        # if we have the Debian/Ubuntu packages for cuda, we get /usr as cuda home.
+        # but gcc doesn't like having /usr/include passed explicitly
+        if cuda_home_include != '/usr/include':
+            paths.append(cuda_home_include)
+
+        # Support CUDA_INC_PATH env variable supported by CMake files
+        if (cuda_inc_path := os.environ.get("CUDA_INC_PATH", None)) and \
+                cuda_inc_path != '/usr/include':
+            paths.append(cuda_inc_path)
+        if CUDNN_HOME is not None:
+            paths.append(os.path.join(CUDNN_HOME, 'include'))
+    elif device_type == "xpu":
+        paths.append(_join_sycl_home('include'))
+        paths.append(_join_sycl_home('include', 'sycl'))
+    return paths
+
+
+def library_paths(device_type: str = "cpu") -> list[str]:
+    """
+    Get the library paths required to build a C++ or CUDA extension.
+
+    Args:
+        device_type: Defaults to "cpu".
+
+    Returns:
+        A list of library path strings.
+    """
+    # We need to link against libtorch.so
+    paths = [TORCH_LIB_PATH]
+
+    if device_type == "cuda" and IS_HIP_EXTENSION:
+        lib_dir = 'lib'
+        paths.append(_join_rocm_home(lib_dir))
+        if HIP_HOME is not None:
+            paths.append(os.path.join(HIP_HOME, 'lib'))
+    elif device_type == "cuda":
+        if IS_WINDOWS:
+            lib_dir = os.path.join('lib', 'x64')
+        else:
+            lib_dir = 'lib64'
+            if (not os.path.exists(_join_cuda_home(lib_dir)) and
+                    os.path.exists(_join_cuda_home('lib'))):
+                # 64-bit CUDA may be installed in 'lib' (see e.g. gh-16955)
+                # Note that it's also possible both don't exist (see
+                # _find_cuda_home) - in that case we stay with 'lib64'.
+                lib_dir = 'lib'
+
+        paths.append(_join_cuda_home(lib_dir))
+        if CUDNN_HOME is not None:
+            paths.append(os.path.join(CUDNN_HOME, lib_dir))
+    elif device_type == "xpu":
+        if IS_WINDOWS:
+            lib_dir = os.path.join('lib', 'x64')
+        else:
+            lib_dir = 'lib64'
+            if (not os.path.exists(_join_sycl_home(lib_dir)) and
+                    os.path.exists(_join_sycl_home('lib'))):
+                lib_dir = 'lib'
+
+        paths.append(_join_sycl_home(lib_dir))
+
+    return paths
+
+
+def load(name,
+         sources: Union[str, list[str]],
+         extra_cflags=None,
+         extra_cuda_cflags=None,
+         extra_sycl_cflags=None,
+         extra_ldflags=None,
+         extra_include_paths=None,
+         build_directory=None,
+         verbose=False,
+         with_cuda: Optional[bool] = None,
+         with_sycl: Optional[bool] = None,
+         is_python_module=True,
+         is_standalone=False,
+         keep_intermediates=True):
+    """
+    Load a PyTorch C++ extension just-in-time (JIT).
+
+    To load an extension, a Ninja build file is emitted, which is used to
+    compile the given sources into a dynamic library. This library is
+    subsequently loaded into the current Python process as a module and
+    returned from this function, ready for use.
+
+    By default, the directory to which the build file is emitted and the
+    resulting library compiled to is ``<tmp>/torch_extensions/<name>``, where
+    ``<tmp>`` is the temporary folder on the current platform and ``<name>``
+    the name of the extension. This location can be overridden in two ways.
+    First, if the ``TORCH_EXTENSIONS_DIR`` environment variable is set, it
+    replaces ``<tmp>/torch_extensions`` and all extensions will be compiled
+    into subfolders of this directory. Second, if the ``build_directory``
+    argument to this function is supplied, it overrides the entire path, i.e.
+    the library will be compiled into that folder directly.
+
+    To compile the sources, the default system compiler (``c++``) is used,
+    which can be overridden by setting the ``CXX`` environment variable. To pass
+    additional arguments to the compilation process, ``extra_cflags`` or
+    ``extra_ldflags`` can be provided. For example, to compile your extension
+    with optimizations, pass ``extra_cflags=['-O3']``. You can also use
+    ``extra_cflags`` to pass further include directories.
+
+    CUDA support with mixed compilation is provided. Simply pass CUDA source
+    files (``.cu`` or ``.cuh``) along with other sources. Such files will be
+    detected and compiled with nvcc rather than the C++ compiler. This includes
+    passing the CUDA lib64 directory as a library directory, and linking
+    ``cudart``. You can pass additional flags to nvcc via
+    ``extra_cuda_cflags``, just like with ``extra_cflags`` for C++. Various
+    heuristics for finding the CUDA install directory are used, which usually
+    work fine. If not, setting the ``CUDA_HOME`` environment variable is the
+    safest option.
+
+    SYCL support with mixed compilation is provided. Simply pass SYCL source
+    files (``.sycl``) along with other sources. Such files will be detected
+    and compiled with SYCL compiler (such as Intel DPC++ Compiler) rather
+    than the C++ compiler. You can pass additional flags to SYCL compiler
+    via ``extra_sycl_cflags``, just like with ``extra_cflags`` for C++.
+    SYCL compiler is expected to be found via system PATH environment
+    variable.
+
+    Args:
+        name: The name of the extension to build. This MUST be the same as the
+            name of the pybind11 module!
+        sources: A list of relative or absolute paths to C++ source files.
+        extra_cflags: optional list of compiler flags to forward to the build.
+        extra_cuda_cflags: optional list of compiler flags to forward to nvcc
+            when building CUDA sources.
+        extra_sycl_cflags: optional list of compiler flags to forward to SYCL
+            compiler when building SYCL sources.
+        extra_ldflags: optional list of linker flags to forward to the build.
+        extra_include_paths: optional list of include directories to forward
+            to the build.
+        build_directory: optional path to use as build workspace.
+        verbose: If ``True``, turns on verbose logging of load steps.
+        with_cuda: Determines whether CUDA headers and libraries are added to
+            the build. If set to ``None`` (default), this value is
+            automatically determined based on the existence of ``.cu`` or
+            ``.cuh`` in ``sources``. Set it to `True`` to force CUDA headers
+            and libraries to be included.
+        with_sycl: Determines whether SYCL headers and libraries are added to
+            the build. If set to ``None`` (default), this value is
+            automatically determined based on the existence of ``.sycl`` in
+            ``sources``. Set it to `True`` to force SYCL headers and
+            libraries to be included.
+        is_python_module: If ``True`` (default), imports the produced shared
+            library as a Python module. If ``False``, behavior depends on
+            ``is_standalone``.
+        is_standalone: If ``False`` (default) loads the constructed extension
+            into the process as a plain dynamic library. If ``True``, build a
+            standalone executable.
+
+    Returns:
+        If ``is_python_module`` is ``True``:
+            Returns the loaded PyTorch extension as a Python module.
+
+        If ``is_python_module`` is ``False`` and ``is_standalone`` is ``False``:
+            Returns nothing. (The shared library is loaded into the process as
+            a side effect.)
+
+        If ``is_standalone`` is ``True``.
+            Return the path to the executable. (On Windows, TORCH_LIB_PATH is
+            added to the PATH environment variable as a side effect.)
+
+    Example:
+        >>> # xdoctest: +SKIP
+        >>> from torch.utils.cpp_extension import load
+        >>> module = load(
+        ...     name='extension',
+        ...     sources=['extension.cpp', 'extension_kernel.cu'],
+        ...     extra_cflags=['-O2'],
+        ...     verbose=True)
+    """
+    return _jit_compile(
+        name,
+        [sources] if isinstance(sources, str) else sources,
+        extra_cflags,
+        extra_cuda_cflags,
+        extra_sycl_cflags,
+        extra_ldflags,
+        extra_include_paths,
+        build_directory or _get_build_directory(name, verbose),
+        verbose,
+        with_cuda,
+        with_sycl,
+        is_python_module,
+        is_standalone,
+        keep_intermediates=keep_intermediates)
+
+def _get_pybind11_abi_build_flags():
+    # Note [Pybind11 ABI constants]
+    #
+    # Pybind11 before 2.4 used to build an ABI strings using the following pattern:
+    # f"__pybind11_internals_v{PYBIND11_INTERNALS_VERSION}{PYBIND11_INTERNALS_KIND}{PYBIND11_BUILD_TYPE}__"
+    # Since 2.4 compier type, stdlib and build abi parameters are also encoded like this:
+    # f"__pybind11_internals_v{PYBIND11_INTERNALS_VERSION}{PYBIND11_INTERNALS_KIND}{PYBIND11_COMPILER_TYPE}{PYBIND11_STDLIB}{PYBIND11_BUILD_ABI}{PYBIND11_BUILD_TYPE}__"
+    #
+    # This was done in order to further narrow down the chances of compiler ABI incompatibility
+    # that can cause a hard to debug segfaults.
+    # For PyTorch extensions we want to relax those restrictions and pass compiler, stdlib and abi properties
+    # captured during PyTorch native library compilation in torch/csrc/Module.cpp
+
+    abi_cflags = []
+    for pname in ["COMPILER_TYPE", "STDLIB", "BUILD_ABI"]:
+        pval = getattr(torch._C, f"_PYBIND11_{pname}", "")
+        if pval is not None and not IS_WINDOWS:
+            abi_cflags.append(f'-DPYBIND11_{pname}=\\"{pval}\\"')
+    return abi_cflags
+
+def _get_glibcxx_abi_build_flags():
+    glibcxx_abi_cflags = ['-D_GLIBCXX_USE_CXX11_ABI=' + str(int(torch._C._GLIBCXX_USE_CXX11_ABI))]
+    return glibcxx_abi_cflags
+
+def check_compiler_is_gcc(compiler):
+    if not IS_LINUX:
+        return False
+
+    env = os.environ.copy()
+    env['LC_ALL'] = 'C'  # Don't localize output
+    try:
+        version_string = subprocess.check_output([compiler, '-v'], stderr=subprocess.STDOUT, env=env).decode(*SUBPROCESS_DECODE_ARGS)
+    except Exception:
+        try:
+            version_string = subprocess.check_output([compiler, '--version'], stderr=subprocess.STDOUT, env=env).decode(*SUBPROCESS_DECODE_ARGS)
+        except Exception:
+            return False
+    # Check for 'gcc' or 'g++' for sccache wrapper
+    pattern = re.compile("^COLLECT_GCC=(.*)$", re.MULTILINE)
+    results = re.findall(pattern, version_string)
+    if len(results) != 1:
+        return False
+    compiler_path = os.path.realpath(results[0].strip())
+    # On RHEL/CentOS c++ is a gcc compiler wrapper
+    if os.path.basename(compiler_path) == 'c++' and 'gcc version' in version_string:
+        return True
+    return False
+
+def _check_and_build_extension_h_precompiler_headers(
+        extra_cflags,
+        extra_include_paths,
+        is_standalone=False):
+    r'''
+    Precompiled Headers(PCH) can pre-build the same headers and reduce build time for pytorch load_inline modules.
+    GCC offical manual: https://gcc.gnu.org/onlinedocs/gcc-4.0.4/gcc/Precompiled-Headers.html
+    PCH only works when built pch file(header.h.gch) and build target have the same build parameters. So, We need
+    add a signature file to record PCH file parameters. If the build parameters(signature) changed, it should rebuild
+    PCH file.
+
+    Note:
+    1. Windows and MacOS have different PCH mechanism. We only support Linux currently.
+    2. It only works on GCC/G++.
+    '''
+    if not IS_LINUX:
+        return
+
+    compiler = get_cxx_compiler()
+
+    b_is_gcc = check_compiler_is_gcc(compiler)
+    if b_is_gcc is False:
+        return
+
+    head_file = os.path.join(_TORCH_PATH, 'include', 'torch', 'extension.h')
+    head_file_pch = os.path.join(_TORCH_PATH, 'include', 'torch', 'extension.h.gch')
+    head_file_signature = os.path.join(_TORCH_PATH, 'include', 'torch', 'extension.h.sign')
+
+    def listToString(s):
+        # initialize an empty string
+        string = ""
+        if s is None:
+            return string
+
+        # traverse in the string
+        for element in s:
+            string += (element + ' ')
+        # return string
+        return string
+
+    def format_precompiler_header_cmd(compiler, head_file, head_file_pch, common_cflags, torch_include_dirs, extra_cflags, extra_include_paths):
+        return re.sub(
+            r"[ \n]+",
+            " ",
+            f"""
+                {compiler} -x c++-header {head_file} -o {head_file_pch} {torch_include_dirs} {extra_include_paths} {extra_cflags} {common_cflags}
+            """,
+        ).strip()
+
+    def command_to_signature(cmd):
+        signature = cmd.replace(' ', '_')
+        return signature
+
+    def check_pch_signature_in_file(file_path, signature):
+        b_exist = os.path.isfile(file_path)
+        if b_exist is False:
+            return False
+
+        with open(file_path) as file:
+            # read all content of a file
+            content = file.read()
+            # check if string present in a file
+            return signature == content
+
+    def _create_if_not_exist(path_dir):
+        if not os.path.exists(path_dir):
+            try:
+                Path(path_dir).mkdir(parents=True, exist_ok=True)
+            except OSError as exc:  # Guard against race condition
+                if exc.errno != errno.EEXIST:
+                    raise RuntimeError(f"Fail to create path {path_dir}") from exc
+
+    def write_pch_signature_to_file(file_path, pch_sign):
+        _create_if_not_exist(os.path.dirname(file_path))
+        with open(file_path, "w") as f:
+            f.write(pch_sign)
+            f.close()
+
+    def build_precompile_header(pch_cmd):
+        try:
+            subprocess.check_output(pch_cmd, shell=True, stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(f"Compile PreCompile Header fail, command: {pch_cmd}") from e
+
+    extra_cflags_str = listToString(extra_cflags)
+    extra_include_paths_str = " ".join(
+        [f"-I{include}" for include in extra_include_paths] if extra_include_paths else []
+    )
+
+    lib_include = os.path.join(_TORCH_PATH, 'include')
+    torch_include_dirs = [
+        f"-I {lib_include}",
+        # Python.h
+        "-I {}".format(sysconfig.get_path("include")),
+        # torch/all.h
+        "-I {}".format(os.path.join(lib_include, 'torch', 'csrc', 'api', 'include')),
+    ]
+
+    torch_include_dirs_str = listToString(torch_include_dirs)
+
+    common_cflags = []
+    if not is_standalone:
+        common_cflags += ['-DTORCH_API_INCLUDE_EXTENSION_H']
+
+    common_cflags += ['-std=c++17', '-fPIC']
+    common_cflags += [f"{x}" for x in _get_pybind11_abi_build_flags()]
+    common_cflags += [f"{x}" for x in _get_glibcxx_abi_build_flags()]
+    common_cflags_str = listToString(common_cflags)
+
+    pch_cmd = format_precompiler_header_cmd(compiler, head_file, head_file_pch, common_cflags_str, torch_include_dirs_str, extra_cflags_str, extra_include_paths_str)
+    pch_sign = command_to_signature(pch_cmd)
+
+    if os.path.isfile(head_file_pch) is not True:
+        build_precompile_header(pch_cmd)
+        write_pch_signature_to_file(head_file_signature, pch_sign)
+    else:
+        b_same_sign = check_pch_signature_in_file(head_file_signature, pch_sign)
+        if b_same_sign is False:
+            build_precompile_header(pch_cmd)
+            write_pch_signature_to_file(head_file_signature, pch_sign)
+
+def remove_extension_h_precompiler_headers():
+    def _remove_if_file_exists(path_file):
+        if os.path.exists(path_file):
+            os.remove(path_file)
+
+    head_file_pch = os.path.join(_TORCH_PATH, 'include', 'torch', 'extension.h.gch')
+    head_file_signature = os.path.join(_TORCH_PATH, 'include', 'torch', 'extension.h.sign')
+
+    _remove_if_file_exists(head_file_pch)
+    _remove_if_file_exists(head_file_signature)
+
+def load_inline(name,
+                cpp_sources,
+                cuda_sources=None,
+                sycl_sources=None,
+                functions=None,
+                extra_cflags=None,
+                extra_cuda_cflags=None,
+                extra_sycl_cflags=None,
+                extra_ldflags=None,
+                extra_include_paths=None,
+                build_directory=None,
+                verbose=False,
+                with_cuda=None,
+                with_sycl=None,
+                is_python_module=True,
+                with_pytorch_error_handling=True,
+                keep_intermediates=True,
+                use_pch=False):
+    r'''
+    Load a PyTorch C++ extension just-in-time (JIT) from string sources.
+
+    This function behaves exactly like :func:`load`, but takes its sources as
+    strings rather than filenames. These strings are stored to files in the
+    build directory, after which the behavior of :func:`load_inline` is
+    identical to :func:`load`.
+
+    See `the
+    tests <https://github.com/pytorch/pytorch/blob/master/test/test_cpp_extensions_jit.py>`_
+    for good examples of using this function.
+
+    Sources may omit two required parts of a typical non-inline C++ extension:
+    the necessary header includes, as well as the (pybind11) binding code. More
+    precisely, strings passed to ``cpp_sources`` are first concatenated into a
+    single ``.cpp`` file. This file is then prepended with ``#include
+    <torch/extension.h>``.
+
+    Furthermore, if the ``functions`` argument is supplied, bindings will be
+    automatically generated for each function specified. ``functions`` can
+    either be a list of function names, or a dictionary mapping from function
+    names to docstrings. If a list is given, the name of each function is used
+    as its docstring.
+
+    The sources in ``cuda_sources`` are concatenated into a separate ``.cu``
+    file and  prepended with ``torch/types.h``, ``cuda.h`` and
+    ``cuda_runtime.h`` includes. The ``.cpp`` and ``.cu`` files are compiled
+    separately, but ultimately linked into a single library. Note that no
+    bindings are generated for functions in ``cuda_sources`` per se. To bind
+    to a CUDA kernel, you must create a C++ function that calls it, and either
+    declare or define this C++ function in one of the ``cpp_sources`` (and
+    include its name in ``functions``).
+
+    The sources in ``sycl_sources`` are concatenated into a separate ``.sycl``
+    file and  prepended with ``torch/types.h``, ``sycl/sycl.hpp`` includes.
+    The ``.cpp`` and ``.sycl`` files are compiled separately, but ultimately
+    linked into a single library. Note that no bindings are generated for
+    functions in ``sycl_sources`` per se. To bind to a SYCL kernel, you must
+    create a C++ function that calls it, and either declare or define this
+    C++ function in one of the ``cpp_sources`` (and include its name
+    in ``functions``).
+
+    See :func:`load` for a description of arguments omitted below.
+
+    Args:
+        cpp_sources: A string, or list of strings, containing C++ source code.
+        cuda_sources: A string, or list of strings, containing CUDA source code.
+        sycl_sources: A string, or list of strings, containing SYCL source code.
+        functions: A list of function names for which to generate function
+            bindings. If a dictionary is given, it should map function names to
+            docstrings (which are otherwise just the function names).
+        with_cuda: Determines whether CUDA headers and libraries are added to
+            the build. If set to ``None`` (default), this value is
+            automatically determined based on whether ``cuda_sources`` is
+            provided. Set it to ``True`` to force CUDA headers
+            and libraries to be included.
+        with_sycl: Determines whether SYCL headers and libraries are added to
+            the build. If set to ``None`` (default), this value is
+            automatically determined based on whether ``sycl_sources`` is
+            provided. Set it to ``True`` to force SYCL headers
+            and libraries to be included.
+        with_pytorch_error_handling: Determines whether pytorch error and
+            warning macros are handled by pytorch instead of pybind. To do
+            this, each function ``foo`` is called via an intermediary ``_safe_foo``
+            function. This redirection might cause issues in obscure cases
+            of cpp. This flag should be set to ``False`` when this redirect
+            causes issues.
+
+    Example:
+        >>> # xdoctest: +REQUIRES(env:TORCH_DOCTEST_CPP_EXT)
+        >>> from torch.utils.cpp_extension import load_inline
+        >>> source = """
+        at::Tensor sin_add(at::Tensor x, at::Tensor y) {
+          return x.sin() + y.sin();
+        }
+        """
+        >>> module = load_inline(name='inline_extension',
+        ...                      cpp_sources=[source],
+        ...                      functions=['sin_add'])
+
+    .. note::
+        Since load_inline will just-in-time compile the source code, please ensure
+        that you have the right toolchains installed in the runtime. For example,
+        when loading C++, make sure a C++ compiler is available. If you're loading
+        a CUDA extension, you will need to additionally install the corresponding CUDA
+        toolkit (nvcc and any other dependencies your code has). Compiling toolchains
+        are not included when you install torch and must be additionally installed.
+
+        During compiling, by default, the Ninja backend uses #CPUS + 2 workers to build
+        the extension. This may use up too many resources on some systems. One
+        can control the number of workers by setting the `MAX_JOBS` environment
+        variable to a non-negative number.
+    '''
+    build_directory = build_directory or _get_build_directory(name, verbose)
+
+    if isinstance(cpp_sources, str):
+        cpp_sources = [cpp_sources]
+    cuda_sources = cuda_sources or []
+    if isinstance(cuda_sources, str):
+        cuda_sources = [cuda_sources]
+    sycl_sources = sycl_sources or []
+    if isinstance(sycl_sources, str):
+        sycl_sources = [sycl_sources]
+
+    cpp_sources.insert(0, '#include <torch/extension.h>')
+
+    if use_pch is True:
+        # Using PreCompile Header('torch/extension.h') to reduce compile time.
+        _check_and_build_extension_h_precompiler_headers(extra_cflags, extra_include_paths)
+    else:
+        remove_extension_h_precompiler_headers()
+
+    # If `functions` is supplied, we create the pybind11 bindings for the user.
+    # Here, `functions` is (or becomes, after some processing) a map from
+    # function names to function docstrings.
+    if functions is not None:
+        module_def = []
+        module_def.append('PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {')
+        if isinstance(functions, str):
+            functions = [functions]
+        if isinstance(functions, list):
+            # Make the function docstring the same as the function name.
+            functions = {f: f for f in functions}
+        elif not isinstance(functions, dict):
+            raise ValueError(f"Expected 'functions' to be a list or dict, but was {type(functions)}")
+        for function_name, docstring in functions.items():
+            if with_pytorch_error_handling:
+                module_def.append(f'm.def("{function_name}", torch::wrap_pybind_function({function_name}), "{docstring}");')
+            else:
+                module_def.append(f'm.def("{function_name}", {function_name}, "{docstring}");')
+        module_def.append('}')
+        cpp_sources += module_def
+
+    cpp_source_path = os.path.join(build_directory, 'main.cpp')
+    _maybe_write(cpp_source_path, "\n".join(cpp_sources))
+
+    sources = [cpp_source_path]
+
+    if cuda_sources:
+        cuda_sources.insert(0, '#include <torch/types.h>')
+        cuda_sources.insert(1, '#include <cuda.h>')
+        cuda_sources.insert(2, '#include <cuda_runtime.h>')
+
+        cuda_source_path = os.path.join(build_directory, 'cuda.cu')
+        _maybe_write(cuda_source_path, "\n".join(cuda_sources))
+
+        sources.append(cuda_source_path)
+
+    if sycl_sources:
+        sycl_sources.insert(0, '#include <torch/types.h>')
+        sycl_sources.insert(1, '#include <sycl/sycl.hpp>')
+
+        sycl_source_path = os.path.join(build_directory, 'sycl.sycl')
+        _maybe_write(sycl_source_path, "\n".join(sycl_sources))
+
+        sources.append(sycl_source_path)
+
+    return _jit_compile(
+        name,
+        sources,
+        extra_cflags,
+        extra_cuda_cflags,
+        extra_sycl_cflags,
+        extra_ldflags,
+        extra_include_paths,
+        build_directory,
+        verbose,
+        with_cuda,
+        with_sycl,
+        is_python_module,
+        is_standalone=False,
+        keep_intermediates=keep_intermediates)
+
+
+def _jit_compile(name,
+                 sources,
+                 extra_cflags,
+                 extra_cuda_cflags,
+                 extra_sycl_cflags,
+                 extra_ldflags,
+                 extra_include_paths,
+                 build_directory: str,
+                 verbose: bool,
+                 with_cuda: Optional[bool],
+                 with_sycl: Optional[bool],
+                 is_python_module,
+                 is_standalone,
+                 keep_intermediates=True) -> None:
+    return
+    if is_python_module and is_standalone:
+        raise ValueError("`is_python_module` and `is_standalone` are mutually exclusive.")
+
+    if with_cuda is None:
+        with_cuda = any(map(_is_cuda_file, sources))
+    with_cudnn = any('cudnn' in f for f in extra_ldflags or [])
+    if with_sycl is None:
+        with_sycl = any(map(_is_sycl_file, sources))
+    old_version = JIT_EXTENSION_VERSIONER.get_version(name)
+    version = JIT_EXTENSION_VERSIONER.bump_version_if_changed(
+        name,
+        sources,
+        build_arguments=[extra_cflags, extra_cuda_cflags, extra_ldflags, extra_include_paths],
+        build_directory=build_directory,
+        with_cuda=with_cuda,
+        with_sycl=with_sycl,
+        is_python_module=is_python_module,
+        is_standalone=is_standalone,
+    )
+    if version > 0:
+        if version != old_version and verbose:
+            print(f'The input conditions for extension module {name} have changed. ' +
+                  f'Bumping to version {version} and re-building as {name}_v{version}...',
+                  file=sys.stderr)
+        name = f'{name}_v{version}'
+
+    baton = FileBaton(os.path.join(build_directory, 'lock'))
+    if baton.try_acquire():
+        try:
+            if version != old_version:
+                with GeneratedFileCleaner(keep_intermediates=keep_intermediates) as clean_ctx:
+                    if IS_HIP_EXTENSION and (with_cuda or with_cudnn):
+                        hipify_result = hipify_python.hipify(
+                            project_directory=build_directory,
+                            output_directory=build_directory,
+                            header_include_dirs=(extra_include_paths if extra_include_paths is not None else []),
+                            extra_files=[os.path.abspath(s) for s in sources],
+                            ignores=[_join_rocm_home('*'), os.path.join(_TORCH_PATH, '*')],  # no need to hipify ROCm or PyTorch headers
+                            show_detailed=verbose,
+                            show_progress=verbose,
+                            is_pytorch_extension=True,
+                            clean_ctx=clean_ctx
+                        )
+
+                        hipified_sources = set()
+                        for source in sources:
+                            s_abs = os.path.abspath(source)
+                            hipified_sources.add(hipify_result[s_abs].hipified_path if s_abs in hipify_result else s_abs)
+
+                        sources = list(hipified_sources)
+
+                    _write_ninja_file_and_build_library(
+                        name=name,
+                        sources=sources,
+                        extra_cflags=extra_cflags or [],
+                        extra_cuda_cflags=extra_cuda_cflags or [],
+                        extra_sycl_cflags=extra_sycl_cflags or [],
+                        extra_ldflags=extra_ldflags or [],
+                        extra_include_paths=extra_include_paths or [],
+                        build_directory=build_directory,
+                        verbose=verbose,
+                        with_cuda=with_cuda,
+                        with_sycl=with_sycl,
+                        is_standalone=is_standalone)
+            elif verbose:
+                print('No modifications detected for re-loaded extension '
+                      f'module {name}, skipping build step...', file=sys.stderr)
+        finally:
+            baton.release()
+    else:
+        baton.wait()
+
+    if verbose:
+        print(f'Loading extension module {name}...', file=sys.stderr)
+
+    if is_standalone:
+        return _get_exec_path(name, build_directory)
+
+    return _import_module_from_library(name, build_directory, is_python_module)
+
+
+def _write_ninja_file_and_compile_objects(
+        sources: list[str],
+        objects,
+        cflags,
+        post_cflags,
+        cuda_cflags,
+        cuda_post_cflags,
+        cuda_dlink_post_cflags,
+        sycl_cflags,
+        sycl_post_cflags,
+        sycl_dlink_post_cflags,
+        build_directory: str,
+        verbose: bool,
+        with_cuda: Optional[bool],
+        with_sycl: Optional[bool]) -> None:
+    verify_ninja_availability()
+
+    compiler = get_cxx_compiler()
+
+    get_compiler_abi_compatibility_and_version(compiler)
+    if with_cuda is None:
+        with_cuda = any(map(_is_cuda_file, sources))
+    if with_sycl is None:
+        with_sycl = any(map(_is_sycl_file, sources))
+    build_file_path = os.path.join(build_directory, 'build.ninja')
+    if verbose:
+        print(f'Emitting ninja build file {build_file_path}...', file=sys.stderr)
+
+    # Create build_directory if it does not exist
+    if not os.path.exists(build_directory):
+        if verbose:
+            print(f'Creating directory {build_directory}...', file=sys.stderr)
+        # This is like mkdir -p, i.e. will also create parent directories.
+        os.makedirs(build_directory, exist_ok=True)
+
+    _write_ninja_file(
+        path=build_file_path,
+        cflags=cflags,
+        post_cflags=post_cflags,
+        cuda_cflags=cuda_cflags,
+        cuda_post_cflags=cuda_post_cflags,
+        cuda_dlink_post_cflags=cuda_dlink_post_cflags,
+        sycl_cflags=sycl_cflags,
+        sycl_post_cflags=sycl_post_cflags,
+        sycl_dlink_post_cflags=sycl_dlink_post_cflags,
+        sources=sources,
+        objects=objects,
+        ldflags=None,
+        library_target=None,
+        with_cuda=with_cuda,
+        with_sycl=with_sycl)
+    if verbose:
+        print('Compiling objects...', file=sys.stderr)
+    _run_ninja_build(
+        build_directory,
+        verbose,
+        # It would be better if we could tell users the name of the extension
+        # that failed to build but there isn't a good way to get it here.
+        error_prefix='Error compiling objects for extension')
+
+
+def _write_ninja_file_and_build_library(
+        name,
+        sources: list[str],
+        extra_cflags,
+        extra_cuda_cflags,
+        extra_sycl_cflags,
+        extra_ldflags,
+        extra_include_paths,
+        build_directory: str,
+        verbose: bool,
+        with_cuda: Optional[bool],
+        with_sycl: Optional[bool],
+        is_standalone: bool = False) -> None:
+    verify_ninja_availability()
+
+    compiler = get_cxx_compiler()
+
+    get_compiler_abi_compatibility_and_version(compiler)
+    if with_cuda is None:
+        with_cuda = any(map(_is_cuda_file, sources))
+    if with_sycl is None:
+        with_sycl = any(map(_is_sycl_file, sources))
+    extra_ldflags = _prepare_ldflags(
+        extra_ldflags or [],
+        with_cuda,
+        verbose,
+        is_standalone)
+    build_file_path = os.path.join(build_directory, 'build.ninja')
+    if verbose:
+        print(f'Emitting ninja build file {build_file_path}...', file=sys.stderr)
+
+    # Create build_directory if it does not exist
+    if not os.path.exists(build_directory):
+        if verbose:
+            print(f'Creating directory {build_directory}...', file=sys.stderr)
+        # This is like mkdir -p, i.e. will also create parent directories.
+        os.makedirs(build_directory, exist_ok=True)
+
+    # NOTE: Emitting a new ninja build file does not cause re-compilation if
+    # the sources did not change, so it's ok to re-emit (and it's fast).
+    _write_ninja_file_to_build_library(
+        path=build_file_path,
+        name=name,
+        sources=sources,
+        extra_cflags=extra_cflags or [],
+        extra_cuda_cflags=extra_cuda_cflags or [],
+        extra_sycl_cflags=extra_sycl_cflags or [],
+        extra_ldflags=extra_ldflags or [],
+        extra_include_paths=extra_include_paths or [],
+        with_cuda=with_cuda,
+        with_sycl=with_sycl,
+        is_standalone=is_standalone)
+
+    if verbose:
+        print(f'Building extension module {name}...', file=sys.stderr)
+    _run_ninja_build(
+        build_directory,
+        verbose,
+        error_prefix=f"Error building extension '{name}'")
+
+
+def is_ninja_available():
+    """Return ``True`` if the `ninja <https://ninja-build.org/>`_ build system is available on the system, ``False`` otherwise."""
+    try:
+        subprocess.check_output('ninja --version'.split())
+    except Exception:
+        return False
+    else:
+        return True
+
+
+def verify_ninja_availability():
+    """Raise ``RuntimeError`` if `ninja <https://ninja-build.org/>`_ build system is not available on the system, does nothing otherwise."""
+    if not is_ninja_available():
+        raise RuntimeError("Ninja is required to load C++ extensions")
+
+
+def _prepare_ldflags(extra_ldflags, with_cuda, verbose, is_standalone):
+    if IS_WINDOWS:
+        python_lib_path = os.path.join(sys.base_exec_prefix, 'libs')
+
+        extra_ldflags.append('c10.lib')
+        if with_cuda:
+            extra_ldflags.append('c10_cuda.lib')
+        extra_ldflags.append('torch_cpu.lib')
+        if with_cuda:
+            extra_ldflags.append('torch_cuda.lib')
+            # /INCLUDE is used to ensure torch_cuda is linked against in a project that relies on it.
+            # Related issue: https://github.com/pytorch/pytorch/issues/31611
+            extra_ldflags.append('-INCLUDE:?warp_size@cuda@at@@YAHXZ')
+        extra_ldflags.append('torch.lib')
+        extra_ldflags.append(f'/LIBPATH:{TORCH_LIB_PATH}')
+        if not is_standalone:
+            extra_ldflags.append('torch_python.lib')
+            extra_ldflags.append(f'/LIBPATH:{python_lib_path}')
+
+    else:
+        extra_ldflags.append(f'-L{TORCH_LIB_PATH}')
+        extra_ldflags.append('-lc10')
+        if with_cuda:
+            extra_ldflags.append('-lc10_hip' if IS_HIP_EXTENSION else '-lc10_cuda')
+        extra_ldflags.append('-ltorch_cpu')
+        if with_cuda:
+            extra_ldflags.append('-ltorch_hip' if IS_HIP_EXTENSION else '-ltorch_cuda')
+        extra_ldflags.append('-ltorch')
+        if not is_standalone:
+            extra_ldflags.append('-ltorch_python')
+
+        if is_standalone:
+            extra_ldflags.append(f"-Wl,-rpath,{TORCH_LIB_PATH}")
+
+    if with_cuda:
+        if verbose:
+            print('Detected CUDA files, patching ldflags', file=sys.stderr)
+        if IS_WINDOWS:
+            extra_ldflags.append(f'/LIBPATH:{_join_cuda_home("lib", "x64")}')
+            extra_ldflags.append('cudart.lib')
+            if CUDNN_HOME is not None:
+                extra_ldflags.append(f'/LIBPATH:{os.path.join(CUDNN_HOME, "lib", "x64")}')
+        elif not IS_HIP_EXTENSION:
+            extra_lib_dir = "lib64"
+            if (not os.path.exists(_join_cuda_home(extra_lib_dir)) and
+                    os.path.exists(_join_cuda_home("lib"))):
+                # 64-bit CUDA may be installed in "lib"
+                # Note that it's also possible both don't exist (see _find_cuda_home) - in that case we stay with "lib64"
+                extra_lib_dir = "lib"
+            extra_ldflags.append(f'-L{_join_cuda_home(extra_lib_dir)}')
+            extra_ldflags.append('-lcudart')
+            if CUDNN_HOME is not None:
+                extra_ldflags.append(f'-L{os.path.join(CUDNN_HOME, "lib64")}')
+        elif IS_HIP_EXTENSION:
+            extra_ldflags.append(f'-L{_join_rocm_home("lib")}')
+            extra_ldflags.append('-lamdhip64')
+    return extra_ldflags
+
+
+def _get_cuda_arch_flags(cflags: Optional[list[str]] = None) -> list[str]:
+    """
+    Determine CUDA arch flags to use.
+
+    For an arch, say "6.1", the added compile flag will be
+    ``-gencode=arch=compute_61,code=sm_61``.
+    For an added "+PTX", an additional
+    ``-gencode=arch=compute_xx,code=compute_xx`` is added.
+
+    See select_compute_arch.cmake for corresponding named and supported arches
+    when building with CMake.
+    """
+    # If cflags is given, there may already be user-provided arch flags in it
+    # (from `extra_compile_args`)
+    if cflags is not None:
+        for flag in cflags:
+            if 'TORCH_EXTENSION_NAME' in flag:
+                continue
+            if 'arch' in flag:
+                return []
+
+    # Note: keep combined names ("arch1+arch2") above single names, otherwise
+    # string replacement may not do the right thing
+    named_arches = collections.OrderedDict([
+        ('Kepler+Tesla', '3.7'),
+        ('Kepler', '3.5+PTX'),
+        ('Maxwell+Tegra', '5.3'),
+        ('Maxwell', '5.0;5.2+PTX'),
+        ('Pascal', '6.0;6.1+PTX'),
+        ('Volta+Tegra', '7.2'),
+        ('Volta', '7.0+PTX'),
+        ('Turing', '7.5+PTX'),
+        ('Ampere+Tegra', '8.7'),
+        ('Ampere', '8.0;8.6+PTX'),
+        ('Ada', '8.9+PTX'),
+        ('Hopper', '9.0+PTX'),
+        ('Blackwell+Tegra', '10.1'),
+        ('Blackwell', '10.0;12.0+PTX'),
+    ])
+
+    supported_arches = ['3.5', '3.7', '5.0', '5.2', '5.3', '6.0', '6.1', '6.2',
+                        '7.0', '7.2', '7.5', '8.0', '8.6', '8.7', '8.9', '9.0', '9.0a',
+                        '10.0', '10.0a', '10.1', '10.1a', '12.0', '12.0a']
+    valid_arch_strings = supported_arches + [s + "+PTX" for s in supported_arches]
+
+    # The default is sm_30 for CUDA 9.x and 10.x
+    # First check for an env var (same as used by the main setup.py)
+    # Can be one or more architectures, e.g. "6.1" or "3.5;5.2;6.0;6.1;7.0+PTX"
+    # See cmake/Modules_CUDA_fix/upstream/FindCUDA/select_compute_arch.cmake
+    _arch_list = os.environ.get('TORCH_CUDA_ARCH_LIST', None)
+
+    # If not given, determine what's best for the GPU / CUDA version that can be found
+    if not _arch_list:
+        warnings.warn(
+            "TORCH_CUDA_ARCH_LIST is not set, all archs for visible cards are included for compilation. \n"
+            "If this is not desired, please set os.environ['TORCH_CUDA_ARCH_LIST'].")
+        arch_list = []
+        # the assumption is that the extension should run on any of the currently visible cards,
+        # which could be of different types - therefore all archs for visible cards should be included
+        for i in range(torch.cuda.device_count()):
+            capability = torch.cuda.get_device_capability(i)
+            supported_sm = [int("".join(re.findall(r"\d+", arch.split('_')[1])))
+                            for arch in torch.cuda.get_arch_list() if 'sm_' in arch]
+            max_supported_sm = max((sm // 10, sm % 10) for sm in supported_sm)
+            # Capability of the device may be higher than what's supported by the user's
+            # NVCC, causing compilation error. User's NVCC is expected to match the one
+            # used to build pytorch, so we use the maximum supported capability of pytorch
+            # to clamp the capability.
+            capability = min(max_supported_sm, capability)
+            arch = f'{capability[0]}.{capability[1]}'
+            if arch not in arch_list:
+                arch_list.append(arch)
+        arch_list = sorted(arch_list)
+        arch_list[-1] += '+PTX'
+    else:
+        # Deal with lists that are ' ' separated (only deal with ';' after)
+        _arch_list = _arch_list.replace(' ', ';')
+        # Expand named arches
+        for named_arch, archval in named_arches.items():
+            _arch_list = _arch_list.replace(named_arch, archval)
+
+        arch_list = _arch_list.split(';')
+
+    flags = []
+    for arch in arch_list:
+        if arch not in valid_arch_strings:
+            raise ValueError(f"Unknown CUDA arch ({arch}) or GPU not supported")
+        else:
+            # Handle both single and double-digit architecture versions
+            version = arch.split('+')[0]  # Remove "+PTX" if present
+            major, minor = version.split('.')
+            num = f"{major}{minor}"
+            flags.append(f'-gencode=arch=compute_{num},code=sm_{num}')
+            if arch.endswith('+PTX'):
+                flags.append(f'-gencode=arch=compute_{num},code=compute_{num}')
+
+    return sorted(set(flags))
+
+
+def _get_rocm_arch_flags(cflags: Optional[list[str]] = None) -> list[str]:
+    # If cflags is given, there may already be user-provided arch flags in it
+    # (from `extra_compile_args`)
+    if cflags is not None:
+        for flag in cflags:
+            if 'amdgpu-target' in flag or 'offload-arch' in flag:
+                return ['-fno-gpu-rdc']
+    # Use same defaults as used for building PyTorch
+    # Allow env var to override, just like during initial cmake build.
+    _archs = os.environ.get('PYTORCH_ROCM_ARCH', None)
+    if not _archs:
+        archFlags = torch._C._cuda_getArchFlags()
+        if archFlags:
+            archs = archFlags.split()
+        else:
+            archs = []
+    else:
+        archs = _archs.replace(' ', ';').split(';')
+    flags = [f'--offload-arch={arch}' for arch in archs]
+    flags += ['-fno-gpu-rdc']
+    return flags
+
+def _get_build_directory(name: str, verbose: bool) -> str:
+    root_extensions_directory = os.environ.get('TORCH_EXTENSIONS_DIR')
+    if root_extensions_directory is None:
+        root_extensions_directory = get_default_build_root()
+        cu_str = ('cpu' if torch.version.cuda is None else
+                  f'cu{torch.version.cuda.replace(".", "")}')
+        python_version = f'py{sys.version_info.major}{sys.version_info.minor}{getattr(sys, "abiflags", "")}'
+        build_folder = f'{python_version}_{cu_str}'
+
+        root_extensions_directory = os.path.join(
+            root_extensions_directory, build_folder)
+
+    if verbose:
+        print(f'Using {root_extensions_directory} as PyTorch extensions root...', file=sys.stderr)
+
+    build_directory = os.path.join(root_extensions_directory, name)
+    if not os.path.exists(build_directory):
+        if verbose:
+            print(f'Creating extension directory {build_directory}...', file=sys.stderr)
+        # This is like mkdir -p, i.e. will also create parent directories.
+        os.makedirs(build_directory, exist_ok=True)
+
+    return build_directory
+
+
+def _get_num_workers(verbose: bool) -> Optional[int]:
+    max_jobs = os.environ.get('MAX_JOBS')
+    if max_jobs is not None and max_jobs.isdigit():
+        if verbose:
+            print(f'Using envvar MAX_JOBS ({max_jobs}) as the number of workers...',
+                  file=sys.stderr)
+        return int(max_jobs)
+    if verbose:
+        print('Allowing ninja to set a default number of workers... '
+              '(overridable by setting the environment variable MAX_JOBS=N)',
+              file=sys.stderr)
+    return None
+
+
+def _get_vc_env(vc_arch: str) -> dict[str, str]:
+    try:
+        from setuptools import distutils
+        return distutils._msvccompiler._get_vc_env(vc_arch)
+    except AttributeError:
+        from setuptools._distutils import _msvccompiler
+        return _msvccompiler._get_vc_env(vc_arch)
+
+
+def _run_ninja_build(build_directory: str, verbose: bool, error_prefix: str) -> None:
+    command = ['ninja', '-v']
+    num_workers = _get_num_workers(verbose)
+    if num_workers is not None:
+        command.extend(['-j', str(num_workers)])
+    env = os.environ.copy()
+    # Try to activate the vc env for the users
+    if IS_WINDOWS and 'VSCMD_ARG_TGT_ARCH' not in env:
+        from setuptools import distutils
+
+        plat_name = distutils.util.get_platform()
+        plat_spec = PLAT_TO_VCVARS[plat_name]
+        vc_env = {k.upper(): v for k, v in _get_vc_env(plat_spec).items()}
+        for k, v in env.items():
+            uk = k.upper()
+            if uk not in vc_env:
+                vc_env[uk] = v
+        env = vc_env
+    try:
+        sys.stdout.flush()
+        sys.stderr.flush()
+        # Warning: don't pass stdout=None to subprocess.run to get output.
+        # subprocess.run assumes that sys.__stdout__ has not been modified and
+        # attempts to write to it by default.  However, when we call _run_ninja_build
+        # from ahead-of-time cpp extensions, the following happens:
+        # 1) If the stdout encoding is not utf-8, setuptools detachs __stdout__.
+        #    https://github.com/pypa/setuptools/blob/7e97def47723303fafabe48b22168bbc11bb4821/setuptools/dist.py#L1110
+        #    (it probably shouldn't do this)
+        # 2) subprocess.run (on POSIX, with no stdout override) relies on
+        #    __stdout__ not being detached:
+        #    https://github.com/python/cpython/blob/c352e6c7446c894b13643f538db312092b351789/Lib/subprocess.py#L1214
+        # To work around this, we pass in the fileno directly and hope that
+        # it is valid.
+        stdout_fileno = 1
+        subprocess.run(
+            command,
+            stdout=stdout_fileno if verbose else subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            cwd=build_directory,
+            check=True,
+            env=env)
+    except subprocess.CalledProcessError as e:
+        # Python 2 and 3 compatible way of getting the error object.
+        _, error, _ = sys.exc_info()
+        # error.output contains the stdout and stderr of the build attempt.
+        message = error_prefix
+        # `error` is a CalledProcessError (which has an `output`) attribute, but
+        # mypy thinks it's Optional[BaseException] and doesn't narrow
+        if hasattr(error, 'output') and error.output:  # type: ignore[union-attr]
+            message += f": {error.output.decode(*SUBPROCESS_DECODE_ARGS)}"  # type: ignore[union-attr]
+        raise RuntimeError(message) from e
+
+
+def _get_exec_path(module_name, path):
+    if IS_WINDOWS and TORCH_LIB_PATH not in os.getenv('PATH', '').split(';'):
+        torch_lib_in_path = any(
+            os.path.exists(p) and os.path.samefile(p, TORCH_LIB_PATH)
+            for p in os.getenv('PATH', '').split(';')
+        )
+        if not torch_lib_in_path:
+            os.environ['PATH'] = f"{TORCH_LIB_PATH};{os.getenv('PATH', '')}"
+    return os.path.join(path, f'{module_name}{EXEC_EXT}')
+
+
+def _import_module_from_library(module_name, path, is_python_module):
+    filepath = os.path.join(path, f"{module_name}{LIB_EXT}")
+    if is_python_module:
+        # https://stackoverflow.com/questions/67631/how-to-import-a-module-given-the-full-path
+        spec = importlib.util.spec_from_file_location(module_name, filepath)
+        assert spec is not None
+        module = importlib.util.module_from_spec(spec)
+        assert isinstance(spec.loader, importlib.abc.Loader)
+        spec.loader.exec_module(module)
+        return module
+    else:
+        torch.ops.load_library(filepath)
+        return filepath
+
+
+def _write_ninja_file_to_build_library(path,
+                                       name,
+                                       sources,
+                                       extra_cflags,
+                                       extra_cuda_cflags,
+                                       extra_sycl_cflags,
+                                       extra_ldflags,
+                                       extra_include_paths,
+                                       with_cuda,
+                                       with_sycl,
+                                       is_standalone) -> None:
+    extra_cflags = [flag.strip() for flag in extra_cflags]
+    extra_cuda_cflags = [flag.strip() for flag in extra_cuda_cflags]
+    extra_sycl_cflags = [flag.strip() for flag in extra_sycl_cflags]
+    extra_ldflags = [flag.strip() for flag in extra_ldflags]
+    extra_include_paths = [flag.strip() for flag in extra_include_paths]
+
+    # Turn into absolute paths so we can emit them into the ninja build
+    # file wherever it is.
+    user_includes = [os.path.abspath(file) for file in extra_include_paths]
+
+    # include_paths() gives us the location of torch/extension.h
+    # TODO generalize with_cuda as specific device type.
+    if with_cuda:
+        system_includes = include_paths("cuda")
+    else:
+        system_includes = include_paths("cpu")
+    # sysconfig.get_path('include') gives us the location of Python.h
+    # Explicitly specify 'posix_prefix' scheme on non-Windows platforms to workaround error on some MacOS
+    # installations where default `get_path` points to non-existing `/Library/Python/M.m/include` folder
+    python_include_path = sysconfig.get_path('include', scheme='nt' if IS_WINDOWS else 'posix_prefix')
+    if python_include_path is not None:
+        system_includes.append(python_include_path)
+
+    common_cflags = []
+    if not is_standalone:
+        common_cflags.append(f'-DTORCH_EXTENSION_NAME={name}')
+        common_cflags.append('-DTORCH_API_INCLUDE_EXTENSION_H')
+
+    common_cflags += [f"{x}" for x in _get_pybind11_abi_build_flags()]
+
+    # Windows does not understand `-isystem` and quotes flags later.
+    if IS_WINDOWS:
+        common_cflags += [f'-I{include}' for include in user_includes + system_includes]
+    else:
+        common_cflags += [f'-I{shlex.quote(include)}' for include in user_includes]
+        common_cflags += [f'-isystem {shlex.quote(include)}' for include in system_includes]
+
+    common_cflags += [f"{x}" for x in _get_glibcxx_abi_build_flags()]
+
+    if IS_WINDOWS:
+        cflags = common_cflags + COMMON_MSVC_FLAGS + ['/std:c++17'] + extra_cflags
+        cflags = _nt_quote_args(cflags)
+    else:
+        cflags = common_cflags + ['-fPIC', '-std=c++17'] + extra_cflags
+
+    if with_cuda and IS_HIP_EXTENSION:
+        cuda_flags = ['-DWITH_HIP'] + cflags + COMMON_HIP_FLAGS + COMMON_HIPCC_FLAGS
+        cuda_flags += extra_cuda_cflags
+        cuda_flags += _get_rocm_arch_flags(cuda_flags)
+    elif with_cuda:
+        cuda_flags = common_cflags + COMMON_NVCC_FLAGS + _get_cuda_arch_flags()
+        if IS_WINDOWS:
+            for flag in COMMON_MSVC_FLAGS:
+                cuda_flags = ['-Xcompiler', flag] + cuda_flags
+            for ignore_warning in MSVC_IGNORE_CUDAFE_WARNINGS:
+                cuda_flags = ['-Xcudafe', '--diag_suppress=' + ignore_warning] + cuda_flags
+            cuda_flags = cuda_flags + ['-std=c++17']
+            cuda_flags = _nt_quote_args(cuda_flags)
+            cuda_flags += _nt_quote_args(extra_cuda_cflags)
+        else:
+            cuda_flags += ['--compiler-options', "'-fPIC'"]
+            cuda_flags += extra_cuda_cflags
+            if not any(flag.startswith('-std=') for flag in cuda_flags):
+                cuda_flags.append('-std=c++17')
+            cc_env = os.getenv("CC")
+            if cc_env is not None:
+                cuda_flags = ['-ccbin', cc_env] + cuda_flags
+    else:
+        cuda_flags = None
+
+    if with_sycl:
+        sycl_cflags = cflags + _COMMON_SYCL_FLAGS
+        sycl_cflags += extra_sycl_cflags
+        _append_sycl_std_if_no_std_present(sycl_cflags)
+        host_cflags = cflags
+        # escaping quoted arguments to pass them thru SYCL compiler
+        host_cflags = [item.replace('\\"', '\\\\"') for item in host_cflags]
+        host_cflags = ' '.join(host_cflags)
+        # sycl_cflags += _wrap_sycl_host_flags(host_cflags)
+        sycl_dlink_post_cflags = _SYCL_DLINK_FLAGS
+    else:
+        sycl_cflags = None
+        sycl_dlink_post_cflags = None
+
+    def object_file_path(source_file: str) -> str:
+        # '/path/to/file.cpp' -> 'file'
+        file_name = os.path.splitext(os.path.basename(source_file))[0]
+        if _is_cuda_file(source_file) and with_cuda:
+            # Use a different object filename in case a C++ and CUDA file have
+            # the same filename but different extension (.cpp vs. .cu).
+            target = f'{file_name}.cuda.o'
+        elif _is_sycl_file(source_file) and with_sycl:
+            target = f'{file_name}.sycl.o'
+        else:
+            target = f'{file_name}.o'
+        return target
+
+    objects = [object_file_path(src) for src in sources]
+    ldflags = ([] if is_standalone else [SHARED_FLAG]) + extra_ldflags
+
+    # The darwin linker needs explicit consent to ignore unresolved symbols.
+    if IS_MACOS:
+        ldflags.append('-undefined dynamic_lookup')
+    elif IS_WINDOWS:
+        ldflags = _nt_quote_args(ldflags)
+
+    ext = EXEC_EXT if is_standalone else LIB_EXT
+    library_target = f'{name}{ext}'
+
+    _write_ninja_file(
+        path=path,
+        cflags=cflags,
+        post_cflags=None,
+        cuda_cflags=cuda_flags,
+        cuda_post_cflags=None,
+        cuda_dlink_post_cflags=None,
+        sycl_cflags=sycl_cflags,
+        sycl_post_cflags=[],
+        sycl_dlink_post_cflags=sycl_dlink_post_cflags,
+        sources=sources,
+        objects=objects,
+        ldflags=ldflags,
+        library_target=library_target,
+        with_cuda=with_cuda,
+        with_sycl=with_sycl)
+
+
+def _write_ninja_file(path,
+                      cflags,
+                      post_cflags,
+                      cuda_cflags,
+                      cuda_post_cflags,
+                      cuda_dlink_post_cflags,
+                      sycl_cflags,
+                      sycl_post_cflags,
+                      sycl_dlink_post_cflags,
+                      sources,
+                      objects,
+                      ldflags,
+                      library_target,
+                      with_cuda,
+                      with_sycl) -> None:
+    r"""Write a ninja file that does the desired compiling and linking.
+
+    `path`: Where to write this file
+    `cflags`: list of flags to pass to $cxx. Can be None.
+    `post_cflags`: list of flags to append to the $cxx invocation. Can be None.
+    `cuda_cflags`: list of flags to pass to $nvcc. Can be None.
+    `cuda_post_cflags`: list of flags to append to the $nvcc invocation. Can be None.
+    `cuda_dlink_post_cflags`: list of flags to append to the $nvcc device code link invocation. Can be None.
+    `sycl_cflags`: list of flags to pass to SYCL compiler. Can be None.
+    `sycl_post_cflags`: list of flags to append to the SYCL compiler invocation. Can be None.
+    `sycl_dlink_post_cflags`: list of flags to append to the SYCL compiler device code link invocation. Can be None.
+e.
+    `sources`: list of paths to source files
+    `objects`: list of desired paths to objects, one per source.
+    `ldflags`: list of flags to pass to linker. Can be None.
+    `library_target`: Name of the output library. Can be None; in that case,
+                      we do no linking.
+    `with_cuda`: If we should be compiling with CUDA.
+    """
+    def sanitize_flags(flags):
+        if flags is None:
+            return []
+        else:
+            return [flag.strip() for flag in flags]
+
+    cflags = sanitize_flags(cflags)
+    post_cflags = sanitize_flags(post_cflags)
+    cuda_cflags = sanitize_flags(cuda_cflags)
+    cuda_post_cflags = sanitize_flags(cuda_post_cflags)
+    cuda_dlink_post_cflags = sanitize_flags(cuda_dlink_post_cflags)
+    sycl_cflags = sanitize_flags(sycl_cflags)
+    sycl_post_cflags = sanitize_flags(sycl_post_cflags)
+    sycl_dlink_post_cflags = sanitize_flags(sycl_dlink_post_cflags)
+    ldflags = sanitize_flags(ldflags)
+
+    # Sanity checks...
+    assert len(sources) == len(objects)
+    assert len(sources) > 0
+
+    compiler = get_cxx_compiler()
+
+    # Version 1.3 is required for the `deps` directive.
+    config = ['ninja_required_version = 1.3']
+    config.append(f'cxx = {compiler}')
+    if with_cuda or cuda_dlink_post_cflags:
+        if "PYTORCH_NVCC" in os.environ:
+            nvcc = os.getenv("PYTORCH_NVCC")    # user can set nvcc compiler with ccache using the environment variable here
+        else:
+            if IS_HIP_EXTENSION:
+                nvcc = _join_rocm_home('bin', 'hipcc')
+            else:
+                nvcc = _join_cuda_home('bin', 'nvcc')
+        config.append(f'nvcc = {nvcc}')
+    if with_sycl or sycl_dlink_post_cflags:
+        sycl = 'icx' if IS_WINDOWS else 'icpx'
+        config.append(f'sycl = {sycl}')
+
+    if IS_HIP_EXTENSION:
+        post_cflags = COMMON_HIP_FLAGS + post_cflags
+    flags = [f'cflags = {" ".join(cflags)}']
+    flags.append(f'post_cflags = {" ".join(post_cflags)}')
+    if with_cuda:
+        flags.append(f'cuda_cflags = {" ".join(cuda_cflags)}')
+        flags.append(f'cuda_post_cflags = {" ".join(cuda_post_cflags)}')
+    flags.append(f'cuda_dlink_post_cflags = {" ".join(cuda_dlink_post_cflags)}')
+    if with_sycl:
+        flags.append(f'sycl_cflags = {" ".join(sycl_cflags)}')
+        flags.append(f'sycl_post_cflags = {" ".join(sycl_post_cflags)}')
+    flags.append(f'sycl_dlink_post_cflags = {" ".join(sycl_dlink_post_cflags)}')
+    flags.append(f'ldflags = {" ".join(ldflags)}')
+
+    # Turn into absolute paths so we can emit them into the ninja build
+    # file wherever it is.
+    sources = [os.path.abspath(file) for file in sources]
+
+    # See https://ninja-build.org/build.ninja.html for reference.
+    compile_rule = ['rule compile']
+    if IS_WINDOWS:
+        compile_rule.append(
+            '  command = cl /showIncludes $cflags -c $in /Fo$out $post_cflags')
+        compile_rule.append('  deps = msvc')
+    else:
+        compile_rule.append(
+            '  command = $cxx -MMD -MF $out.d $cflags -c $in -o $out $post_cflags')
+        compile_rule.append('  depfile = $out.d')
+        compile_rule.append('  deps = gcc')
+
+    if with_cuda:
+        cuda_compile_rule = ['rule cuda_compile']
+        nvcc_gendeps = ''
+        # --generate-dependencies-with-compile is not supported by ROCm
+        # Nvcc flag `--generate-dependencies-with-compile` is not supported by sccache, which may increase build time.
+        if torch.version.cuda is not None and os.getenv('TORCH_EXTENSION_SKIP_NVCC_GEN_DEPENDENCIES', '0') != '1':
+            cuda_compile_rule.append('  depfile = $out.d')
+            cuda_compile_rule.append('  deps = gcc')
+            # Note: non-system deps with nvcc are only supported
+            # on Linux so use --generate-dependencies-with-compile
+            # to make this work on Windows too.
+            nvcc_gendeps = '--generate-dependencies-with-compile --dependency-output $out.d'
+        cuda_compile_rule.append(
+            f'  command = $nvcc {nvcc_gendeps} $cuda_cflags -c $in -o $out $cuda_post_cflags')
+
+    if with_sycl:
+        sycl_compile_rule = ['rule sycl_compile']
+        # SYCL compiler does not recognize .sycl extension automatically,
+        # so we pass '-x c++' explicitly notifying compiler of file format
+        sycl_compile_rule.append(
+            '  command = $sycl $sycl_cflags -c -x c++ $in -o $out $sycl_post_cflags')
+
+
+    # Emit one build rule per source to enable incremental build.
+    build = []
+    for source_file, object_file in zip(sources, objects):
+        is_cuda_source = _is_cuda_file(source_file) and with_cuda
+        is_sycl_source = _is_sycl_file(source_file) and with_sycl
+        if is_cuda_source:
+            rule = 'cuda_compile'
+        elif is_sycl_source:
+            rule = 'sycl_compile'
+        else:
+            rule = 'compile'
+        if IS_WINDOWS:
+            source_file = source_file.replace(':', '$:')
+            object_file = object_file.replace(':', '$:')
+        source_file = source_file.replace(" ", "$ ")
+        object_file = object_file.replace(" ", "$ ")
+        build.append(f'build {object_file}: {rule} {source_file}')
+
+    if cuda_dlink_post_cflags:
+        cuda_devlink_out = os.path.join(os.path.dirname(objects[0]), 'dlink.o')
+        cuda_devlink_rule = ['rule cuda_devlink']
+        cuda_devlink_rule.append('  command = $nvcc $in -o $out $cuda_dlink_post_cflags')
+        cuda_devlink = [f'build {cuda_devlink_out}: cuda_devlink {" ".join(objects)}']
+        objects += [cuda_devlink_out]
+    else:
+        cuda_devlink_rule, cuda_devlink = [], []
+
+    if sycl_dlink_post_cflags:
+        sycl_devlink_out = os.path.join(os.path.dirname(objects[0]), 'sycl_dlink.o')
+        sycl_devlink_rule = ['rule sycl_devlink']
+        sycl_devlink_rule.append('  command = $sycl $in -o $out $sycl_dlink_post_cflags')
+        sycl_devlink = [f'build {sycl_devlink_out}: sycl_devlink {" ".join(objects)}']
+        objects += [sycl_devlink_out]
+    else:
+        sycl_devlink_rule, sycl_devlink = [], []
+
+    if library_target is not None:
+        link_rule = ['rule link']
+        if IS_WINDOWS:
+            cl_paths = subprocess.check_output(['where',
+                                                'cl']).decode(*SUBPROCESS_DECODE_ARGS).split('\r\n')
+            if len(cl_paths) >= 1:
+                cl_path = os.path.dirname(cl_paths[0]).replace(':', '$:')
+            else:
+                raise RuntimeError("MSVC is required to load C++ extensions")
+            link_rule.append(f'  command = "{cl_path}/link.exe" $in /nologo $ldflags /out:$out')
+        else:
+            link_rule.append('  command = $cxx $in $ldflags -o $out')
+
+        link = [f'build {library_target}: link {" ".join(objects)}']
+
+        default = [f'default {library_target}']
+    else:
+        link_rule, link, default = [], [], []
+
+    # 'Blocks' should be separated by newlines, for visual benefit.
+    blocks = [config, flags, compile_rule]
+    if with_cuda:
+        blocks.append(cuda_compile_rule)  # type: ignore[possibly-undefined]
+    if with_sycl:
+        blocks.append(sycl_compile_rule)  # type: ignore[possibly-undefined]
+    blocks += [cuda_devlink_rule, sycl_devlink_rule, link_rule, build, cuda_devlink, sycl_devlink, link, default]
+    content = "\n\n".join("\n".join(b) for b in blocks)
+    # Ninja requires a new lines at the end of the .ninja file
+    content += "\n"
+    _maybe_write(path, content)
+
+def _join_cuda_home(*paths) -> str:
+    """
+    Join paths with CUDA_HOME, or raises an error if it CUDA_HOME is not set.
+
+    This is basically a lazy way of raising an error for missing $CUDA_HOME
+    only once we need to get any CUDA-specific path.
+    """
+    if CUDA_HOME is None:
+        raise OSError('CUDA_HOME environment variable is not set. '
+                      'Please set it to your CUDA install root.')
+    return os.path.join(CUDA_HOME, *paths)
+
+
+def _is_cuda_file(path: str) -> bool:
+    valid_ext = ['.cu', '.cuh']
+    if IS_HIP_EXTENSION:
+        valid_ext.append('.hip')
+    return os.path.splitext(path)[1] in valid_ext
+
+def _is_sycl_file(path: str) -> bool:
+    valid_ext = ['.sycl']
+    return os.path.splitext(path)[1] in valid_ext

--- a/vllm/custom-esimd-kernels-vllm/include/kernel_ops.h
+++ b/vllm/custom-esimd-kernels-vllm/include/kernel_ops.h
@@ -1,0 +1,181 @@
+#pragma once
+
+#include <ATen/ATen.h>
+#include <ATen/Tensor.h>
+#include <torch/library.h>
+#include <torch/torch.h>
+
+// FP8 weight GEMV with per-N scale: output = input @ dequant(weight_fp8) * scale
+// FP32 accumulation, element-wise acc + deferred scale. Optimized for decode (M=1).
+at::Tensor esimd_gemv_fp8_pern(
+    at::Tensor input, at::Tensor weight, at::Tensor weight_scale,
+    at::Tensor output,
+    int64_t N, int64_t K);
+
+// Fused FP8 GEMV: single kernel submit for 2 weight matrices (same input, same K)
+at::Tensor esimd_gemv_fp8_pern_fused2(
+    at::Tensor input,
+    at::Tensor w0, at::Tensor s0, at::Tensor o0, int64_t N0,
+    at::Tensor w1, at::Tensor s1, at::Tensor o1, int64_t N1,
+    int64_t K);
+
+// Fused FP8 GEMV: single kernel submit for 3 weight matrices (same input, same K)
+at::Tensor esimd_gemv_fp8_pern_fused3(
+    at::Tensor input,
+    at::Tensor w0, at::Tensor s0, at::Tensor o0, int64_t N0,
+    at::Tensor w1, at::Tensor s1, at::Tensor o1, int64_t N1,
+    at::Tensor w2, at::Tensor s2, at::Tensor o2, int64_t N2,
+    int64_t K);
+
+// Per-tensor scale variants: scale is fp32 scalar, N/K auto-detected from tensor shapes
+at::Tensor esimd_gemv_fp8_pert(
+    at::Tensor input, at::Tensor weight, at::Tensor weight_scale,
+    at::Tensor output);
+
+at::Tensor esimd_gemv_fp8_pert_fused2(
+    at::Tensor input,
+    at::Tensor w0, at::Tensor s0, at::Tensor o0,
+    at::Tensor w1, at::Tensor s1, at::Tensor o1);
+
+at::Tensor esimd_gemv_fp8_pert_fused3(
+    at::Tensor input,
+    at::Tensor w0, at::Tensor s0, at::Tensor o0,
+    at::Tensor w1, at::Tensor s1, at::Tensor o1,
+    at::Tensor w2, at::Tensor s2, at::Tensor o2);
+
+// Fused QKV Split + RMSNorm(weight+1.0, eps=1e-6) + RoPE(theta=10M, headDim=256)
+// qkv_state: [nTokens, hiddenDim] fp16 — packed QKV (or QGKV with gating)
+// q_out:     [nTokens, qHead*256] fp16
+// gate_out:  [nTokens, qHead*256] fp16 (ignored if !attn_output_gate)
+// k_out:     [nTokens, kvHead*256] fp16
+// v_out:     [nTokens, kvHead*256] fp16
+// norm_wq/wk: [256] fp16 — RMSNorm weights
+// positions: [nTokens] int32 — RoPE position indices
+at::Tensor esimd_qkv_split_norm_rope(
+    at::Tensor qkv_state,
+    at::Tensor q_out, at::Tensor gate_out,
+    at::Tensor k_out, at::Tensor v_out,
+    at::Tensor norm_wq, at::Tensor norm_wk,
+    at::Tensor positions,
+    int64_t q_heads, int64_t kv_heads, bool attn_output_gate,
+    int64_t rotary_dim, at::Tensor cos_sin_cache);
+
+// Fused Conv1d + GDN for Qwen3-Next-80B-A3B decode — reads from projections directly
+// qkvz:               [N, qkvz_dim] fp16 — projected_states_qkvz, read-only
+// conv_state:         [num_cache, 3, 2048] fp16, strided dim0
+// conv_weight:        [2048, 4] fp16
+// conv_bias:          [2048] fp16 (zeros if model has no bias)
+// conv_state_indices: [N] int32
+// A_log:              [HV] fp16
+// dt_bias:            [HV] fp16
+// ba:                 [N, 2*HV] fp16 — projected_states_ba, interleaved [b_grp, a_grp, ...]
+// ssm_state:          [num_states, HV, V, K] fp16, strided dim0
+// ssm_state_indices:  [N] int32
+// output:             [N, HV, V] fp16
+// z_out:              [N, HV, V] fp16 — z gate extracted from qkvz
+at::Tensor esimd_gdn_conv_fused(
+    at::Tensor qkvz,
+    at::Tensor conv_state, at::Tensor conv_weight, at::Tensor conv_bias,
+    at::Tensor conv_state_indices,
+    at::Tensor A_log, at::Tensor dt_bias,
+    at::Tensor ba,
+    at::Tensor ssm_state, at::Tensor ssm_state_indices,
+    at::Tensor output, at::Tensor z_out,
+    int64_t N, int64_t H, int64_t HV,
+    int64_t K, int64_t V,
+    double scale);
+
+// Fused Conv1d + GDN for SEQUENTIAL qkvz layout [q_all|k_all|v_all|z_all]
+// Same as esimd_gdn_conv_fused but reads qkvz/ba in sequential (non-interleaved) order.
+// For models like Qwen3.5-35B-A3B where GEMV outputs sequential layout.
+at::Tensor esimd_gdn_conv_fused_seq(
+    at::Tensor qkvz,
+    at::Tensor conv_state, at::Tensor conv_weight, at::Tensor conv_bias,
+    at::Tensor conv_state_indices,
+    at::Tensor A_log, at::Tensor dt_bias,
+    at::Tensor ba,
+    at::Tensor ssm_state, at::Tensor ssm_state_indices,
+    at::Tensor output, at::Tensor z_out,
+    int64_t N, int64_t H, int64_t HV,
+    int64_t K, int64_t V,
+    double scale);
+
+// Fused ResidualAdd + RMSNorm + FP8 GEMV (post_attn_norm + router)
+at::Tensor esimd_resadd_norm_gemv_fp8_pert(
+    at::Tensor hidden_states, at::Tensor residual, at::Tensor norm_weight,
+    at::Tensor gemv_weight, at::Tensor gemv_scale, at::Tensor output, at::Tensor normed_out,
+    double eps);
+
+// Fused ResidualAdd + RMSNorm + 2-matrix FP8 GEMV (input_norm + GDN in_proj)
+at::Tensor esimd_resadd_norm_gemv2_fp8_pert(
+    at::Tensor hidden_states, at::Tensor residual, at::Tensor norm_weight,
+    at::Tensor w0, at::Tensor s0, at::Tensor o0,
+    at::Tensor w1, at::Tensor s1, at::Tensor o1,
+    double eps);
+
+// Fused RMSNormGated + FP8 GEMV for GDN out_proj decode path
+// x:            [HV, V] fp16 — core_attn_out from GDN kernel
+// z:            [HV, V] fp16 — z_out from GDN kernel
+// norm_weight:  [V] fp16 — RMSNorm weight (per head_v_dim)
+// gemv_weight:  [N, K] FP8, K = HV*V — out_proj weight
+// gemv_scale:   [1] fp32 — per-tensor FP8 scale
+// output:       [1, N] fp16
+at::Tensor esimd_norm_gemv_fp8_pert(
+    at::Tensor x, at::Tensor z, at::Tensor norm_weight,
+    at::Tensor gemv_weight, at::Tensor gemv_scale, at::Tensor output,
+    int64_t HV, int64_t V, double eps);
+
+// Fused Add + RMSNorm (Gemma-style)
+at::Tensor esimd_fused_add_rms_norm(
+    at::Tensor hidden_states, at::Tensor residual,
+    at::Tensor weight, double eps);
+
+// ======================== MoE Auxiliary Ops ========================
+
+// Fused softmax + top-8 + normalize
+at::Tensor esimd_moe_topk(
+    at::Tensor router_logits, at::Tensor top_values, at::Tensor top_indices,
+    int64_t T);
+
+// Scatter hidden_states by expert grouping
+at::Tensor esimd_moe_scatter(
+    at::Tensor hidden_states, at::Tensor router_top_value,
+    at::Tensor sorted_token_ids,
+    at::Tensor scattered_hidden, at::Tensor scattered_weights,
+    int64_t K, int64_t topk, int64_t total_expanded);
+
+// Fused GPU scatter: atomic counting → prefix-sum → copy (no CPU preprocessing)
+at::Tensor esimd_moe_scatter_fused(
+    at::Tensor hidden_states, at::Tensor top_values, at::Tensor top_indices,
+    at::Tensor scattered_hidden, at::Tensor scattered_weights,
+    at::Tensor topk_ids, at::Tensor expert_start, at::Tensor max_tokens_out,
+    int64_t K, int64_t topk, int64_t T, int64_t num_experts);
+
+// SiLU(gate) * up activation
+at::Tensor esimd_moe_silu_mul(
+    at::Tensor input, at::Tensor output,
+    int64_t N_gate_up, int64_t N_half, int64_t total_rows);
+
+// Weighted gather/reduce
+at::Tensor esimd_moe_gather(
+    at::Tensor moe_output, at::Tensor topk_ids, at::Tensor scattered_weights,
+    at::Tensor final_hidden,
+    int64_t K, int64_t topk, int64_t T);
+
+// MoE grouped GEMM — FP8 E5M2 with per-N scale
+at::Tensor esimd_moe_gemm_fp8(
+    at::Tensor input, at::Tensor weight, at::Tensor scale,
+    at::Tensor output, at::Tensor expert_idx,
+    int64_t N, int64_t K, int64_t num_experts, int64_t max_tokens_per_expert);
+
+// FP8 GEMM per-tensor scale: input [M, K] fp16, weight [N, K] fp8, output [M, N] fp16
+// Auto-dispatches: M<=3 → batched GEMV, M>=2 E4M3 → DPAS V9, else → WS
+at::Tensor esimd_gemm_fp8_pert(
+    at::Tensor input, at::Tensor weight, at::Tensor weight_scale,
+    at::Tensor output);
+
+// MoE grouped GEMM — FP8 E5M2 with per-tensor scale (one scalar per expert)
+at::Tensor esimd_moe_gemm_fp8_pert(
+    at::Tensor input, at::Tensor weight, at::Tensor scale,
+    at::Tensor output, at::Tensor expert_idx,
+    int64_t N, int64_t K, int64_t num_experts, int64_t max_tokens_per_expert);

--- a/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/__init__.py
+++ b/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/__init__.py
@@ -1,0 +1,48 @@
+import torch
+
+# Core ESIMD kernels (4 compiled modules)
+from custom_esimd_kernels_vllm import custom_esimd_kernels
+from custom_esimd_kernels_vllm import custom_esimd_kernels_lgrf
+from custom_esimd_kernels_vllm import custom_esimd_kernels_moe
+from custom_esimd_kernels_vllm import custom_esimd_kernels_gemm
+
+# Eagle kernels — registers torch.ops.eagle_ops.*
+from custom_esimd_kernels_vllm import eagle_ops
+
+# MoE Batch kernels — registers torch.ops.moe_ops.*
+from custom_esimd_kernels_vllm import moe_ops
+
+from custom_esimd_kernels_vllm.ops import (
+    # Core ESIMD ops
+    esimd_gemv_fp8_pern,
+    esimd_gemv_fp8_pern_fused2,
+    esimd_gemv_fp8_pern_fused3,
+    esimd_gemv_fp8_pert,
+    esimd_gemv_fp8_pert_fused2,
+    esimd_gemv_fp8_pert_fused3,
+    esimd_qkv_split_norm_rope,
+    esimd_gdn_conv_fused,
+    esimd_fused_add_rms_norm,
+    esimd_resadd_norm_gemv_fp8_pert,
+    esimd_resadd_norm_gemv2_fp8_pert,
+    esimd_norm_gemv_fp8_pert,
+    esimd_gdn_conv_fused_seq,
+    esimd_moe_topk,
+    esimd_moe_scatter_fused,
+    esimd_moe_silu_mul,
+    esimd_moe_gather,
+    esimd_moe_gemm_fp8,
+    esimd_moe_gemm_fp8_pert,
+    esimd_gemm_fp8_pert,
+    # Eagle ops
+    eagle_gdn,
+    eagle_page_attn_decode,
+    # MoE Batch ops
+    moe_router_forward,
+    moe_batch_topk,
+    moe_up_forward,
+    moe_down_forward,
+    moe_accumulate,
+    moe_forward_fused,
+    moe_forward_full,
+)

--- a/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/ops.py
+++ b/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/ops.py
@@ -1,0 +1,697 @@
+"""Python wrappers for custom ESIMD kernels."""
+import torch
+
+_ops = torch.ops.custom_esimd_kernels_vllm
+
+
+def esimd_gemv_fp8_pern(
+    input: torch.Tensor, weight: torch.Tensor, weight_scale: torch.Tensor,
+    output: torch.Tensor,
+    N: int, K: int,
+) -> torch.Tensor:
+    """FP8 weight GEMV with per-N scale, FP32 accumulation, deferred scale.
+
+    input: [1, K] fp16, weight: [N, K] fp8_e4m3, scale: [N] fp16, output: [1, N] fp16.
+    K must be 256-aligned. N must be 8-aligned.
+    """
+    return _ops.esimd_gemv_fp8_pern(input, weight, weight_scale, output, N, K)
+
+
+def esimd_gemv_fp8_pern_fused2(
+    input: torch.Tensor,
+    w0: torch.Tensor, s0: torch.Tensor, o0: torch.Tensor, N0: int,
+    w1: torch.Tensor, s1: torch.Tensor, o1: torch.Tensor, N1: int,
+    K: int,
+) -> torch.Tensor:
+    """Fused FP8 GEMV for 2 weight matrices sharing the same input and K.
+
+    Single kernel submit: eliminates redundant launch overhead.
+    Each weight/scale/output is independent; results written to o0 and o1.
+    Returns o0 (first output tensor).
+    """
+    return _ops.esimd_gemv_fp8_pern_fused2(input, w0, s0, o0, N0, w1, s1, o1, N1, K)
+
+
+def esimd_gemv_fp8_pern_fused3(
+    input: torch.Tensor,
+    w0: torch.Tensor, s0: torch.Tensor, o0: torch.Tensor, N0: int,
+    w1: torch.Tensor, s1: torch.Tensor, o1: torch.Tensor, N1: int,
+    w2: torch.Tensor, s2: torch.Tensor, o2: torch.Tensor, N2: int,
+    K: int,
+) -> torch.Tensor:
+    """Fused FP8 GEMV for 3 weight matrices sharing the same input and K.
+
+    Single kernel submit: eliminates redundant launch overhead.
+    Each weight/scale/output is independent; results written to o0, o1, o2.
+    Returns o0 (first output tensor).
+    """
+    return _ops.esimd_gemv_fp8_pern_fused3(input, w0, s0, o0, N0, w1, s1, o1, N1, w2, s2, o2, N2, K)
+
+
+# ---- Per-tensor scale variants (N/K auto-detected from weight shape) ----
+
+def esimd_gemv_fp8_pert(
+    input: torch.Tensor, weight: torch.Tensor, weight_scale: torch.Tensor,
+    output: torch.Tensor,
+) -> torch.Tensor:
+    """FP8 weight GEMV with per-tensor scale (fp32 scalar).
+
+    input: [1, K] fp16, weight: [N, K] fp8_e4m3, scale: fp32 scalar, output: [1, N] fp16.
+    N and K are inferred from weight shape.
+    """
+    return _ops.esimd_gemv_fp8_pert(input, weight, weight_scale, output)
+
+
+def esimd_gemv_fp8_pert_fused2(
+    input: torch.Tensor,
+    w0: torch.Tensor, s0: torch.Tensor, o0: torch.Tensor,
+    w1: torch.Tensor, s1: torch.Tensor, o1: torch.Tensor,
+) -> torch.Tensor:
+    """Fused FP8 GEMV for 2 weight matrices with per-tensor scale.
+
+    N0, N1 inferred from w0.size(0), w1.size(0). K from w0.size(1).
+    """
+    return _ops.esimd_gemv_fp8_pert_fused2(input, w0, s0, o0, w1, s1, o1)
+
+
+def esimd_gemv_fp8_pert_fused3(
+    input: torch.Tensor,
+    w0: torch.Tensor, s0: torch.Tensor, o0: torch.Tensor,
+    w1: torch.Tensor, s1: torch.Tensor, o1: torch.Tensor,
+    w2: torch.Tensor, s2: torch.Tensor, o2: torch.Tensor,
+) -> torch.Tensor:
+    """Fused FP8 GEMV for 3 weight matrices with per-tensor scale.
+
+    N0, N1, N2 inferred from w0/w1/w2.size(0). K from w0.size(1).
+    """
+    return _ops.esimd_gemv_fp8_pert_fused3(input, w0, s0, o0, w1, s1, o1, w2, s2, o2)
+
+
+# ---- Fused QKV Split + RMSNorm + RoPE ----
+
+def esimd_qkv_split_norm_rope(
+    qkv_state: torch.Tensor,
+    q_out: torch.Tensor,
+    gate_out: torch.Tensor,
+    k_out: torch.Tensor,
+    v_out: torch.Tensor,
+    norm_wq: torch.Tensor,
+    norm_wk: torch.Tensor,
+    positions: torch.Tensor,
+    q_heads: int,
+    kv_heads: int,
+    attn_output_gate: bool,
+    rotary_dim: int = 256,
+    cos_sin_cache: torch.Tensor = None,
+) -> torch.Tensor:
+    """Fused QKV Split + RMSNorm(weight+1.0, eps=1e-6) + RoPE.
+
+    qkv_state:     [nTokens, hiddenDim] fp16 — packed QKV projection output
+    q_out:         [nTokens, qHead*256] fp16
+    gate_out:      [nTokens, qHead*256] fp16 (unused if not attn_output_gate)
+    k_out:         [nTokens, kvHead*256] fp16
+    v_out:         [nTokens, kvHead*256] fp16
+    norm_wq/wk:    [256] fp16 — RMSNorm weights (Qwen3 weight+1.0 convention)
+    positions:     [nTokens] int32 — RoPE position indices
+    rotary_dim:    number of dimensions to apply RoPE.
+    cos_sin_cache: [max_pos, rotary_dim] fp16 — from rotary_emb.cos_sin_cache.
+                   Layout: [cos(rotary_dim/2), sin(rotary_dim/2)] per row.
+    headDim=256 only.
+    """
+    return _ops.esimd_qkv_split_norm_rope(
+        qkv_state, q_out, gate_out, k_out, v_out,
+        norm_wq, norm_wk, positions,
+        q_heads, kv_heads, attn_output_gate, rotary_dim, cos_sin_cache)
+
+
+# ---- Fused Conv1d + GDN (doubleGRF, LGRF module) ----
+
+def esimd_gdn_conv_fused(
+    qkvz: torch.Tensor,
+    conv_state: torch.Tensor,
+    conv_weight: torch.Tensor,
+    conv_bias: torch.Tensor,
+    conv_state_indices: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    ba: torch.Tensor,
+    ssm_state: torch.Tensor,
+    ssm_state_indices: torch.Tensor,
+    output: torch.Tensor,
+    z_out: torch.Tensor,
+    N: int, H: int, HV: int,
+    K: int, V: int,
+    scale: float,
+) -> torch.Tensor:
+    """Fused Conv1d + GDN for Qwen3-Next-80B-A3B decode.
+
+    Reads directly from projection outputs — zero extra submits.
+    Phase 1: Conv1d with SiLU, reads x from qkvz at mapped offsets.
+    Phase 2: GDN recurrent update.
+    Phase 3: conv_state shift + z extraction from qkvz.
+
+    qkvz:               [N, qkvz_dim] fp16 — projected_states_qkvz (read-only)
+    conv_state:         [num_cache, 3, 2048] fp16, strided dim0
+    conv_weight:        [2048, 4] fp16
+    conv_bias:          [2048] fp16 (zeros if no bias)
+    conv_state_indices: [N] int32
+    A_log:              [HV] fp16
+    dt_bias:            [HV] fp16
+    ba:                 [N, 2*HV] fp16 — projected_states_ba, interleaved layout
+    ssm_state:          [num_states, HV, V, K] fp16, strided dim0
+    ssm_state_indices:  [N] int32
+    output:             [N, HV, V] fp16 — GDN output (core_attn_out)
+    z_out:              [N, HV, V] fp16 — z gate extracted from qkvz
+    """
+    return _ops.esimd_gdn_conv_fused(
+        qkvz, conv_state, conv_weight, conv_bias, conv_state_indices,
+        A_log, dt_bias, ba,
+        ssm_state, ssm_state_indices, output, z_out,
+        N, H, HV, K, V, scale)
+
+
+def esimd_fused_add_rms_norm(
+    hidden_states: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    """Fused residual add + RMSNorm (Gemma-style).
+
+    residual = hidden_states + residual  (in-place)
+    hidden_states = rmsnorm(residual) * weight  (output)
+    weight must be pre-adjusted (w+1.0).
+    """
+    return _ops.esimd_fused_add_rms_norm(hidden_states, residual, weight, eps)
+
+
+def esimd_resadd_norm_gemv_fp8_pert(
+    hidden_states: torch.Tensor,
+    residual: torch.Tensor,
+    norm_weight: torch.Tensor,
+    gemv_weight: torch.Tensor,
+    gemv_scale: torch.Tensor,
+    output: torch.Tensor,
+    normed_out: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    """Fused ResidualAdd + RMSNorm + FP8 GEMV.
+
+    Combines post_attention_layernorm + MoE router GEMV:
+      1. residual = hidden_states + residual  (in-place)
+      2. normed = rmsnorm(residual) * norm_weight  (Gemma-style, w+1 pre-applied)
+      3. output = normed @ dequant(gemv_weight^T) * scale
+      4. normed_out = normed  (for MoE expert consumption)
+
+    hidden_states: [1, K] fp16
+    residual:      [1, K] fp16 (updated in-place)
+    norm_weight:   [K] fp16 (Gemma _gemma_w)
+    gemv_weight:   [N, K] FP8
+    gemv_scale:    [1] fp32
+    output:        [1, N] fp16 — router logits
+    normed_out:    [1, K] fp16 — normed hidden for experts
+    """
+    return _ops.esimd_resadd_norm_gemv_fp8_pert(
+        hidden_states, residual, norm_weight,
+        gemv_weight, gemv_scale, output, normed_out, eps)
+
+
+def esimd_resadd_norm_gemv2_fp8_pert(
+    hidden_states: torch.Tensor,
+    residual: torch.Tensor,
+    norm_weight: torch.Tensor,
+    w0: torch.Tensor, s0: torch.Tensor, o0: torch.Tensor,
+    w1: torch.Tensor, s1: torch.Tensor, o1: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    """Fused ResidualAdd + RMSNorm + 2-matrix FP8 GEMV.
+
+    For input_layernorm + GDN in_proj (qkvz + ba projections).
+    residual updated in-place. o0/o1 are output buffers.
+    """
+    return _ops.esimd_resadd_norm_gemv2_fp8_pert(
+        hidden_states, residual, norm_weight,
+        w0, s0, o0, w1, s1, o1, eps)
+
+
+def esimd_norm_gemv_fp8_pert(
+    x: torch.Tensor,
+    z: torch.Tensor,
+    norm_weight: torch.Tensor,
+    gemv_weight: torch.Tensor,
+    gemv_scale: torch.Tensor,
+    output: torch.Tensor,
+    HV: int,
+    V: int,
+    eps: float,
+) -> torch.Tensor:
+    """Fused RMSNormGated + FP8 GEMV for GDN out_proj decode path.
+
+    Combines norm(x, z) + out_proj(normed) into a single kernel.
+    Eliminates norm kernel launch, torch.empty, reshape overhead.
+
+    x:            [HV, V] fp16 — core_attn_out
+    z:            [HV, V] fp16 — z_out
+    norm_weight:  [V] fp16 — RMSNorm weight
+    gemv_weight:  [N, K] FP8, K = HV*V — out_proj weight
+    gemv_scale:   [1] fp32 — per-tensor scale
+    output:       [1, N] fp16 — pre-allocated output buffer
+    """
+    return _ops.esimd_norm_gemv_fp8_pert(
+        x, z, norm_weight, gemv_weight, gemv_scale, output,
+        HV, V, eps)
+
+
+def esimd_gdn_conv_fused_seq(
+    qkvz: torch.Tensor,
+    conv_state: torch.Tensor,
+    conv_weight: torch.Tensor,
+    conv_bias: torch.Tensor,
+    conv_state_indices: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    ba: torch.Tensor,
+    ssm_state: torch.Tensor,
+    ssm_state_indices: torch.Tensor,
+    output: torch.Tensor,
+    z_out: torch.Tensor,
+    N: int, H: int, HV: int,
+    K: int, V: int,
+    scale: float,
+) -> torch.Tensor:
+    """Fused Conv1d + GDN for SEQUENTIAL qkvz layout [q|k|v|z].
+
+    Same as esimd_gdn_conv_fused but reads qkvz in sequential order
+    instead of GQA-interleaved. For models like Qwen3.5-35B-A3B where
+    MergedColumnParallelLinear outputs [q_all|k_all|v_all|z_all].
+
+    ba is also sequential: [b_all(HV) | a_all(HV)].
+
+    Eliminates ALL host-side rearrangement (no cat, reshape, gather).
+    """
+    return _ops.esimd_gdn_conv_fused_seq(
+        qkvz, conv_state, conv_weight, conv_bias, conv_state_indices,
+        A_log, dt_bias, ba,
+        ssm_state, ssm_state_indices, output, z_out,
+        N, H, HV, K, V, scale)
+
+
+# ---- MoE Auxiliary Ops (doubleGRF, LGRF module) ----
+
+def esimd_moe_topk(
+    router_logits: torch.Tensor,
+    top_values: torch.Tensor,
+    top_indices: torch.Tensor,
+    T: int,
+) -> torch.Tensor:
+    """Fused softmax + top-8 selection + normalize.
+
+    router_logits: [T, 128] fp16
+    top_values:    [T, 8] fp16 (output)
+    top_indices:   [T, 8] int32 (output)
+    """
+    return _ops.esimd_moe_topk(router_logits, top_values, top_indices, T)
+
+
+def esimd_moe_scatter(
+    hidden_states: torch.Tensor,
+    router_top_value: torch.Tensor,
+    sorted_token_ids: torch.Tensor,
+    scattered_hidden: torch.Tensor,
+    scattered_weights: torch.Tensor,
+    K: int,
+    topk: int,
+    total_expanded: int,
+) -> torch.Tensor:
+    """Scatter hidden_states by expert grouping.
+
+    hidden_states:    [T, K] fp16
+    router_top_value: [T, topk] fp16
+    sorted_token_ids: [total_expanded] int32
+    scattered_hidden: [total_expanded, K] fp16 (output)
+    scattered_weights:[total_expanded] fp16 (output)
+    """
+    return _ops.esimd_moe_scatter(
+        hidden_states, router_top_value, sorted_token_ids,
+        scattered_hidden, scattered_weights, K, topk, total_expanded)
+
+
+def esimd_moe_scatter_fused(
+    hidden_states: torch.Tensor,
+    top_values: torch.Tensor,
+    top_indices: torch.Tensor,
+    scattered_hidden: torch.Tensor,
+    scattered_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    expert_start: torch.Tensor,
+    max_tokens_out: torch.Tensor,
+    K: int,
+    topk: int,
+    T: int,
+    num_experts: int,
+) -> torch.Tensor:
+    """Fused GPU scatter: atomic counting + prefix-sum + copy. No CPU preprocessing.
+
+    hidden_states:    [T, K] fp16
+    top_values:       [T, topk] fp16
+    top_indices:      [T, topk] int32
+    scattered_hidden: [T*topk, K] fp16 (output)
+    scattered_weights:[T*topk] fp16 (output)
+    topk_ids:         [T*topk] int32 (output — reverse map for Gather)
+    expert_start:     [num_experts+1] uint32 (output)
+    max_tokens_out:   [1] int32 (output)
+    """
+    return _ops.esimd_moe_scatter_fused(
+        hidden_states, top_values, top_indices,
+        scattered_hidden, scattered_weights,
+        topk_ids, expert_start, max_tokens_out,
+        K, topk, T, num_experts)
+
+
+def esimd_moe_silu_mul(
+    input: torch.Tensor,
+    output: torch.Tensor,
+    N_gate_up: int,
+    N_half: int,
+    total_rows: int,
+) -> torch.Tensor:
+    """SiLU(gate) * up activation.
+
+    input:  [total_rows, N_gate_up] fp16
+    output: [total_rows, N_half] fp16
+    """
+    return _ops.esimd_moe_silu_mul(input, output, N_gate_up, N_half, total_rows)
+
+
+def esimd_moe_gather(
+    moe_output: torch.Tensor,
+    topk_ids: torch.Tensor,
+    scattered_weights: torch.Tensor,
+    final_hidden: torch.Tensor,
+    K: int,
+    topk: int,
+    T: int,
+) -> torch.Tensor:
+    """Weighted gather/reduce from scattered expert outputs.
+
+    moe_output:       [total_expanded, K] fp16
+    topk_ids:         [T, topk] int32
+    scattered_weights:[total_expanded] fp16
+    final_hidden:     [T, K] fp16 (output)
+    """
+    return _ops.esimd_moe_gather(
+        moe_output, topk_ids, scattered_weights, final_hidden, K, topk, T)
+
+
+def esimd_moe_gemm_fp8(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    output: torch.Tensor,
+    expert_idx: torch.Tensor,
+    N: int,
+    K: int,
+    num_experts: int,
+    max_tokens_per_expert: int,
+) -> torch.Tensor:
+    """MoE grouped GEMM — FP8 E5M2 with per-N scale.
+
+    input:      [total_tokens, K] fp16
+    weight:     [num_experts, N, K] uint8 FP8 E5M2
+    scale:      [num_experts, N] float32
+    output:     [total_tokens, N] fp16
+    expert_idx: [num_experts+1] uint32 — token start offsets per expert
+    """
+    return _ops.esimd_moe_gemm_fp8(
+        input, weight, scale, output, expert_idx,
+        N, K, num_experts, max_tokens_per_expert)
+
+
+def esimd_gemm_fp8_pert(
+    input: torch.Tensor, weight: torch.Tensor, weight_scale: torch.Tensor,
+    output: torch.Tensor,
+) -> torch.Tensor:
+    """FP8 GEMM with per-tensor scale — handles any M (auto-dispatches).
+
+    input:  [M, K] fp16, weight: [N, K] fp8, scale: fp32 scalar, output: [M, N] fp16.
+    N and K are inferred from weight shape. M from input shape.
+
+    Auto-dispatch:
+      M=1-3  → batched GEMV (BW-bound, K-split SLM reduction)
+      M>=2   → DPAS V9 (E4M3, K%64==0) or DPAS V7 (E5M2) or WS fallback
+    """
+    return _ops.esimd_gemm_fp8_pert(input, weight, weight_scale, output)
+
+
+def esimd_moe_gemm_fp8_pert(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    output: torch.Tensor,
+    expert_idx: torch.Tensor,
+    N: int,
+    K: int,
+    num_experts: int,
+    max_tokens_per_expert: int,
+) -> torch.Tensor:
+    """MoE grouped GEMM — FP8 E5M2 with per-tensor scale (one per expert).
+
+    input:      [total_tokens, K] fp16
+    weight:     [num_experts, N, K] uint8 FP8 E5M2
+    scale:      [num_experts] float32 — one scalar per expert
+    output:     [total_tokens, N] fp16
+    expert_idx: [num_experts+1] uint32 — token start offsets per expert
+    """
+    return _ops.esimd_moe_gemm_fp8_pert(
+        input, weight, scale, output, expert_idx,
+        N, K, num_experts, max_tokens_per_expert)
+
+
+# ---- Eagle Ops (GDN + Page Attention) ----
+
+_eagle_ops = torch.ops.eagle_ops
+
+
+def eagle_gdn(
+    qkvz: torch.Tensor,
+    z_out: torch.Tensor,
+    conv_w: torch.Tensor,
+    conv_b: torch.Tensor,
+    conv_state: torch.Tensor,
+    accepted_tokens: torch.Tensor,
+    ba: torch.Tensor,
+    a_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    state_in: torch.Tensor,
+    ssm_state_idx: torch.Tensor,
+    norm_w: torch.Tensor,
+    max_query_len: int,
+) -> torch.Tensor:
+    """Eagle GDN fused kernel: Conv1d + SSM + Attention.
+
+    qkvz:            [batches, dim] fp16 — packed projection output
+    z_out:           [batches, HV*V] fp16 — z gate output
+    conv_w:          [dim, kernel_size] fp16
+    conv_b:          [dim] fp16 or None
+    conv_state:      [num_cache, kernel_size-1, dim] fp16
+    accepted_tokens: [batches] int32
+    ba:              [batches, 2*HV] fp16
+    a_log:           [HV] fp16
+    dt_bias:         [HV] fp16
+    state_in:        [num_states, HV, V, K] fp16
+    ssm_state_idx:   [batches] int32
+    norm_w:          [dim] fp16
+    max_query_len:   int
+    """
+    return _eagle_ops.gdn_eagle(
+        qkvz, z_out, conv_w, conv_b, conv_state,
+        accepted_tokens, ba, a_log, dt_bias,
+        state_in, ssm_state_idx, norm_w, max_query_len)
+
+
+def eagle_page_attn_decode(
+    query: torch.Tensor,
+    kv_cache: torch.Tensor,
+    block_table: torch.Tensor,
+    seq_lens: torch.Tensor,
+    out: torch.Tensor,
+    max_query_len: int,
+    max_seq_len: int,
+) -> None:
+    """Eagle paged attention decode.
+
+    query:       [batches, num_heads, head_dim] fp16
+    kv_cache:    paged KV cache tensor
+    block_table: [batches, max_blocks] int32
+    seq_lens:    [batches] int32
+    out:         [batches, num_heads, head_dim] fp16 (output)
+    """
+    return _eagle_ops.page_attn_decode(
+        query, kv_cache, block_table, seq_lens, out,
+        max_query_len, max_seq_len)
+
+
+# ---- MoE Batch Ops (Router, TopK, Up/Down, Accumulate) ----
+
+_moe_batch = torch.ops.moe_ops
+
+
+def moe_router_forward(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+) -> torch.Tensor:
+    """MoE router forward: batched GEMV with weight reuse.
+
+    x:      [n_tokens, hidden_size] fp16
+    weight: [num_experts, hidden_size] fp8
+    scale:  [num_experts] fp32
+    Returns: [n_tokens, num_experts] fp16
+    """
+    return _moe_batch.moe_router_forward(x, weight, scale)
+
+
+def moe_batch_topk(
+    logits: torch.Tensor,
+    top_k: int,
+    norm: bool = True,
+) -> tuple:
+    """MoE fused softmax + top-k selection + normalize.
+
+    logits: [n_tokens, num_experts] fp16
+    top_k:  number of experts to select
+    norm:   whether to normalize top-k weights
+    Returns: (top_values [n_tokens, top_k] fp16, top_indices [n_tokens, top_k] int32)
+    """
+    return _moe_batch.moe_topk(logits, top_k, norm)
+
+
+def moe_up_forward(
+    x: torch.Tensor,
+    gate_up_weight: torch.Tensor,
+    gate_up_scale: torch.Tensor,
+    shared_gate_up_weight: torch.Tensor,
+    shared_gate_up_scale: torch.Tensor,
+    selected_experts: torch.Tensor,
+    top_k: int,
+    num_shared_experts: int,
+) -> torch.Tensor:
+    """MoE gate+up projection with SiLU (routed + shared experts).
+
+    x:                    [n_tokens, hidden_size] fp16
+    gate_up_weight:       [num_experts, hidden_size, 2*intermediate_size] fp8
+    gate_up_scale:        [num_experts] fp32
+    shared_gate_up_weight:[num_shared, 2*intermediate_size, hidden_size] fp8
+    shared_gate_up_scale: [num_shared] fp32
+    selected_experts:     [n_tokens, top_k] int32
+    Returns: [n_tokens * (top_k + num_shared), intermediate_size] fp16
+    """
+    return _moe_batch.moe_up_forward(
+        x, gate_up_weight, gate_up_scale,
+        shared_gate_up_weight, shared_gate_up_scale,
+        selected_experts, top_k, num_shared_experts)
+
+
+def moe_down_forward(
+    x: torch.Tensor,
+    intermediates: torch.Tensor,
+    down_weight: torch.Tensor,
+    down_scale: torch.Tensor,
+    shared_down_weight: torch.Tensor,
+    shared_down_scale: torch.Tensor,
+    shared_expert_gate_weight: torch.Tensor,
+    routing_weights: torch.Tensor,
+    selected_experts: torch.Tensor,
+    top_k: int,
+    num_shared_experts: int,
+) -> torch.Tensor:
+    """MoE down projection (routed + shared experts).
+
+    x:                        [n_tokens, hidden_size] fp16
+    intermediates:            [n_tokens * (top_k + num_shared), intermediate_size] fp16
+    down_weight:              [num_experts, intermediate_size, hidden_size] fp8
+    down_scale:               [num_experts] fp32
+    shared_down_weight:       [num_shared, hidden_size, intermediate_size] fp8
+    shared_down_scale:        [num_shared] fp32
+    shared_expert_gate_weight:[num_shared, hidden_size] fp16
+    routing_weights:          [n_tokens, top_k] fp16
+    selected_experts:         [n_tokens, top_k] int32
+    Returns: [n_tokens * (top_k + num_shared), hidden_size] fp16
+    """
+    return _moe_batch.moe_down_forward(
+        x, intermediates, down_weight, down_scale,
+        shared_down_weight, shared_down_scale,
+        shared_expert_gate_weight, routing_weights,
+        selected_experts, top_k, num_shared_experts)
+
+
+def moe_accumulate(
+    partials: torch.Tensor,
+    top_k: int,
+    num_shared_experts: int,
+) -> torch.Tensor:
+    """Accumulate expert outputs per token.
+
+    partials: [n_tokens * (top_k + num_shared), hidden_size] fp16
+    Returns:  [n_tokens, hidden_size] fp16
+    """
+    return _moe_batch.moe_accumulate(partials, top_k, num_shared_experts)
+
+
+def moe_forward_fused(
+    x: torch.Tensor,
+    gate_up_weight: torch.Tensor,
+    gate_up_scale: torch.Tensor,
+    shared_gate_up_weight: torch.Tensor,
+    shared_gate_up_scale: torch.Tensor,
+    down_weight: torch.Tensor,
+    down_scale: torch.Tensor,
+    shared_down_weight: torch.Tensor,
+    shared_down_scale: torch.Tensor,
+    shared_expert_gate_weight: torch.Tensor,
+    routing_weights: torch.Tensor,
+    selected_experts: torch.Tensor,
+    top_k: int,
+    num_shared_experts: int,
+) -> torch.Tensor:
+    """MoE fused forward: up + down_routed + down_finalize in one C++ call.
+
+    Requires routing_weights and selected_experts to be pre-computed.
+    """
+    return _moe_batch.moe_forward_fused(
+        x, gate_up_weight, gate_up_scale,
+        shared_gate_up_weight, shared_gate_up_scale,
+        down_weight, down_scale,
+        shared_down_weight, shared_down_scale,
+        shared_expert_gate_weight,
+        routing_weights, selected_experts,
+        top_k, num_shared_experts)
+
+
+def moe_forward_full(
+    x: torch.Tensor,
+    logits: torch.Tensor,
+    gate_up_weight: torch.Tensor,
+    gate_up_scale: torch.Tensor,
+    shared_gate_up_weight: torch.Tensor,
+    shared_gate_up_scale: torch.Tensor,
+    down_weight: torch.Tensor,
+    down_scale: torch.Tensor,
+    shared_down_weight: torch.Tensor,
+    shared_down_scale: torch.Tensor,
+    shared_expert_gate_weight: torch.Tensor,
+    top_k: int,
+    num_shared_experts: int,
+    n_routed_experts: int,
+) -> torch.Tensor:
+    """MoE full forward: topk + up + down_routed + down_finalize in one C++ call.
+
+    Pre-allocates buffers to eliminate torch::empty overhead.
+    """
+    return _moe_batch.moe_forward_full(
+        x, logits, gate_up_weight, gate_up_scale,
+        shared_gate_up_weight, shared_gate_up_scale,
+        down_weight, down_scale,
+        shared_down_weight, shared_down_scale,
+        shared_expert_gate_weight,
+        top_k, num_shared_experts, n_routed_experts)

--- a/vllm/custom-esimd-kernels-vllm/setup.py
+++ b/vllm/custom-esimd-kernels-vllm/setup.py
@@ -1,0 +1,175 @@
+import sys
+from pathlib import Path
+
+from setuptools import find_packages, setup
+from torch.utils.cpp_extension import SyclExtension
+from esimd_build_extention import BuildExtension
+
+root = Path(__file__).parent.resolve()
+
+import torch
+torch_include = str(Path(torch.__file__).parent / "include")
+
+ext_modules = [
+    SyclExtension(
+        name="custom_esimd_kernels_vllm.custom_esimd_kernels",
+        sources=[
+            "csrc/xpu/esimd_kernel.sycl",
+            "csrc/xpu/torch_extension.cc",
+        ],
+        include_dirs=[
+            root / "include",
+            root / "csrc",
+        ],
+        extra_compile_args={
+            "cxx": ["-O3", "-std=c++17"],
+            "sycl": ["-ffast-math", "-fsycl-device-code-split=per_kernel",
+                     f"-I{torch_include}"],
+        },
+        extra_link_args=["-Wl,-rpath,$ORIGIN/../../torch/lib"],
+        py_limited_api=False,
+    )
+]
+
+### for lgrf esimd kernels (GDN conv fused — separate module, doubleGRF)
+ext_modules.append(
+    SyclExtension(
+        name="custom_esimd_kernels_vllm.custom_esimd_kernels_lgrf",
+        sources=[
+            "csrc/xpu/esimd_kernel_lgrf.sycl",
+            "csrc/xpu/torch_extension_lgrf.cc",
+        ],
+        include_dirs=[
+            root / "include",
+            root / "csrc",
+        ],
+        extra_compile_args={
+            "cxx": ["-O3", "-std=c++17"],
+            "sycl": ["-fsycl", "-ffast-math", "-fsycl-device-code-split=per_kernel",
+                     "-fsycl-targets=spir64_gen", "-Xs", "-device bmg",
+                     f"-I{torch_include}"],
+        },
+        extra_link_args=["-Wl,-rpath,$ORIGIN/../../torch/lib"],
+        py_limited_api=False,
+    )
+)
+### for lgrf esimd kernels
+
+### MoE auxiliary kernels — no DPAS, standard compilation
+ext_modules.append(
+    SyclExtension(
+        name="custom_esimd_kernels_vllm.custom_esimd_kernels_moe",
+        sources=[
+            "csrc/xpu/esimd_kernel_moe.sycl",
+            "csrc/xpu/torch_extension_moe.cc",
+        ],
+        include_dirs=[
+            root / "include",
+            root / "csrc",
+        ],
+        extra_compile_args={
+            "cxx": ["-O3", "-std=c++17"],
+            "sycl": ["-ffast-math", "-fsycl-device-code-split=per_kernel",
+                     f"-I{torch_include}"],
+        },
+        extra_link_args=["-Wl,-rpath,$ORIGIN/../../torch/lib"],
+        py_limited_api=False,
+    )
+)
+### MoE auxiliary kernels
+
+### FP8 GEMM (M>1) — uses DPAS, compile with JIT only (no AOT to avoid device mismatch)
+ext_modules.append(
+    SyclExtension(
+        name="custom_esimd_kernels_vllm.custom_esimd_kernels_gemm",
+        sources=[
+            "csrc/xpu/esimd_kernel_gemm.sycl",
+            "csrc/xpu/torch_extension_gemm.cc",
+        ],
+        include_dirs=[
+            root / "include",
+            root / "csrc",
+        ],
+        extra_compile_args={
+            "cxx": ["-O3", "-std=c++17"],
+            "sycl": ["-ffast-math", "-fsycl-device-code-split=per_kernel",
+                     f"-I{torch_include}"],
+        },
+        extra_link_args=["-Wl,-rpath,$ORIGIN/../../torch/lib"],
+        py_limited_api=False,
+    )
+)
+### FP8 GEMM kernels
+
+### TopK V2 — vectorized softmax+topk for 512 experts (AOT for BMG)
+ext_modules.append(
+    SyclExtension(
+        name="custom_esimd_kernels_vllm.esimd_topk_v2",
+        sources=[
+            "csrc/xpu/esimd_kernel_topk_v2.sycl",
+            "csrc/xpu/torch_extension_topk_v2.cc",
+        ],
+        include_dirs=[
+            root / "include",
+            root / "csrc",
+        ],
+        extra_compile_args={
+            "cxx": ["-O3", "-std=c++17"],
+            "sycl": ["-fsycl", "-ffast-math", "-fsycl-device-code-split=per_kernel",
+                     "-fsycl-targets=spir64_gen", "-Xs", "-device bmg",
+                     f"-I{torch_include}"],
+        },
+        extra_link_args=["-Wl,-rpath,$ORIGIN/../../torch/lib"],
+        py_limited_api=False,
+    )
+)
+### TopK V2 kernels
+
+### Eagle kernels (GDN + Page Attention) — from custom-esimd-kernels-vllm-eagle
+ext_modules.append(
+    SyclExtension(
+        name="custom_esimd_kernels_vllm.eagle_ops",
+        sources=[
+            "csrc/eagle/eagle.sycl",
+        ],
+        include_dirs=[
+            root / "csrc" / "eagle",
+        ],
+        extra_compile_args={
+            "cxx": ["-O3", "-std=c++20"],
+            "sycl": ["-ffast-math", "-fsycl-device-code-split=per_kernel",
+                     f"-I{torch_include}"],
+        },
+        extra_link_args=["-Wl,-rpath,$ORIGIN/../../torch/lib"],
+        py_limited_api=False,
+    )
+)
+### Eagle kernels
+
+### MoE Batch kernels (Router, TopK, Up/Down, Accumulate) — from custom-esimd-kernels-vllm-moe-batch-test
+ext_modules.append(
+    SyclExtension(
+        name="custom_esimd_kernels_vllm.moe_ops",
+        sources=[
+            "csrc/moe_batch/moe.sycl",
+        ],
+        include_dirs=[],
+        extra_compile_args={
+            "cxx": ["-O3", "-std=c++20"],
+            "sycl": ["-ffast-math", "-fsycl-device-code-split=per_kernel",
+                     f"-I{torch_include}"],
+        },
+        extra_link_args=["-Wl,-rpath,$ORIGIN/../../torch/lib"],
+        py_limited_api=False,
+    )
+)
+### MoE Batch kernels
+
+setup(
+    name="custom-esimd-kernels-vllm",
+    version="0.1.0",
+    packages=find_packages(where="python"),
+    package_dir={"": "python"},
+    ext_modules=ext_modules,
+    cmdclass={"build_ext": BuildExtension.with_options(use_ninja=True)},
+)

--- a/vllm/custom-esimd-kernels-vllm/setup_sycl.py
+++ b/vllm/custom-esimd-kernels-vllm/setup_sycl.py
@@ -1,0 +1,175 @@
+import sys
+from pathlib import Path
+
+from setuptools import find_packages, setup
+from torch.utils.cpp_extension import SyclExtension
+from esimd_build_extention import BuildExtension
+
+root = Path(__file__).parent.resolve()
+
+import torch
+torch_include = str(Path(torch.__file__).parent / "include")
+
+ext_modules = [
+    SyclExtension(
+        name="custom_esimd_kernels_vllm.custom_esimd_kernels",
+        sources=[
+            "csrc/xpu/esimd_kernel.sycl",
+            "csrc/xpu/torch_extension.cc",
+        ],
+        include_dirs=[
+            root / "include",
+            root / "csrc",
+        ],
+        extra_compile_args={
+            "cxx": ["-O3", "-std=c++17"],
+            "sycl": ["-ffast-math", "-fsycl-device-code-split=per_kernel",
+                     f"-I{torch_include}"],
+        },
+        extra_link_args=["-Wl,-rpath,$ORIGIN/../../torch/lib"],
+        py_limited_api=False,
+    )
+]
+
+### for lgrf esimd kernels (GDN conv fused — separate module, doubleGRF)
+ext_modules.append(
+    SyclExtension(
+        name="custom_esimd_kernels_vllm.custom_esimd_kernels_lgrf",
+        sources=[
+            "csrc/xpu/esimd_kernel_lgrf.sycl",
+            "csrc/xpu/torch_extension_lgrf.cc",
+        ],
+        include_dirs=[
+            root / "include",
+            root / "csrc",
+        ],
+        extra_compile_args={
+            "cxx": ["-O3", "-std=c++17"],
+            "sycl": ["-fsycl", "-ffast-math", "-fsycl-device-code-split=per_kernel",
+                     "-fsycl-targets=spir64_gen", "-Xs", "-device bmg",
+                     f"-I{torch_include}"],
+        },
+        extra_link_args=["-Wl,-rpath,$ORIGIN/../../torch/lib"],
+        py_limited_api=False,
+    )
+)
+### for lgrf esimd kernels
+
+### MoE auxiliary kernels — no DPAS, standard compilation
+ext_modules.append(
+    SyclExtension(
+        name="custom_esimd_kernels_vllm.custom_esimd_kernels_moe",
+        sources=[
+            "csrc/xpu/esimd_kernel_moe.sycl",
+            "csrc/xpu/torch_extension_moe.cc",
+        ],
+        include_dirs=[
+            root / "include",
+            root / "csrc",
+        ],
+        extra_compile_args={
+            "cxx": ["-O3", "-std=c++17"],
+            "sycl": ["-ffast-math", "-fsycl-device-code-split=per_kernel",
+                     f"-I{torch_include}"],
+        },
+        extra_link_args=["-Wl,-rpath,$ORIGIN/../../torch/lib"],
+        py_limited_api=False,
+    )
+)
+### MoE auxiliary kernels
+
+### FP8 GEMM (M>1) — uses DPAS, compile with JIT only (no AOT to avoid device mismatch)
+ext_modules.append(
+    SyclExtension(
+        name="custom_esimd_kernels_vllm.custom_esimd_kernels_gemm",
+        sources=[
+            "csrc/xpu/esimd_kernel_gemm.sycl",
+            "csrc/xpu/torch_extension_gemm.cc",
+        ],
+        include_dirs=[
+            root / "include",
+            root / "csrc",
+        ],
+        extra_compile_args={
+            "cxx": ["-O3", "-std=c++17"],
+            "sycl": ["-ffast-math", "-fsycl-device-code-split=per_kernel",
+                     f"-I{torch_include}"],
+        },
+        extra_link_args=["-Wl,-rpath,$ORIGIN/../../torch/lib"],
+        py_limited_api=False,
+    )
+)
+### FP8 GEMM kernels
+
+### TopK V2 — vectorized softmax+topk for 512 experts (AOT for BMG)
+ext_modules.append(
+    SyclExtension(
+        name="custom_esimd_kernels_vllm.esimd_topk_v2",
+        sources=[
+            "csrc/xpu/esimd_kernel_topk_v2.sycl",
+            "csrc/xpu/torch_extension_topk_v2.cc",
+        ],
+        include_dirs=[
+            root / "include",
+            root / "csrc",
+        ],
+        extra_compile_args={
+            "cxx": ["-O3", "-std=c++17"],
+            "sycl": ["-fsycl", "-ffast-math", "-fsycl-device-code-split=per_kernel",
+                     "-fsycl-targets=spir64_gen", "-Xs", "-device bmg",
+                     f"-I{torch_include}"],
+        },
+        extra_link_args=["-Wl,-rpath,$ORIGIN/../../torch/lib"],
+        py_limited_api=False,
+    )
+)
+### TopK V2 kernels
+
+### Eagle kernels (GDN + Page Attention) — from custom-esimd-kernels-vllm-eagle
+ext_modules.append(
+    SyclExtension(
+        name="custom_esimd_kernels_vllm.eagle_ops",
+        sources=[
+            "csrc/eagle/eagle.sycl",
+        ],
+        include_dirs=[
+            root / "csrc" / "eagle",
+        ],
+        extra_compile_args={
+            "cxx": ["-O3", "-std=c++20"],
+            "sycl": ["-ffast-math", "-fsycl-device-code-split=per_kernel",
+                     f"-I{torch_include}"],
+        },
+        extra_link_args=["-Wl,-rpath,$ORIGIN/../../torch/lib"],
+        py_limited_api=False,
+    )
+)
+### Eagle kernels
+
+### MoE Batch kernels (Router, TopK, Up/Down, Accumulate) — from custom-esimd-kernels-vllm-moe-batch-test
+ext_modules.append(
+    SyclExtension(
+        name="custom_esimd_kernels_vllm.moe_ops",
+        sources=[
+            "csrc/moe_batch/moe.sycl",
+        ],
+        include_dirs=[],
+        extra_compile_args={
+            "cxx": ["-O3", "-std=c++20"],
+            "sycl": ["-ffast-math", "-fsycl-device-code-split=per_kernel",
+                     f"-I{torch_include}"],
+        },
+        extra_link_args=["-Wl,-rpath,$ORIGIN/../../torch/lib"],
+        py_limited_api=False,
+    )
+)
+### MoE Batch kernels
+
+setup(
+    name="custom-esimd-kernels-vllm",
+    version="0.1.0",
+    packages=find_packages(where="python"),
+    package_dir={"": "python"},
+    ext_modules=ext_modules,
+    cmdclass={"build_ext": BuildExtension.with_options(use_ninja=True)},
+)

--- a/vllm/docker/Dockerfile
+++ b/vllm/docker/Dockerfile
@@ -29,9 +29,7 @@ RUN apt-get update -y && \
         numactl \
         wget \
         vim \
-        linux-libc-dev \
-    # Install Intel GPU runtime packages
-        intel-oneapi-dpcpp-ct=2025.2.0-517 && \
+        linux-libc-dev && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 
@@ -43,6 +41,7 @@ RUN apt-get update -y && \
 WORKDIR /llm
 COPY ./patches/vllm_for_multi_arc.patch /tmp/
 # COPY ./patches/miner-u.patch /tmp/
+COPY ./custom-esimd-kernels-vllm /tmp/custom-esimd-kernels-vllm
 
 # Set environment variables early
 ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib/"
@@ -62,6 +61,13 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     # pip install --no-cache-dir arctic-inference==0.1.1 && \
     export CPATH=/opt/intel/oneapi/dpcpp-ct/2025.2/include/:${CPATH} && \
     pip install --no-build-isolation . 
+
+# Install unified custom ESIMD kernels (6 modules: core, lgrf, moe, gemm, eagle, moe_batch)
+RUN --mount=type=cache,target=/root/.cache/pip \
+    cd /tmp/custom-esimd-kernels-vllm && \
+    TORCH_XPU_ARCH_LIST=bmg-g21 MAX_JOBS=1 python3 setup.py bdist_wheel && \
+    pip install dist/*.whl --no-deps && \
+    rm -rf /tmp/custom-esimd-kernels-vllm
 
 # Clone + patch miner-U
 RUN --mount=type=cache,target=/root/.cache/pip \

--- a/vllm/patches/vllm_for_multi_arc.patch
+++ b/vllm/patches/vllm_for_multi_arc.patch
@@ -493,6 +493,33 @@ index f63ce2c50..da2db6485 100644
  # PyJWT-2.7.0 will influence some wheel behaviors, remove its dist-info to avoid conflicts
  RUN rm /usr/lib/python3/dist-packages/PyJWT-2.7.0.dist-info/ -rf
  
+diff --git a/docs/contributing/profiling.md b/docs/contributing/profiling.md
+index ce10adaf0..8d9ee40c6 100644
+--- a/docs/contributing/profiling.md
++++ b/docs/contributing/profiling.md
+@@ -13,8 +13,12 @@ when launching the server, and setting the entries `profiler` to `'torch'` and `
+ - `torch_profiler_with_stack` to enable recording stack information, on by default
+ - `torch_profiler_with_flops` to enable recording FLOPs, off by default
+ - `torch_profiler_use_gzip` to control gzip-compressing profiling files, on by default
++- `torch_profiler_save_traces` to control whether trace json files are written, on by default
+ - `torch_profiler_dump_cuda_time_total` to control dumping and printing the aggregated CUDA self time table, on by default
+ 
++If you only want the aggregated `profiler_out_<rank>.txt` outputs and do not
++want the large trace json files, set `torch_profiler_save_traces` to `false`.
++
+ When using `vllm bench serve`, you can enable profiling by passing the `--profile` flag.
+ 
+ Traces can be visualized using <https://ui.perfetto.dev/>.
+@@ -40,6 +44,9 @@ Refer to [examples/offline_inference/simple_profiling.py](../../examples/offline
+ 
+ ```bash
+ vllm serve meta-llama/Llama-3.1-8B-Instruct --profiler-config '{"profiler": "torch", "torch_profiler_dir": "./vllm_profile"}'
++
++# Only dump profiler_out_<rank>.txt, do not save trace json files.
++vllm serve meta-llama/Llama-3.1-8B-Instruct --profiler-config '{"profiler": "torch", "torch_profiler_dir": "./vllm_profile", "torch_profiler_save_traces": false}'
+ ```
+ 
+ vllm bench command:
 diff --git a/docs/features/quantization/fp8.md b/docs/features/quantization/fp8.md
 index f17ef89a5..b3ceab13f 100644
 --- a/docs/features/quantization/fp8.md
@@ -704,11 +731,41 @@ index 2599c951e..a95a74475 100644
                      stream=False,
                      **PARAMS[name],
                  )
+diff --git a/pyproject.toml b/pyproject.toml
+index a5d41c673..842321f96 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -6,7 +6,7 @@ requires = [
+     "packaging>=24.2",
+     "setuptools>=77.0.3,<81.0.0",
+     "setuptools-scm>=8.0",
+-    "torch == 2.9.1",
++    "torch == 2.10.0+xpu",
+     "wheel",
+     "jinja2",
+     "grpcio-tools>=1.76.0",
+@@ -308,4 +308,4 @@ windo = "windo"
+ [tool.typos.type.vimscript.extend-words]
+ 
+ [tool.uv]
+-no-build-isolation-package = ["torch"]
+\ No newline at end of file
++no-build-isolation-package = ["torch"]
 diff --git a/requirements/common.txt b/requirements/common.txt
-index 26d53f80a..285e758aa 100644
+index 26d53f80a..a154cd383 100644
 --- a/requirements/common.txt
 +++ b/requirements/common.txt
-@@ -32,7 +32,7 @@ pyzmq >= 25.0.0
+@@ -7,7 +7,8 @@ requests >= 2.26.0
+ tqdm
+ blake3
+ py-cpuinfo
+-transformers >= 4.56.0, < 5
++#transformers >= 4.56.0, < 5
++transformers >= 4.56.0
+ tokenizers >= 0.21.1  # Required for fast incremental detokenization.
+ protobuf >= 6.30.0 # Required by LlamaTokenizer, gRPC.
+ fastapi[standard] >= 0.115.0 # Required by FastAPI's form models in the OpenAI API server's audio transcriptions endpoint.
+@@ -32,7 +33,7 @@ pyzmq >= 25.0.0
  msgspec
  gguf >= 0.17.0
  mistral_common[image] >= 1.8.8
@@ -717,6 +774,13 @@ index 26d53f80a..285e758aa 100644
  pyyaml
  six>=1.16.0; python_version > '3.11' # transitive dependency of pandas that needs to be the latest version for python 3.12
  setuptools>=77.0.3,<81.0.0; python_version > '3.11' # Setuptools is used by triton, we need to ensure a modern version is installed for 3.12+ so that it does not try to import distutils, which was removed in 3.12
+@@ -52,4 +53,4 @@ anthropic == 0.71.0
+ model-hosting-container-standards >= 0.1.10, < 1.0.0
+ mcp
+ grpcio>=1.76.0
+-grpcio-reflection>=1.76.0
+\ No newline at end of file
++grpcio-reflection>=1.76.0
 diff --git a/requirements/nightly_torch_test.txt b/requirements/nightly_torch_test.txt
 index 72fa13692..cdb5aef4b 100644
 --- a/requirements/nightly_torch_test.txt
@@ -1104,6 +1168,82 @@ index 4f3c52df6..65febae59 100644
 +        output = llm.generate_greedy(["The capital of France is"], max_tokens=32)
      assert output
      print(output)
+diff --git a/tests/v1/core/test_single_type_kv_cache_manager.py b/tests/v1/core/test_single_type_kv_cache_manager.py
+index 23097bf2a..b05040ebe 100644
+--- a/tests/v1/core/test_single_type_kv_cache_manager.py
++++ b/tests/v1/core/test_single_type_kv_cache_manager.py
+@@ -24,7 +24,7 @@ pytestmark = pytest.mark.cpu_test
+ def get_sliding_window_manager(sliding_window_spec, block_pool, enable_caching=True):
+     return SlidingWindowManager(
+         sliding_window_spec,
+-        block_pool,
++        block_pool=block_pool,
+         enable_caching=enable_caching,
+         kv_cache_group_id=0,
+     )
+@@ -35,7 +35,7 @@ def get_chunked_local_attention_manager(
+ ):
+     return ChunkedLocalAttentionManager(
+         chunked_local_attention_spec,
+-        block_pool,
++        block_pool=block_pool,
+         enable_caching=enable_caching,
+         kv_cache_group_id=0,
+     )
+@@ -342,11 +342,15 @@ def test_get_num_blocks_to_allocate():
+     ]
+ 
+     assert (
+-        manager.get_num_blocks_to_allocate("1", 20 * block_size, cached_blocks_1, 0)
++        manager.get_num_blocks_to_allocate(
++            "1", 20 * block_size, cached_blocks_1, 0, 20 * block_size
++        )
+         == 20
+     )
+     assert (
+-        manager.get_num_blocks_to_allocate("2", 20 * block_size, cached_blocks_2, 0)
++        manager.get_num_blocks_to_allocate(
++            "2", 20 * block_size, cached_blocks_2, 0, 20 * block_size
++        )
+         == 15
+     )
+ 
+@@ -375,6 +379,7 @@ def test_evictable_cached_blocks_not_double_allocated():
+         num_tokens=2 * block_size,
+         new_computed_blocks=[evictable_block],
+         total_computed_tokens=block_size,
++        num_tokens_main_model=2 * block_size,
+     )
+     # Free capacity check should count evictable cached blocks, but allocation
+     # should only allocate the truly new block.
+@@ -386,7 +391,9 @@ def test_evictable_cached_blocks_not_double_allocated():
+         num_local_computed_tokens=block_size,
+         num_external_computed_tokens=0,
+     )
+-    new_blocks = manager.allocate_new_blocks(request_id, num_tokens=4)
++    new_blocks = manager.allocate_new_blocks(
++        request_id, num_tokens=4, num_tokens_main_model=4
++    )
+     assert len(new_blocks) == 1
+     assert len(manager.req_to_blocks[request_id]) == 2
+ 
+@@ -411,10 +418,14 @@ def test_chunked_local_attention_get_num_blocks_to_allocate():
+     ]
+ 
+     assert (
+-        manager.get_num_blocks_to_allocate("1", 20 * block_size, cached_blocks_1, 0)
++        manager.get_num_blocks_to_allocate(
++            "1", 20 * block_size, cached_blocks_1, 0, 20 * block_size
++        )
+         == 20
+     )
+     assert (
+-        manager.get_num_blocks_to_allocate("2", 20 * block_size, cached_blocks_2, 0)
++        manager.get_num_blocks_to_allocate(
++            "2", 20 * block_size, cached_blocks_2, 0, 20 * block_size
++        )
+         == 15
+     )
 diff --git a/tests/v1/e2e/test_correctness_sliding_window.py b/tests/v1/e2e/test_correctness_sliding_window.py
 index b6a78eaa0..2e215acb6 100644
 --- a/tests/v1/e2e/test_correctness_sliding_window.py
@@ -1151,6 +1291,776 @@ index b6a78eaa0..2e215acb6 100644
      )
      sampling_params = SamplingParams(temperature=0.0, max_tokens=100)
  
+diff --git a/tests/v1/e2e/test_mamba_prefix_cache.py b/tests/v1/e2e/test_mamba_prefix_cache.py
+new file mode 100644
+index 000000000..7fe95366b
+--- /dev/null
++++ b/tests/v1/e2e/test_mamba_prefix_cache.py
+@@ -0,0 +1,764 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++import multiprocessing as mp
++import os
++import traceback
++from collections.abc import Callable
++from dataclasses import dataclass
++from typing import Any
++
++import datasets
++import pytest
++import torch
++
++from vllm import LLM, SamplingParams, TokensPrompt
++from vllm.config import CacheConfig
++from vllm.model_executor.layers.mamba.mamba_utils import MambaStateCopyFunc
++from vllm.sequence import IntermediateTensors
++from vllm.v1.attention.backends.utils import CommonAttentionMetadata
++from vllm.v1.core.kv_cache_manager import KVCacheBlocks, KVCacheManager
++from vllm.v1.core.sched.output import SchedulerOutput
++from vllm.v1.engine.core_client import InprocClient
++from vllm.v1.kv_cache_interface import KVCacheConfig
++from vllm.v1.outputs import SamplerOutput
++from vllm.v1.request import Request
++from vllm.v1.sample.metadata import SamplingMetadata
++from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
++from vllm.v1.worker import mamba_utils
++from vllm.v1.worker.gpu_input_batch import CachedRequestState
++from vllm.v1.worker.gpu_model_runner import GPUModelRunner
++from vllm.v1.worker.lora_model_runner_mixin import GPUInputBatch
++from vllm.v1.worker.mamba_utils import get_mamba_groups
++
++
++@dataclass
++class StepAction:
++    num_computed_tokens_start: int
++    num_scheduled_tokens: int
++    kv_cache_block_ids: list[int]  # [] to follow last step
++    preprocess_copy_idx: tuple[int, int]  # -1, -1 for no copy
++    postprocess_copy_idx: tuple[int, int]  # -1, -1 for no copy
++
++
++num_speculative_tokens = 3
++
++num_accepted_tokens = 1
++prompt_token_ids: list[int] = []
++MODEL = "Qwen/Qwen3-Next-80B-A3B-Instruct-FP8"
++BLOCK_SIZE = 560
++NUM_HIDDEN_LAYERS = 1
++cur_step_action_idx = 0
++cur_step_action: StepAction | None = None
++step_actions: list[StepAction] = []
++
++
++def get_fake_sample_fn() -> SamplerOutput:
++    def fake_sample_fn(
++        self: GPUModelRunner,
++        logits: torch.Tensor | None,
++        spec_decode_metadata: SpecDecodeMetadata | None,
++    ) -> SamplerOutput:
++        assert logits is not None
++        num_computed_tokens_cpu_tensor = self.input_batch.num_computed_tokens_cpu_tensor
++        num_computed_tokens = num_computed_tokens_cpu_tensor[0].item()
++        if num_computed_tokens < self.input_batch.num_prompt_tokens[0].item():
++            first_token_id_index = self.input_batch.num_prompt_tokens[0].item()
++        else:
++            first_token_id_index = num_computed_tokens + 1
++        if spec_decode_metadata is None:
++            return SamplerOutput(
++                sampled_token_ids=torch.tensor(
++                    [[prompt_token_ids[first_token_id_index]]],
++                    device="cuda",
++                    dtype=torch.int32,
++                ),
++                logprobs_tensors=None,
++            )
++        num_sampled_tokens = spec_decode_metadata.cu_num_sampled_tokens[0].item() + 1
++        accpeted_tokens = prompt_token_ids[
++            first_token_id_index : first_token_id_index
++            + min(num_accepted_tokens, logits.shape[0])
++        ]
++        sampled_token_ids = accpeted_tokens + [-1] * (
++            num_sampled_tokens - len(accpeted_tokens)
++        )
++        return SamplerOutput(
++            sampled_token_ids=torch.tensor(
++                [sampled_token_ids], device="cuda", dtype=torch.int32
++            ),
++            logprobs_tensors=None,
++        )
++
++    return fake_sample_fn
++
++
++def get_fake_propose_draft_token_ids_fn():
++    def fake_propose_draft_token_ids_fn(
++        self: GPUModelRunner,
++        scheduler_output: SchedulerOutput,
++        sampled_token_ids: torch.Tensor | list[list[int]],
++        sampling_metadata: SamplingMetadata,
++        hidden_states: torch.Tensor,
++        sample_hidden_states: torch.Tensor,
++        aux_hidden_states: list[torch.Tensor] | None,
++        spec_decode_metadata: SpecDecodeMetadata | None,
++        common_attn_metadata: CommonAttentionMetadata,
++    ) -> list[list[int]]:
++        num_computed_tokens_cpu_tensor = self.input_batch.num_computed_tokens_cpu_tensor
++        num_computed_tokens = num_computed_tokens_cpu_tensor[0].item()
++        if (
++            self.input_batch.num_tokens_no_spec[0].item()
++            <= self.input_batch.num_prompt_tokens[0].item()
++        ):
++            first_token_id_index = self.input_batch.num_prompt_tokens[0].item()
++        else:
++            first_token_id_index = (
++                num_computed_tokens + 1
++            )  # bonus token isn't considered as computed
++        first_token_id_index += self.input_batch.num_accepted_tokens_cpu[0].item()
++        proposed_draft_token_ids = [
++            prompt_token_ids[
++                first_token_id_index : first_token_id_index + num_speculative_tokens
++            ]
++        ]
++        return proposed_draft_token_ids
++
++    return fake_propose_draft_token_ids_fn
++
++
++def get_fake_step_action_fn(original_step_action_fn: Callable):
++    def fake_get_output(self: InprocClient):
++        global cur_step_action_idx
++        global cur_step_action
++        if cur_step_action_idx < len(step_actions):
++            cur_step_action = step_actions[cur_step_action_idx]
++            cur_step_action_idx += 1
++        else:
++            cur_step_action = None
++        print(f"cur_step_action: {cur_step_action_idx=} {cur_step_action=}")
++        return original_step_action_fn(self)
++
++    return fake_get_output
++
++
++def get_fake_allocate_slots_fn(original_allocate_slots_fn: Callable):
++    def fake_allocate_slots_fn(
++        self: KVCacheManager,
++        request: Request,
++        num_new_tokens: int,
++        num_new_computed_tokens: int = 0,
++        new_computed_blocks: KVCacheBlocks | None = None,
++        num_lookahead_tokens: int = 0,
++        num_external_computed_tokens: int = 0,
++        delay_cache_blocks: bool = False,
++        num_encoder_tokens: int = 0,
++    ):
++        ret = original_allocate_slots_fn(
++            self,
++            request,
++            num_new_tokens,
++            num_new_computed_tokens,
++            new_computed_blocks,
++            num_lookahead_tokens,
++            num_external_computed_tokens,
++            delay_cache_blocks,
++            num_encoder_tokens,
++        )
++        if cur_step_action is not None:
++            cur_block_ids = self.coordinator.single_type_managers[0].req_to_blocks[
++                request.request_id
++            ]
++            not_null_block_flags = [not block.is_null for block in cur_block_ids]
++            block_ids = [1 if block else 0 for block in not_null_block_flags]
++            assert block_ids == cur_step_action.kv_cache_block_ids
++        return ret
++
++    return fake_allocate_slots_fn
++
++
++mamba_kv_cache_dict = {}
++
++
++def get_fake_execute_model_fn(original_execute_model_fn: Callable):
++    last_num_computed_tokens = 0
++
++    def fake_execute_model_fn(
++        self: GPUModelRunner,
++        scheduler_output: SchedulerOutput,
++        intermediate_tensors: IntermediateTensors | None = None,
++    ):
++        if cur_step_action is not None:
++            num_scheduled_tokens = next(
++                iter(scheduler_output.num_scheduled_tokens.values())
++            )
++            assert num_scheduled_tokens == cur_step_action.num_scheduled_tokens
++        mamba_group_ids, mamba_spec = get_mamba_groups(self.kv_cache_config)
++        mamba_group_id = mamba_group_ids[0]
++        mamba_layer_name = self.kv_cache_config.kv_cache_groups[
++            mamba_group_id
++        ].layer_names[0]
++        nonlocal last_num_computed_tokens
++        if len(scheduler_output.scheduled_cached_reqs.req_ids) > 0:
++            num_computed_tokens = (
++                scheduler_output.scheduled_cached_reqs.num_computed_tokens[0]
++            )
++            if (
++                num_computed_tokens // BLOCK_SIZE
++                > last_num_computed_tokens // BLOCK_SIZE
++            ):
++                # generated a new aligned block in this step
++                block_idx = num_computed_tokens // mamba_spec.block_size - 1
++                block_id = (
++                    self.input_batch.block_table.block_tables[mamba_group_id]
++                    .block_table.cpu[0, block_idx]
++                    .item()
++                )
++                if block_id != 0:
++                    kv_cache = self.compilation_config.static_forward_context[
++                        mamba_layer_name
++                    ].kv_cache
++                    mamba_kv_cache_dict[
++                        num_computed_tokens - num_computed_tokens % BLOCK_SIZE
++                    ] = (
++                        kv_cache[0][0][block_id].clone(),
++                        kv_cache[0][1][block_id].clone(),
++                    )
++
++            last_num_computed_tokens = num_computed_tokens
++        else:
++            last_num_computed_tokens = 0
++
++        ret = original_execute_model_fn(self, scheduler_output, intermediate_tensors)
++
++        if cur_step_action is not None:
++            assert (
++                cur_step_action.num_computed_tokens_start
++                == self.input_batch.num_computed_tokens_cpu[0].item()
++            )
++
++        return ret
++
++    return fake_execute_model_fn
++
++
++def get_fake_process_mamba_fn(
++    original_preprocess_mamba_fn: Callable,
++    original_post_process_mamba_fn: Callable,
++    original_copy_fn: Callable,
++):
++    copy_info: tuple[list[int], list[int], list[int]] | None = None
++
++    def check_copy_info(
++        action: tuple[int, int],
++        kv_cache_config: KVCacheConfig,
++        forward_context: dict[str, Any],
++        input_batch: GPUInputBatch,
++    ):
++        assert copy_info is not None
++        if action == (-1, -1):
++            assert len(copy_info[0]) == len(copy_info[1]) == len(copy_info[2]) == 0
++        else:
++            assert len(copy_info[0]) == len(copy_info[1]) == len(copy_info[2]) == 2
++            mamba_group_ids, mamba_spec = get_mamba_groups(kv_cache_config)
++            mamba_group_id = mamba_group_ids[0]
++            mamba_layer_name = kv_cache_config.kv_cache_groups[
++                mamba_group_id
++            ].layer_names[0]
++            mamba_kv_cache = forward_context[mamba_layer_name].kv_cache[0][-1]
++            mamba_block_table = input_batch.block_table.block_tables[
++                mamba_group_id
++            ].block_table.cpu[0]
++            expected_temporal_src = mamba_kv_cache[
++                mamba_block_table[action[0]]
++            ].data_ptr()
++            expected_temporal_dest = mamba_kv_cache[
++                mamba_block_table[action[1]]
++            ].data_ptr()
++            # -1 is qwen3-next's temporal. We skip checking conv as it is more complex.
++            assert copy_info[0][-1] == expected_temporal_src
++            assert copy_info[1][-1] == expected_temporal_dest
++
++    def fake_preprocess_mamba_fn(
++        scheduler_output: SchedulerOutput,
++        kv_cache_config: KVCacheConfig,
++        cache_config: CacheConfig,
++        mamba_state_idx: dict[str, int],
++        input_batch: GPUInputBatch,
++        requests: dict[str, CachedRequestState],
++        forward_context: dict[str, Any],
++        mamba_state_copy_funcs: tuple[MambaStateCopyFunc, ...],
++    ):
++        nonlocal copy_info
++        copy_info = None
++        ret = original_preprocess_mamba_fn(
++            scheduler_output,
++            kv_cache_config,
++            cache_config,
++            mamba_state_idx,
++            input_batch,
++            requests,
++            forward_context,
++            mamba_state_copy_funcs,
++        )
++        if cur_step_action is not None:
++            check_copy_info(
++                cur_step_action.preprocess_copy_idx,
++                kv_cache_config,
++                forward_context,
++                input_batch,
++            )
++        return ret
++
++    def fake_post_process_mamba_fn(
++        scheduler_output: SchedulerOutput,
++        kv_cache_config: KVCacheConfig,
++        input_batch: GPUInputBatch,
++        requests: dict[str, CachedRequestState],
++        mamba_state_idx: dict[str, int],
++        forward_context: dict[str, Any],
++        mamba_state_copy_funcs: tuple[MambaStateCopyFunc, ...],
++    ):
++        nonlocal copy_info
++        copy_info = None
++        ret = original_post_process_mamba_fn(
++            scheduler_output,
++            kv_cache_config,
++            input_batch,
++            requests,
++            mamba_state_idx,
++            forward_context,
++            mamba_state_copy_funcs,
++        )
++        if cur_step_action is not None:
++            check_copy_info(
++                cur_step_action.postprocess_copy_idx,
++                kv_cache_config,
++                forward_context,
++                input_batch,
++            )
++        return ret
++
++    def fake_copy_fn(
++        src_state_list: list[int],
++        dest_state_list: list[int],
++        num_elements_list: list[int],
++    ):
++        nonlocal copy_info
++        assert copy_info is None
++        copy_info = (src_state_list, dest_state_list, num_elements_list)
++        return original_copy_fn(
++            src_state_list,
++            dest_state_list,
++            num_elements_list,
++        )
++
++    return fake_preprocess_mamba_fn, fake_post_process_mamba_fn, fake_copy_fn
++
++
++def run_ref_mamba_state_in_subprocess() -> None:
++    ctx = mp.get_context("spawn")
++    proc = ctx.Process(target=_run_ref_mamba_state_worker)
++    proc.start()
++    proc.join(timeout=600)
++    if proc.exitcode != 0:
++        raise RuntimeError(f"Ref mamba state process exited with code {proc.exitcode}.")
++
++
++def _run_ref_mamba_state_worker():
++    try:
++        os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
++        num_generated_tokens = 8000
++        num_prompt_tokens = 500
++        sampling_params = SamplingParams(
++            temperature=0.0, max_tokens=num_generated_tokens
++        )
++        prompt_dataset = datasets.load_dataset("heheda/a_long_article")
++        full_prompt = prompt_dataset["train"][0]["text"]
++        fake_execute_model_fn = get_fake_execute_model_fn(GPUModelRunner.execute_model)
++        GPUModelRunner.execute_model = fake_execute_model_fn
++        fake_sample_fn = get_fake_sample_fn()
++        GPUModelRunner._sample = fake_sample_fn
++        engine = LLM(
++            model=MODEL,
++            block_size=BLOCK_SIZE,
++            hf_overrides={"num_hidden_layers": NUM_HIDDEN_LAYERS},
++            seed=42,
++        )
++        global prompt_token_ids
++        prompt_token_ids = engine.get_tokenizer().encode(full_prompt)
++        print(f"Token IDs length: {len(prompt_token_ids)}")
++
++        _outputs = engine.generate(
++            [TokensPrompt(prompt_token_ids=prompt_token_ids[:num_prompt_tokens])],
++            sampling_params,
++        )
++        # ref_mamba_kv_cache_dict = torch.load("mamba_kv_cache_dict.pth")
++        # check_mamba_state_equal(ref_mamba_kv_cache_dict, mamba_kv_cache_dict)
++        # torch.save(mamba_kv_cache_dict, "mamba_kv_cache_dict.pth")
++        cpu_state_ref = {
++            key: tuple(tensor.detach().cpu() for tensor in tensors)
++            for key, tensors in mamba_kv_cache_dict.items()
++        }
++        torch.save(cpu_state_ref, "mamba_kv_cache_dict_ref.pth")
++        mamba_kv_cache_dict.clear()
++    except Exception:
++        traceback.print_exc()
++        raise
++
++
++def check_mamba_state_equal(
++    mamba_state_ref: dict, mamba_state_new: dict, keys_to_check: list[int]
++):
++    atol = 1e-2
++    rtol = 1e-2
++    for key in keys_to_check:
++        assert key in mamba_state_new
++        assert key in mamba_state_ref
++        # mamba state new is a subset of mamba state ref
++        for i, (ref, new) in enumerate(zip(mamba_state_ref[key], mamba_state_new[key])):
++            if ref.device != new.device:
++                new = new.to(ref.device)
++            new = new[: ref.shape[0]]
++            if not torch.allclose(ref, new, atol=atol, rtol=rtol):
++                diff_mask = ~torch.isclose(ref, new, atol=atol, rtol=rtol)
++                diff_idx = torch.nonzero(diff_mask)
++                if diff_idx.shape[0] * 100 < ref.numel():
++                    print(
++                        f"[WARNING] found {diff_idx.shape[0] * 100 / ref.numel()}% of the elements are different"  # noqa: E501
++                    )
++                    continue
++                raise ValueError(
++                    f"Mamba state is not equal for key: {key} at index {i}"
++                )
++    return True
++
++
++@dataclass
++class TestConfig:
++    num_prompt_tokens: int
++    num_generated_tokens: int
++    num_accepted_tokens: int
++    step_actions: list[StepAction]
++
++
++def apply_patch(monkeypatch: pytest.MonkeyPatch):
++    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
++
++    fake_sample_fn = get_fake_sample_fn()
++    monkeypatch.setattr(GPUModelRunner, "_sample", fake_sample_fn)
++
++    fake_propose_draft_token_ids_fn = get_fake_propose_draft_token_ids_fn()
++    monkeypatch.setattr(
++        GPUModelRunner, "propose_draft_token_ids", fake_propose_draft_token_ids_fn
++    )
++
++    fake_execute_model_fn = get_fake_execute_model_fn(GPUModelRunner.execute_model)
++    monkeypatch.setattr(GPUModelRunner, "execute_model", fake_execute_model_fn)
++
++    fake_step_action_fn = get_fake_step_action_fn(InprocClient.get_output)
++    monkeypatch.setattr(InprocClient, "get_output", fake_step_action_fn)
++
++    fake_allocate_slots_fn = get_fake_allocate_slots_fn(KVCacheManager.allocate_slots)
++    monkeypatch.setattr(KVCacheManager, "allocate_slots", fake_allocate_slots_fn)
++
++    fake_preprocess_mamba_fn, fake_post_process_mamba_fn, fake_copy_fn = (
++        get_fake_process_mamba_fn(
++            mamba_utils.preprocess_mamba,
++            mamba_utils.postprocess_mamba,
++            mamba_utils.do_mamba_copy_block,
++        )
++    )
++    monkeypatch.setattr(mamba_utils, "preprocess_mamba", fake_preprocess_mamba_fn)
++    monkeypatch.setattr(mamba_utils, "postprocess_mamba", fake_post_process_mamba_fn)
++    monkeypatch.setattr(mamba_utils, "do_mamba_copy_block", fake_copy_fn)
++
++
++@pytest.mark.skip(
++    reason="Skipping test_mamba_prefix_cache because it is based on spec "
++    "decode which is not allowed now."
++)
++def test_mamba_prefix_cache(monkeypatch: pytest.MonkeyPatch):
++    run_ref_mamba_state_in_subprocess()
++    apply_patch(monkeypatch)
++    prompt_dataset = datasets.load_dataset("heheda/a_long_article")
++    full_prompt = prompt_dataset["train"][0]["text"]
++    tests = {
++        "accept_1": TestConfig(
++            num_prompt_tokens=554,
++            num_generated_tokens=20,
++            num_accepted_tokens=1,
++            step_actions=[
++                StepAction(0, 554, [1, 1, 1, 1], (-1, -1), (-1, -1)),
++                StepAction(554, 4, [], (-1, -1), (-1, -1)),
++                StepAction(555, 4, [], (-1, -1), (-1, -1)),
++                StepAction(556, 4, [], (-1, -1), (-1, -1)),
++                StepAction(557, 4, [1, 1, 1, 1, 1], (0, 1), (-1, -1)),
++                StepAction(558, 4, [], (-1, -1), (-1, -1)),
++                StepAction(559, 4, [], (-1, -1), (1, 0)),
++                StepAction(560, 4, [], (-1, -1), (-1, -1)),
++                StepAction(561, 4, [0, 1, 1, 1, 1], (-1, -1), (-1, -1)),
++            ],
++        ),
++        # test case 2.1: no hit, accept 2 tokens
++        "accept_2_1": TestConfig(
++            num_prompt_tokens=554,
++            num_generated_tokens=20,
++            num_accepted_tokens=2,
++            step_actions=[
++                StepAction(0, 554, [1, 1, 1, 1], (-1, -1), (-1, -1)),
++                StepAction(554, 4, [], (-1, -1), (-1, -1)),
++                StepAction(556, 4, [], (-1, -1), (-1, -1)),
++                StepAction(558, 4, [1, 1, 1, 1, 1], (1, 1), (2, 0)),
++                StepAction(560, 4, [], (-1, -1), (-1, -1)),
++                StepAction(562, 4, [0, 1, 1, 1, 1], (-1, -1), (-1, -1)),
++            ],
++        ),
++        # test case 2.2: no hit, accept 2 tokens
++        "accept_2_2": TestConfig(
++            num_prompt_tokens=555,
++            num_generated_tokens=20,
++            num_accepted_tokens=2,
++            step_actions=[
++                StepAction(0, 555, [1, 1, 1, 1], (-1, -1), (-1, -1)),
++                StepAction(555, 4, [], (-1, -1), (-1, -1)),
++                StepAction(557, 4, [1, 1, 1, 1, 1], (1, 1), (-1, -1)),
++                StepAction(559, 4, [], (-1, -1), (1, 0)),
++                StepAction(561, 4, [0, 1, 1, 1, 1], (-1, -1), (-1, -1)),
++            ],
++        ),
++        "accept_3_1": TestConfig(
++            num_prompt_tokens=553,
++            num_generated_tokens=20,
++            num_accepted_tokens=3,
++            step_actions=[
++                StepAction(0, 553, [1, 1, 1, 1], (-1, -1), (-1, -1)),
++                StepAction(553, 4, [], (-1, -1), (-1, -1)),
++                StepAction(556, 4, [], (-1, -1), (-1, -1)),
++                StepAction(559, 4, [1, 1, 1, 1, 1], (2, 1), (1, 0)),
++                StepAction(562, 4, [0, 1, 1, 1, 1], (-1, -1), (-1, -1)),
++            ],
++        ),
++        "accept_3_2": TestConfig(
++            num_prompt_tokens=554,
++            num_generated_tokens=20,
++            num_accepted_tokens=3,
++            step_actions=[
++                StepAction(0, 554, [1, 1, 1, 1], (-1, -1), (-1, -1)),
++                StepAction(554, 4, [], (-1, -1), (-1, -1)),
++                StepAction(557, 4, [1, 1, 1, 1, 1], (2, 1), (3, 0)),
++                StepAction(560, 4, [], (-1, -1), (-1, -1)),
++                StepAction(563, 4, [0, 1, 1, 1, 1], (-1, -1), (-1, -1)),
++            ],
++        ),
++        "accept_3_3": TestConfig(
++            num_prompt_tokens=555,
++            num_generated_tokens=20,
++            num_accepted_tokens=3,
++            step_actions=[
++                StepAction(0, 555, [1, 1, 1, 1], (-1, -1), (-1, -1)),
++                StepAction(555, 4, [], (-1, -1), (-1, -1)),
++                StepAction(558, 4, [1, 1, 1, 1, 1], (2, 1), (2, 0)),
++                StepAction(561, 4, [0, 1, 1, 1, 1], (-1, -1), (-1, -1)),
++            ],
++        ),
++        "accept_4_1": TestConfig(
++            num_prompt_tokens=553,
++            num_generated_tokens=20,
++            num_accepted_tokens=4,
++            step_actions=[
++                StepAction(0, 553, [1, 1, 1, 1], (-1, -1), (-1, -1)),
++                StepAction(553, 4, [], (-1, -1), (-1, -1)),
++                StepAction(557, 4, [1, 1, 1, 1, 1], (3, 1), (3, 0)),
++                StepAction(561, 4, [0, 1, 1, 1, 1], (-1, -1), (-1, -1)),
++                StepAction(565, 4, [], (-1, -1), (-1, -1)),
++            ],
++        ),
++        "accept_4_2": TestConfig(
++            num_prompt_tokens=554,
++            num_generated_tokens=25,
++            num_accepted_tokens=4,
++            step_actions=[
++                StepAction(0, 554, [1, 1, 1, 1], (-1, -1), (-1, -1)),
++                StepAction(554, 4, [], (-1, -1), (-1, -1)),
++                StepAction(558, 4, [1, 1, 1, 1, 1], (3, 1), (2, 0)),
++                StepAction(562, 4, [0, 1, 1, 1, 1], (-1, -1), (-1, -1)),
++                StepAction(566, 4, [], (-1, -1), (-1, -1)),
++            ],
++        ),
++        "accept_4_3": TestConfig(
++            num_prompt_tokens=555,
++            num_generated_tokens=25,
++            num_accepted_tokens=4,
++            step_actions=[
++                StepAction(0, 555, [1, 1, 1, 1], (-1, -1), (-1, -1)),
++                StepAction(555, 4, [], (-1, -1), (-1, -1)),
++                StepAction(559, 4, [1, 1, 1, 1, 1], (3, 1), (1, 0)),
++                StepAction(563, 4, [0, 1, 1, 1, 1], (-1, -1), (-1, -1)),
++            ],
++        ),
++        "accept_4_4": TestConfig(
++            num_prompt_tokens=556,
++            num_generated_tokens=25,
++            num_accepted_tokens=4,
++            step_actions=[
++                StepAction(0, 556, [1, 1, 1, 1], (-1, -1), (-1, -1)),
++                StepAction(556, 4, [], (-1, -1), (3, 0)),
++                StepAction(560, 4, [1, 1, 1, 1, 1], (0, 1), (-1, -1)),
++                StepAction(564, 4, [0, 1, 1, 1, 1], (-1, -1), (-1, -1)),
++            ],
++        ),
++        "prompt_block_size": TestConfig(
++            num_prompt_tokens=560,
++            num_generated_tokens=10,
++            num_accepted_tokens=4,
++            step_actions=[
++                StepAction(0, 560, [1, 1, 1, 1], (-1, -1), (-1, -1)),
++                StepAction(560, 4, [1, 1, 1, 1, 1], (0, 1), (-1, -1)),
++            ],
++        ),
++        "prompt_2_block_size": TestConfig(
++            num_prompt_tokens=560 * 2,
++            num_generated_tokens=10,
++            num_accepted_tokens=4,
++            step_actions=[
++                StepAction(0, 560, [1, 1, 1, 1], (-1, -1), (-1, -1)),
++                StepAction(560, 560, [1, 1, 1, 1, 1], (0, 1), (-1, -1)),
++                StepAction(560 * 2, 4, [0, 1, 1, 1, 1, 1], (1, 2), (-1, -1)),
++            ],
++        ),
++        "prompt_2_block_size_10": TestConfig(
++            num_prompt_tokens=560 * 2 + 10,
++            num_generated_tokens=10,
++            num_accepted_tokens=4,
++            step_actions=[
++                StepAction(0, 560, [1, 1, 1, 1], (-1, -1), (-1, -1)),
++                StepAction(560, 570, [1, 0, 1, 1, 1, 1], (0, 2), (-1, -1)),
++                StepAction(560 * 2 + 10, 4, [0, 0, 1, 1, 1, 1], (-1, -1), (-1, -1)),
++            ],
++        ),
++        "prompt_3_block_size": TestConfig(
++            num_prompt_tokens=560 * 3,
++            num_generated_tokens=10,
++            num_accepted_tokens=4,
++            step_actions=[
++                StepAction(0, 560 * 2, [0, 1, 1, 1, 1], (-1, -1), (-1, -1)),
++                StepAction(560 * 2, 560, [0, 1, 1, 1, 1, 1], (1, 2), (-1, -1)),
++                StepAction(560 * 3, 4, [0, 0, 1, 1, 1, 1, 1], (2, 3), (-1, -1)),
++            ],
++        ),
++        "prompt_3_block_size_10": TestConfig(
++            num_prompt_tokens=560 * 3 + 10,
++            num_generated_tokens=10,
++            num_accepted_tokens=4,
++            step_actions=[
++                StepAction(0, 560 * 2, [0, 1, 1, 1, 1], (-1, -1), (-1, -1)),
++                StepAction(560 * 2, 570, [0, 1, 0, 1, 1, 1, 1], (1, 3), (-1, -1)),
++                StepAction(560 * 3 + 10, 4, [0, 0, 0, 1, 1, 1, 1], (-1, -1), (-1, -1)),
++            ],
++        ),
++        "prompt_10_block_size": TestConfig(
++            num_prompt_tokens=560 * 10,
++            num_generated_tokens=10,
++            num_accepted_tokens=4,
++            step_actions=[
++                StepAction(0, 560 * 5, [0, 0, 0, 0, 1, 1, 1, 1], (-1, -1), (-1, -1)),
++                StepAction(
++                    560 * 5,
++                    560 * 4,
++                    [0, 0, 0, 0, 1, 0, 0, 0, 1, 1, 1, 1],
++                    (4, 8),
++                    (-1, -1),
++                ),
++                StepAction(
++                    560 * 9,
++                    560,
++                    [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1],
++                    (8, 9),
++                    (-1, -1),
++                ),
++                StepAction(
++                    560 * 10,
++                    4,
++                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1],
++                    (9, 10),
++                    (-1, -1),
++                ),
++            ],
++        ),
++        "prompt_10_block_size_10": TestConfig(
++            num_prompt_tokens=560 * 10 + 10,
++            num_generated_tokens=10,
++            num_accepted_tokens=4,
++            step_actions=[
++                StepAction(0, 560 * 5, [0, 0, 0, 0, 1, 1, 1, 1], (-1, -1), (-1, -1)),
++                StepAction(
++                    560 * 5,
++                    560 * 4,
++                    [0, 0, 0, 0, 1, 0, 0, 0, 1, 1, 1, 1],
++                    (4, 8),
++                    (-1, -1),
++                ),
++                StepAction(
++                    560 * 9,
++                    560 + 10,
++                    [0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 1, 1],
++                    (8, 10),
++                    (-1, -1),
++                ),
++            ],
++        ),
++    }
++
++    engine = LLM(
++        model=MODEL,
++        enable_prefix_caching=True,
++        block_size=BLOCK_SIZE,
++        mamba_cache_mode="align",
++        speculative_config={
++            "method": "qwen3_next_mtp",
++            "num_speculative_tokens": num_speculative_tokens,
++        },
++        max_num_batched_tokens=3072,
++        hf_overrides={"num_hidden_layers": NUM_HIDDEN_LAYERS},
++        seed=42,
++    )
++    global prompt_token_ids
++    prompt_token_ids = engine.get_tokenizer().encode(full_prompt)
++    print(f"Token IDs length: {len(prompt_token_ids)}")
++    for test_case_name, test_config in tests.items():
++        print(f"Running test case: {test_case_name}")
++        num_generated_tokens = test_config.num_generated_tokens
++        num_prompt_tokens = test_config.num_prompt_tokens
++        global num_accepted_tokens
++        num_accepted_tokens = test_config.num_accepted_tokens
++        sampling_params = SamplingParams(
++            temperature=0.0, max_tokens=num_generated_tokens
++        )
++        global cur_step_action_idx
++        cur_step_action_idx = 0
++        for step_action_prev, step_action_next in zip(
++            test_config.step_actions[:-1], test_config.step_actions[1:]
++        ):
++            if (
++                step_action_next.kv_cache_block_ids is not None
++                and len(step_action_next.kv_cache_block_ids) == 0
++            ):
++                prev_block_ids = step_action_prev.kv_cache_block_ids
++                if prev_block_ids is not None:
++                    step_action_next.kv_cache_block_ids = prev_block_ids.copy()
++        global step_actions
++        step_actions = test_config.step_actions
++        _ = engine.generate(
++            [TokensPrompt(prompt_token_ids=prompt_token_ids[:num_prompt_tokens])],
++            sampling_params,
++        )
++        assert engine.llm_engine.engine_core.engine_core.scheduler.reset_prefix_cache()
++        print(f"End test case: {test_case_name}")
++        keys_to_check = [
++            (action.postprocess_copy_idx[1] + 1) * BLOCK_SIZE
++            for action in test_config.step_actions
++            if action.postprocess_copy_idx and action.postprocess_copy_idx[0] != -1
++        ]
++        mamba_state_ref = torch.load("mamba_kv_cache_dict_ref.pth")
++        check_mamba_state_equal(mamba_state_ref, mamba_kv_cache_dict, keys_to_check)
++        mamba_kv_cache_dict.clear()
 diff --git a/tests/v1/e2e/test_spec_decode.py b/tests/v1/e2e/test_spec_decode.py
 index a25114a4d..43bf3c962 100644
 --- a/tests/v1/e2e/test_spec_decode.py
@@ -1784,6 +2694,150 @@ index 103675608..497a9fe11 100644
  
  class MockSubscriber:
      """Helper class to receive and verify published events"""
+diff --git a/tests/v1/worker/test_gpu_profiler.py b/tests/v1/worker/test_gpu_profiler.py
+index 933ea42f1..5a1031198 100644
+--- a/tests/v1/worker/test_gpu_profiler.py
++++ b/tests/v1/worker/test_gpu_profiler.py
+@@ -1,9 +1,12 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++from types import SimpleNamespace
++
+ import pytest
++import torch
+ 
+ from vllm.config import ProfilerConfig
+-from vllm.profiler.wrapper import WorkerProfiler
++from vllm.profiler.wrapper import TorchProfilerWrapper, WorkerProfiler
+ 
+ 
+ class ConcreteWorkerProfiler(WorkerProfiler):
+@@ -202,3 +205,52 @@ def test_mixed_delay_and_stop(default_profiler_config):
+     profiler.step()
+ 
+     assert profiler.start_call_count == 0
++
++
++def test_torch_profiler_wrapper_disables_trace_export(monkeypatch):
++    captured = {}
++
++    class FakeProfiler:
++        def start(self) -> None:
++            pass
++
++        def stop(self) -> None:
++            pass
++
++        def key_averages(self):
++            return SimpleNamespace(table=lambda **kwargs: "table")
++
++    def fake_trace_handler(*args, **kwargs):
++        captured["trace_handler_called"] = True
++        return "trace-handler"
++
++    def fake_profile(**kwargs):
++        captured["profile_kwargs"] = kwargs
++        return FakeProfiler()
++
++    monkeypatch.setattr(torch.profiler, "tensorboard_trace_handler", fake_trace_handler)
++    monkeypatch.setattr(torch.profiler, "profile", fake_profile)
++
++    TorchProfilerWrapper(
++        ProfilerConfig(
++            profiler="torch",
++            torch_profiler_dir="/tmp/mock",
++            torch_profiler_save_traces=False,
++        ),
++        worker_name="worker0",
++        local_rank=0,
++        activities=["CPU"],
++    )
++
++    assert captured["profile_kwargs"]["on_trace_ready"] is None
++    assert "trace_handler_called" not in captured
++
++
++def test_profiler_config_reads_save_traces_from_env(monkeypatch):
++    monkeypatch.setenv("VLLM_TORCH_PROFILER_DIR", "/tmp/mock")
++    monkeypatch.setenv("VLLM_TORCH_PROFILER_SAVE_TRACES", "0")
++
++    profiler_config = ProfilerConfig()
++
++    assert profiler_config.profiler == "torch"
++    assert profiler_config.torch_profiler_save_traces is False
+diff --git a/tests/v1/worker/test_mamba_utils.py b/tests/v1/worker/test_mamba_utils.py
+new file mode 100644
+index 000000000..38eb250fb
+--- /dev/null
++++ b/tests/v1/worker/test_mamba_utils.py
+@@ -0,0 +1,67 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++from unittest.mock import MagicMock, patch
++
++from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
++from vllm.v1.worker.mamba_utils import preprocess_mamba
++
++
++def _make_scheduler_output(
++    finished_req_ids: set[str],
++    preempted_req_ids: set[str] | None,
++    resumed_req_ids: set[str],
++) -> SchedulerOutput:
++    cached = CachedRequestData.make_empty()
++    cached.resumed_req_ids = resumed_req_ids
++    return SchedulerOutput(
++        scheduled_new_reqs=[],
++        scheduled_cached_reqs=cached,
++        num_scheduled_tokens={},
++        total_num_scheduled_tokens=0,
++        scheduled_spec_decode_tokens={},
++        scheduled_encoder_inputs={},
++        num_common_prefix_blocks=[],
++        finished_req_ids=finished_req_ids,
++        free_encoder_mm_hashes=[],
++        preempted_req_ids=preempted_req_ids,
++    )
++
++
++def test_resumed_req_ids_cleared_from_mamba_state_idx():
++    """When a request is force-preempted (e.g. reset_prefix_cache),
++    it appears in resumed_req_ids but NOT in preempted_req_ids.
++    preprocess_mamba must still clear its mamba_state_idx entry,
++    otherwise stale indices can point beyond the new block allocation.
++    """
++    spec = MagicMock(block_size=64, num_speculative_blocks=0)
++    cache_config = MagicMock(enable_prefix_caching=True)
++    input_batch = MagicMock(req_ids=[])
++
++    mamba_state_idx = {
++        "finished": 1,
++        "preempted": 2,
++        "resumed": 3,  # only in resumed_req_ids, NOT in preempted
++        "keep": 99,
++    }
++    sched = _make_scheduler_output(
++        finished_req_ids={"finished"},
++        preempted_req_ids={"preempted"},
++        resumed_req_ids={"resumed"},
++    )
++
++    with patch(
++        "vllm.v1.worker.mamba_utils.get_mamba_groups",
++        return_value=([0], spec),
++    ):
++        preprocess_mamba(
++            sched,
++            MagicMock(),
++            cache_config,
++            mamba_state_idx,
++            input_batch,
++            {},
++            {},
++            (),
++        )
++
++    assert mamba_state_idx == {"keep": 99}
 diff --git a/vllm/_ipex_ops.py b/vllm/_ipex_ops.py
 index 239f5376e..5b04d8d90 100644
 --- a/vllm/_ipex_ops.py
@@ -1896,6 +2950,34 @@ index 9d6298927..00546dd5c 100644
          input_requests[0].multi_modal_data,
      )
  
+diff --git a/vllm/config/cache.py b/vllm/config/cache.py
+index 839ea4780..abf10e21d 100644
+--- a/vllm/config/cache.py
++++ b/vllm/config/cache.py
+@@ -31,6 +31,7 @@ CacheDType = Literal[
+     "fp8_ds_mla",
+ ]
+ MambaDType = Literal["auto", "float32", "float16"]
++MambaCacheMode = Literal["all", "align", "none"]
+ PrefixCachingHashAlgo = Literal["sha256", "sha256_cbor", "xxhash", "xxhash_cbor"]
+ KVOffloadingBackend = Literal["native", "lmcache"]
+ 
+@@ -123,6 +124,15 @@ class CacheConfig:
+     """The data type to use for the Mamba cache (ssm state only, conv state will
+     still be controlled by mamba_cache_dtype). If set to 'auto', the data type
+     for the ssm state will be determined by mamba_cache_dtype."""
++    mamba_cache_mode: MambaCacheMode = "none"
++    """The cache strategy for Mamba layers.
++    - "none": set when prefix caching is disabled.
++    - "all": cache the mamba state of all tokens at position i * block_size. This is 
++           the default behavior (for models that support it) when prefix caching is
++           enabled.
++    - "align": only cache the mamba state of the last token of each scheduler step and
++           when the token is at position i * block_size.
++    """
+ 
+     # Will be set after profiling.
+     num_gpu_blocks: int | None = field(default=None, init=False)
 diff --git a/vllm/config/model.py b/vllm/config/model.py
 index f46918029..75cc84a24 100644
 --- a/vllm/config/model.py
@@ -2002,6 +3084,31 @@ index ecb346af8..937687bac 100644
          limit_data = self.limit_per_prompt.get(modality)
  
          if limit_data is None:
+diff --git a/vllm/config/profiler.py b/vllm/config/profiler.py
+index 76cc546f3..6eabf18ad 100644
+--- a/vllm/config/profiler.py
++++ b/vllm/config/profiler.py
+@@ -43,6 +43,9 @@ class ProfilerConfig:
+     torch_profiler_use_gzip: bool = True
+     """If `True`, saves torch profiler traces in gzip format. Enabled by default"""
+ 
++    torch_profiler_save_traces: bool = True
++    """If `True`, saves torch profiler trace files. Enabled by default."""
++
+     torch_profiler_dump_cuda_time_total: bool = True
+     """If `True`, dumps total CUDA time in torch profiler traces. Enabled by default."""
+ 
+@@ -158,6 +161,10 @@ class ProfilerConfig:
+                     "torch_profiler_use_gzip",
+                     "VLLM_TORCH_PROFILER_USE_GZIP",
+                 )
++                self._set_from_env_if_set(
++                    "torch_profiler_save_traces",
++                    "VLLM_TORCH_PROFILER_SAVE_TRACES",
++                )
+                 self._set_from_env_if_set(
+                     "torch_profiler_dump_cuda_time_total",
+                     "VLLM_TORCH_PROFILER_DUMP_CUDA_TIME_TOTAL",
 diff --git a/vllm/config/speculative.py b/vllm/config/speculative.py
 index cba00daaa..5a2ff79ca 100644
 --- a/vllm/config/speculative.py
@@ -2054,7 +3161,7 @@ index cba00daaa..5a2ff79ca 100644
              hf_config.model_type = "longcat_flash_mtp"
              n_predict = getattr(hf_config, "num_nextn_predict_layers", 1)
 diff --git a/vllm/config/vllm.py b/vllm/config/vllm.py
-index ec699b629..72da0a11f 100644
+index ec699b629..7f11b3bed 100644
 --- a/vllm/config/vllm.py
 +++ b/vllm/config/vllm.py
 @@ -559,6 +559,8 @@ class VllmConfig:
@@ -2088,6 +3195,24 @@ index ec699b629..72da0a11f 100644
          if (
              self.model_config is not None
              and self.scheduler_config.enable_chunked_prefill
+@@ -1008,6 +1012,17 @@ class VllmConfig:
+             # Default to enable HMA if not explicitly disabled by user or logic above.
+             self.scheduler_config.disable_hybrid_kv_cache_manager = False
+ 
++        if self.cache_config.mamba_cache_mode == "align":
++            if self.scheduler_config.long_prefill_token_threshold > 0:
++                assert (
++                    self.scheduler_config.long_prefill_token_threshold
++                    >= self.cache_config.block_size
++                )
++            assert not self.scheduler_config.disable_chunked_mm_input, (
++                "Chunked MM input is required because we need the flexibility to "
++                "schedule a multiple of block_size tokens even if they are in the "
++                "middle of a mm input"
++            )
+         if self.compilation_config.debug_dump_path:
+             self.compilation_config.debug_dump_path = (
+                 self.compilation_config.debug_dump_path.absolute().expanduser()
 diff --git a/vllm/connections.py b/vllm/connections.py
 index 31b0d5e9c..f79d681ce 100644
 --- a/vllm/connections.py
@@ -2282,10 +3407,18 @@ index f3d9262d2..b4b5b0378 100644
          self, input_: torch.Tensor, dst: int = 0, dim: int = -1
      ) -> torch.Tensor | None:
 diff --git a/vllm/engine/arg_utils.py b/vllm/engine/arg_utils.py
-index 3a36ca797..6638d4de4 100644
+index 3a36ca797..d4aa35f21 100644
 --- a/vllm/engine/arg_utils.py
 +++ b/vllm/engine/arg_utils.py
-@@ -455,6 +455,7 @@ class EngineArgs:
+@@ -60,6 +60,7 @@ from vllm.config.cache import (
+     BlockSize,
+     CacheDType,
+     KVOffloadingBackend,
++    MambaCacheMode,
+     MambaDType,
+     PrefixCachingHashAlgo,
+ )
+@@ -455,6 +456,7 @@ class EngineArgs:
      allow_deprecated_quantization: bool = ModelConfig.allow_deprecated_quantization
      enforce_eager: bool = ModelConfig.enforce_eager
      disable_custom_all_reduce: bool = ParallelConfig.disable_custom_all_reduce
@@ -2293,7 +3426,25 @@ index 3a36ca797..6638d4de4 100644
      limit_mm_per_prompt: dict[str, int | dict[str, int]] = get_field(
          MultiModalConfig, "limit_per_prompt"
      )
-@@ -955,6 +956,9 @@ class EngineArgs:
+@@ -559,6 +561,7 @@ class EngineArgs:
+     mamba_cache_dtype: MambaDType = CacheConfig.mamba_cache_dtype
+     mamba_ssm_cache_dtype: MambaDType = CacheConfig.mamba_ssm_cache_dtype
+     mamba_block_size: int | None = get_field(CacheConfig, "mamba_block_size")
++    mamba_cache_mode: MambaCacheMode = CacheConfig.mamba_cache_mode
+ 
+     additional_config: dict[str, Any] = get_field(VllmConfig, "additional_config")
+ 
+@@ -942,6 +945,9 @@ class EngineArgs:
+         cache_group.add_argument(
+             "--mamba-block-size", **cache_kwargs["mamba_block_size"]
+         )
++        cache_group.add_argument(
++            "--mamba-cache-mode", **cache_kwargs["mamba_cache_mode"]
++        )
+         cache_group.add_argument(
+             "--kv-offloading-size", **cache_kwargs["kv_offloading_size"]
+         )
+@@ -955,6 +961,9 @@ class EngineArgs:
              title="MultiModalConfig",
              description=MultiModalConfig.__doc__,
          )
@@ -2303,7 +3454,7 @@ index 3a36ca797..6638d4de4 100644
          multimodal_group.add_argument(
              "--limit-mm-per-prompt", **multimodal_kwargs["limit_per_prompt"]
          )
-@@ -1250,6 +1254,7 @@ class EngineArgs:
+@@ -1250,6 +1259,7 @@ class EngineArgs:
              skip_tokenizer_init=self.skip_tokenizer_init,
              enable_prompt_embeds=self.enable_prompt_embeds,
              served_model_name=self.served_model_name,
@@ -2311,6 +3462,14 @@ index 3a36ca797..6638d4de4 100644
              limit_mm_per_prompt=self.limit_mm_per_prompt,
              enable_mm_embeds=self.enable_mm_embeds,
              interleave_mm_strings=self.interleave_mm_strings,
+@@ -1416,6 +1426,7 @@ class EngineArgs:
+             mamba_cache_dtype=self.mamba_cache_dtype,
+             mamba_ssm_cache_dtype=self.mamba_ssm_cache_dtype,
+             mamba_block_size=self.mamba_block_size,
++            mamba_cache_mode=self.mamba_cache_mode,
+             kv_offloading_size=self.kv_offloading_size,
+             kv_offloading_backend=self.kv_offloading_backend,
+         )
 diff --git a/vllm/entrypoints/openai/translations/speech_to_text.py b/vllm/entrypoints/openai/translations/speech_to_text.py
 new file mode 100644
 index 000000000..c993e1ebd
@@ -3052,10 +4211,18 @@ index 000000000..c993e1ebd
 +                min_energy = energy
 +        return quietest_idx
 diff --git a/vllm/envs.py b/vllm/envs.py
-index d77c1e9d9..af1b68962 100755
+index d77c1e9d9..f652ec4e7 100755
 --- a/vllm/envs.py
 +++ b/vllm/envs.py
-@@ -252,6 +252,9 @@ if TYPE_CHECKING:
+@@ -99,6 +99,7 @@ if TYPE_CHECKING:
+     VLLM_TORCH_PROFILER_WITH_STACK: str | None = None
+     VLLM_TORCH_PROFILER_WITH_FLOPS: str | None = None
+     VLLM_TORCH_PROFILER_USE_GZIP: str | None = None
++    VLLM_TORCH_PROFILER_SAVE_TRACES: str | None = None
+     VLLM_TORCH_PROFILER_DUMP_CUDA_TIME_TOTAL: str | None = None
+     VLLM_PROFILER_DELAY_ITERS: str | None = None
+     VLLM_PROFILER_MAX_ITERS: str | None = None
+@@ -252,6 +253,9 @@ if TYPE_CHECKING:
      VLLM_USE_V2_MODEL_RUNNER: bool = False
      VLLM_LOG_MODEL_INSPECTION: bool = False
      VLLM_DEBUG_MFU_METRICS: bool = False
@@ -3065,7 +4232,7 @@ index d77c1e9d9..af1b68962 100755
  
  
  def get_default_cache_root():
-@@ -442,9 +445,9 @@ def get_vllm_port() -> int | None:
+@@ -442,9 +446,9 @@ def get_vllm_port() -> int | None:
      try:
          return int(port)
      except ValueError as err:
@@ -3077,7 +4244,20 @@ index d77c1e9d9..af1b68962 100755
          if parsed.scheme:
              raise ValueError(
                  f"VLLM_PORT '{port}' appears to be a URI. "
-@@ -1611,6 +1614,18 @@ environment_variables: dict[str, Callable[[], Any]] = {
+@@ -909,6 +913,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
+     # Control whether torch profiler gzip-compresses profiling files.
+     # Deprecated, see profiler_config.
+     "VLLM_TORCH_PROFILER_USE_GZIP": lambda: os.getenv("VLLM_TORCH_PROFILER_USE_GZIP"),
++    # Control whether torch profiler saves trace files.
++    # Set to 0 to only keep the aggregated text outputs.
++    # Deprecated, see profiler_config.
++    "VLLM_TORCH_PROFILER_SAVE_TRACES": lambda: os.getenv(
++        "VLLM_TORCH_PROFILER_SAVE_TRACES"
++    ),
+     # Control whether torch profiler dumps the self_cuda_time_total table.
+     # Set to 0 to disable dumping the table.
+     # Deprecated, see profiler_config.
+@@ -1611,6 +1621,18 @@ environment_variables: dict[str, Callable[[], Any]] = {
      "VLLM_DEBUG_MFU_METRICS": lambda: bool(
          int(os.getenv("VLLM_DEBUG_MFU_METRICS", "0"))
      ),
@@ -3291,7 +4471,7 @@ index 18e17a511..65af42589 100644
              ctx = contextlib.nullcontext()
  
 diff --git a/vllm/model_executor/layers/fused_moe/layer.py b/vllm/model_executor/layers/fused_moe/layer.py
-index 3b3a789f6..712bdf85c 100644
+index 3b3a789f6..24ce30e6a 100644
 --- a/vllm/model_executor/layers/fused_moe/layer.py
 +++ b/vllm/model_executor/layers/fused_moe/layer.py
 @@ -667,6 +667,7 @@ class FusedMoE(CustomOp):
@@ -3302,11 +4482,89 @@ index 3b3a789f6..712bdf85c 100644
              "CompressedTensorsWNA16MarlinMoEMethod",
              "CompressedTensorsWNA16MoEMethod",
          ):
+@@ -1697,6 +1698,9 @@ class FusedMoE(CustomOp):
+         """
+         Some combine kernels reduce across GPU ranks by default.
+         """
++        import os
++        if os.environ.get("SKIP_ALL_REDUCE", "0") == "1":
++            return final_hidden_states
+         if self.must_reduce_shared_expert_outputs():
+             return final_hidden_states
+         else:
+@@ -1707,6 +1711,7 @@ class FusedMoE(CustomOp):
+         hidden_states: torch.Tensor,
+         router_logits: torch.Tensor,
+     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
++        # print("Using forward_native for MoE layer:", self.layer_name)
+         og_hidden_states = hidden_states.shape[-1]
+         if self.hidden_size != og_hidden_states:
+             hidden_states = F.pad(
+@@ -1766,6 +1771,7 @@ class FusedMoE(CustomOp):
+         hidden_states: torch.Tensor,
+         router_logits: torch.Tensor,
+     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
++        # print("Using forward_cuda for MoE layer:", self.layer_name)
+         return self.forward_native(hidden_states, router_logits)
+ 
+     def forward_impl_chunked(
+@@ -1774,6 +1780,7 @@ class FusedMoE(CustomOp):
+         full_router_logits: torch.Tensor,
+         has_separate_shared_experts: bool,
+     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
++        # print("Using forward_impl_chunked for MoE layer:", self.layer_name)
+         assert self.batched_hidden_states is not None
+         assert self.batched_router_logits is not None
+         assert self.batched_hidden_states.dtype == full_hidden_states.dtype
+@@ -1889,6 +1896,7 @@ class FusedMoE(CustomOp):
+         hidden_states: torch.Tensor,
+         router_logits: torch.Tensor,
+     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
++        # print("Using forward_impl for MoE layer:", self.layer_name)
+         assert self.quant_method is not None
+ 
+         self.ensure_moe_quant_config_init()
+diff --git a/vllm/model_executor/layers/fused_moe/shared_fused_moe.py b/vllm/model_executor/layers/fused_moe/shared_fused_moe.py
+index a143347b1..97df0f09f 100644
+--- a/vllm/model_executor/layers/fused_moe/shared_fused_moe.py
++++ b/vllm/model_executor/layers/fused_moe/shared_fused_moe.py
+@@ -63,14 +63,17 @@ class SharedFusedMoE(FusedMoE):
+     ) -> tuple[torch.Tensor, torch.Tensor]:
+         if not self.use_overlapped:
+             if self._shared_experts is not None:
++                print("Computing shared expert outputs...")
+                 shared_out = self._shared_experts(hidden_states)
+ 
+                 # Reduce shared expert outputs if necessary, since the MLP
+                 # should have been created with reduce_results=False.
++                import os
+                 if (
+                     self.reduce_results
+                     and get_tensor_model_parallel_world_size() > 1
+                     and self.must_reduce_shared_expert_outputs()
++                    and os.environ.get("SKIP_ALL_REDUCE", "0") != "1"
+                 ):
+                     shared_out = tensor_model_parallel_all_reduce(shared_out)
+             else:
+@@ -86,11 +89,13 @@ class SharedFusedMoE(FusedMoE):
+                 router_logits=router_logits,
+             )
+             # ensure early TP reduction of shared expert outputs when required
++            import os
+             if (
+                 shared_out is not None
+                 and self.reduce_results
+                 and get_tensor_model_parallel_world_size() > 1
+                 and self.must_reduce_shared_expert_outputs()
++                and os.environ.get("SKIP_ALL_REDUCE", "0") != "1"
+             ):
+                 shared_out = tensor_model_parallel_all_reduce(shared_out)
+         return shared_out, fused_out
 diff --git a/vllm/model_executor/layers/layernorm.py b/vllm/model_executor/layers/layernorm.py
-index d962ab8bb..6bb7479ce 100644
+index d962ab8bb..ed7f62cd6 100644
 --- a/vllm/model_executor/layers/layernorm.py
 +++ b/vllm/model_executor/layers/layernorm.py
-@@ -326,6 +326,21 @@ class GemmaRMSNorm(CustomOp):
+@@ -326,6 +326,31 @@ class GemmaRMSNorm(CustomOp):
              self._is_compiled = True
          return self.forward_native(x, residual)
  
@@ -3315,42 +4573,63 @@ index d962ab8bb..6bb7479ce 100644
 +        x: torch.Tensor,
 +        residual: torch.Tensor | None = None,
 +    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-+        from vllm._ipex_ops import ipex_ops as ops
-+
 +        # Gemma weight semantics: x * (1 + w) instead of x * w
-+        w = self.weight.data + 1.0
++        if not hasattr(self, '_gemma_w'):
++            self._gemma_w = self.weight.data + 1.0
++        if not hasattr(self, '_gemma_w_fp16'):
++            self._gemma_w_fp16 = self._gemma_w.half()
 +
-+        if residual is not None:
-+            ops.fused_add_rms_norm(x, residual, w, self.variance_epsilon)
++        if residual is not None and x.shape[0] == 1:
++            # Decode fast path: ESIMD kernel (lower dispatch overhead than IPEX)
++            from custom_esimd_kernels_vllm import esimd_fused_add_rms_norm
++            esimd_fused_add_rms_norm(x, residual, self._gemma_w_fp16,
++                                     self.variance_epsilon)
 +            return x, residual
-+        return ops.rms_norm(x, w, self.variance_epsilon)
++
++        from vllm._ipex_ops import ipex_ops as ops
++        if residual is not None:
++            ops.fused_add_rms_norm(x, residual, self._gemma_w,
++                                   self.variance_epsilon)
++            return x, residual
++        return ops.rms_norm(x, self._gemma_w, self.variance_epsilon)
 +
  
  # --8<-- [start:rms_norm_gated]
  @CustomOp.register("rms_norm_gated")
-@@ -432,6 +447,20 @@ class RMSNormGated(CustomOp):
+@@ -432,6 +457,31 @@ class RMSNormGated(CustomOp):
              norm_before_gate=self.norm_before_gate,
          )
  
 +    def forward_xpu(
 +        self, x: torch.Tensor, z: torch.Tensor | None = None
 +    ) -> torch.Tensor:
-+        from vllm.model_executor.layers.fla.ops.layernorm_guard import rmsnorm_fn
++        from vllm.model_executor.layers.fla.ops.layernorm_guard import (
++            layer_norm_fwd,
++        )
 +
-+        return rmsnorm_fn(
++        # Bypass rmsnorm_fn -> LayerNormFn.apply -> @input_guard path
++        # to avoid: unconditional .contiguous(), torch.xpu.device() ctx,
++        # autograd save_for_backward, and per-call tensor allocations.
++        x_shape_og = x.shape
++        x = x.reshape(-1, x.shape[-1])
++        if z is not None:
++            z = z.reshape(-1, z.shape[-1])
++        y, _, _ = layer_norm_fwd(
 +            x,
 +            self.weight,
 +            self.bias,
++            self.eps,
 +            z=z,
-+            eps=self.eps,
 +            group_size=self.group_size,
 +            norm_before_gate=self.norm_before_gate,
++            is_rms_norm=True,
 +        )
++        return y.reshape(x_shape_og)
  
  class LayerNorm(nn.Module):
      """
 diff --git a/vllm/model_executor/layers/linear.py b/vllm/model_executor/layers/linear.py
-index 3df20796b..2a1e804ce 100644
+index 3df20796b..56aa0591c 100644
 --- a/vllm/model_executor/layers/linear.py
 +++ b/vllm/model_executor/layers/linear.py
 @@ -61,6 +61,7 @@ WEIGHT_LOADER_V2_SUPPORTED = [
@@ -3361,8 +4640,127 @@ index 3df20796b..2a1e804ce 100644
  ]
  
  
+@@ -685,8 +686,13 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
+         self,
+         param: Parameter,
+         loaded_weight: torch.Tensor,
+-        loaded_shard_id: int | None = None,
++        loaded_shard_id: tuple[int, ...] | int | None = None,
+     ):
++        if isinstance(loaded_shard_id, tuple):
++            raise NotImplementedError(
++                "Shard id with multiple indices is not supported in weight_loader, "
++                "please use weight_loader_v2 instead."
++            )
+         # Special case for GGUF
+         # initialize GGUF param after we know the quantize type
+         is_gguf_weight = getattr(param, "is_gguf_weight", False)
+@@ -774,6 +780,8 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
+         if output_dim is not None:
+             shard_offset = sum(self.output_sizes[:loaded_shard_id])
+             shard_size = self.output_sizes[loaded_shard_id]
++            shard_offset //= self.tp_size
++            shard_size //= self.tp_size
+ 
+             if isinstance(param, BlockQuantScaleParameter):
+                 weight_block_size = getattr(self, "weight_block_size", None)
+@@ -781,9 +789,6 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
+                     weight_block_size, shard_size, shard_offset
+                 )
+ 
+-            shard_offset //= self.tp_size
+-            shard_size //= self.tp_size
+-
+             # Special case for quantization.
+             # If quantized, we need to adjust the offset and size to account
+             # for the packing.
+@@ -832,7 +837,10 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
+         param_data.copy_(loaded_weight)
+ 
+     def _load_fused_module_from_checkpoint(
+-        self, param: BasevLLMParameter, loaded_weight: torch.Tensor
++        self,
++        param: BasevLLMParameter,
++        loaded_weight: torch.Tensor,
++        output_sizes: list[int] | None = None,
+     ):
+         """
+         Handle special case for models where MLP layers are already
+@@ -846,7 +854,8 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
+ 
+         current_shard_offset = 0
+         shard_offsets: list[tuple[int, int, int]] = []
+-        for i, output_size in enumerate(self.output_sizes):
++        output_sizes = output_sizes or self.output_sizes
++        for i, output_size in enumerate(output_sizes):
+             shard_offsets.append((i, current_shard_offset, output_size))
+             current_shard_offset += output_size
+ 
+@@ -871,23 +880,38 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
+         self,
+         param: BasevLLMParameter,
+         loaded_weight: torch.Tensor,
+-        loaded_shard_id: int | None = None,
++        loaded_shard_id: tuple[int, ...] | int | None = None,
+     ):
+-        if loaded_shard_id is None:
++        if loaded_shard_id is None or isinstance(loaded_shard_id, tuple):
+             if isinstance(param, PerTensorScaleParameter):
+                 param.load_merged_column_weight(loaded_weight=loaded_weight, shard_id=0)
+                 return
+             elif type(param) in (RowvLLMParameter, BasevLLMParameter):
+                 param.load_merged_column_weight(loaded_weight=loaded_weight)
+                 return
++            output_sizes = (
++                [self.output_sizes[idx] for idx in loaded_shard_id]
++                if loaded_shard_id
++                else None
++            )
++            if isinstance(param, BlockQuantScaleParameter):
++                weight_block_size = getattr(self, "weight_block_size", None)
++                output_sizes = [
++                    adjust_block_scale_shard(weight_block_size, size, 0)[0]
++                    for size in (output_sizes or self.output_sizes)
++                ]
+             # TODO: @dsikka - move to parameter.py
+-            self._load_fused_module_from_checkpoint(param, loaded_weight)
++            self._load_fused_module_from_checkpoint(
++                param, loaded_weight, output_sizes=output_sizes
++            )
+             return
+ 
+         assert loaded_shard_id < len(self.output_sizes)
+ 
+         shard_offset = sum(self.output_sizes[:loaded_shard_id])
+         shard_size = self.output_sizes[loaded_shard_id]
++        shard_offset //= self.tp_size
++        shard_size //= self.tp_size
+ 
+         if isinstance(param, BlockQuantScaleParameter):
+             weight_block_size = getattr(self, "weight_block_size", None)
+@@ -895,9 +919,6 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
+                 weight_block_size, shard_size, shard_offset
+             )
+ 
+-        shard_offset //= self.tp_size
+-        shard_size //= self.tp_size
+-
+         param.load_merged_column_weight(
+             loaded_weight=loaded_weight,
+             shard_id=loaded_shard_id,
+@@ -1459,7 +1480,9 @@ class RowParallelLinear(LinearBase):
+         bias_ = None if (self.tp_rank > 0 or self.skip_bias_add) else self.bias
+         output_parallel = self.quant_method.apply(self, input_parallel, bias_)
+ 
+-        if self.reduce_results and self.tp_size > 1:
++        import os
++        _skip_all_reduce = os.environ.get("SKIP_ALL_REDUCE", "0") == "1"
++        if self.reduce_results and self.tp_size > 1 and not _skip_all_reduce:
+             output = tensor_model_parallel_all_reduce(output_parallel)
+         else:
+             output = output_parallel
 diff --git a/vllm/model_executor/layers/mamba/abstract.py b/vllm/model_executor/layers/mamba/abstract.py
-index 4f45dd6ca..4336cde92 100644
+index 4f45dd6ca..347ce139e 100644
 --- a/vllm/model_executor/layers/mamba/abstract.py
 +++ b/vllm/model_executor/layers/mamba/abstract.py
 @@ -43,7 +43,8 @@ class MambaBase(AttentionLayerBase):
@@ -3375,6 +4773,212 @@ index 4f45dd6ca..4336cde92 100644
          ):
              raise NotImplementedError(
                  "Mamba with speculative decoding is not supported yet."
+@@ -56,6 +57,7 @@ class MambaBase(AttentionLayerBase):
+             block_size=mamba_block_size,
+             page_size_padded=page_size_padded,
+             mamba_type=self.mamba_type,
++            mamba_cache_mode=vllm_config.cache_config.mamba_cache_mode,
+             num_speculative_blocks=(
+                 vllm_config.speculative_config.num_speculative_tokens
+                 if vllm_config.speculative_config
+diff --git a/vllm/model_executor/layers/mamba/mamba_mixer.py b/vllm/model_executor/layers/mamba/mamba_mixer.py
+index c22a309ce..134e1dfd6 100644
+--- a/vllm/model_executor/layers/mamba/mamba_mixer.py
++++ b/vllm/model_executor/layers/mamba/mamba_mixer.py
+@@ -255,7 +255,7 @@ class MambaMixer(MambaBase, CustomOp):
+ 
+         assert self.cache_config is not None
+         mamba_block_size = self.cache_config.mamba_block_size
+-        prefix_caching_enabled = self.cache_config.enable_prefix_caching
++        is_mamba_cache_all = self.cache_config.mamba_cache_mode == "all"
+ 
+         if attn_metadata is not None:
+             assert isinstance(attn_metadata, dict)
+@@ -304,7 +304,7 @@ class MambaMixer(MambaBase, CustomOp):
+         state_indices_tensor_p = prefill_decode_split.state_indices_tensor_p
+         state_indices_tensor_d = prefill_decode_split.state_indices_tensor_d
+ 
+-        if prefix_caching_enabled:
++        if is_mamba_cache_all:
+             block_idx_last_computed_token_d, block_idx_last_computed_token_p = (
+                 torch.split(
+                     attn_metadata.block_idx_last_computed_token,
+@@ -380,7 +380,7 @@ class MambaMixer(MambaBase, CustomOp):
+             ssm_outputs.append(scan_out_p)
+ 
+         if has_decode:
+-            if prefix_caching_enabled:
++            if is_mamba_cache_all:
+                 state_indices_tensor_d_input = state_indices_tensor_d.gather(
+                     1, block_idx_last_computed_token_d.unsqueeze(1)
+                 ).squeeze(1)
+diff --git a/vllm/model_executor/layers/mamba/mamba_mixer2.py b/vllm/model_executor/layers/mamba/mamba_mixer2.py
+index 74e4a34b4..7af5e02c2 100644
+--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
++++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
+@@ -570,7 +570,7 @@ class MambaMixer2(MambaBase, CustomOp):
+ 
+         assert self.cache_config is not None
+         mamba_block_size = self.cache_config.mamba_block_size
+-        prefix_caching_enabled = self.cache_config.enable_prefix_caching
++        is_mamba_cache_all = self.cache_config.mamba_cache_mode == "all"
+         if attn_metadata is not None:
+             assert isinstance(attn_metadata, dict)
+             attn_metadata = attn_metadata[self.prefix]
+@@ -622,7 +622,7 @@ class MambaMixer2(MambaBase, CustomOp):
+             dim=0,
+         )
+ 
+-        if prefix_caching_enabled:
++        if is_mamba_cache_all:
+             # If prefix caching is enabled, retrieve the relevant variables
+             # for prefill and decode
+             block_idx_last_computed_token_d, block_idx_last_computed_token_p = (
+@@ -701,7 +701,7 @@ class MambaMixer2(MambaBase, CustomOp):
+             initial_states = None
+             if has_initial_states_p is not None and prep_initial_states:
+                 kernel_ssm_indices = state_indices_tensor_p
+-                if prefix_caching_enabled:
++                if is_mamba_cache_all:
+                     kernel_ssm_indices = state_indices_tensor_p.gather(
+                         1, block_idx_last_computed_token_p.unsqueeze(1)
+                     ).squeeze(1)
+@@ -729,14 +729,14 @@ class MambaMixer2(MambaBase, CustomOp):
+                 cu_chunk_seqlens=cu_chunk_seqlen_p,
+                 last_chunk_indices=last_chunk_indices_p,
+                 initial_states=initial_states,
+-                return_intermediate_states=prefix_caching_enabled,
++                return_intermediate_states=is_mamba_cache_all,
+                 dt_softplus=True,
+                 dt_limit=(0.0, float("inf")),
+                 out=preallocated_ssm_out_p.view(num_prefill_tokens, -1, self.head_dim),
+                 state_dtype=ssm_state.dtype,
+             )
+ 
+-            if prefix_caching_enabled:
++            if is_mamba_cache_all:
+                 # The chunk_stride is the number of chunks per mamba block
+                 # e.g., if mamba_block_size = 512 and chunk_size = 256,
+                 # then chunk_stride = 2
+@@ -815,7 +815,7 @@ class MambaMixer2(MambaBase, CustomOp):
+ 
+         # Process decode requests
+         if has_decode:
+-            if prefix_caching_enabled:
++            if is_mamba_cache_all:
+                 state_indices_tensor_d_input = state_indices_tensor_d.gather(
+                     1, block_idx_last_computed_token_d.unsqueeze(1)
+                 ).squeeze(1)
+diff --git a/vllm/model_executor/layers/mamba/mamba_utils.py b/vllm/model_executor/layers/mamba/mamba_utils.py
+index 831dab2fb..816f76bfa 100644
+--- a/vllm/model_executor/layers/mamba/mamba_utils.py
++++ b/vllm/model_executor/layers/mamba/mamba_utils.py
+@@ -1,6 +1,10 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ 
++from collections.abc import Callable
++from dataclasses import dataclass
++from typing import TypeAlias
++
+ import torch
+ 
+ from vllm.config.cache import MambaDType
+@@ -223,3 +227,94 @@ class MambaStateShapeCalculator:
+             conv_state_k_shape,
+             recurrent_state_shape,
+         )
++
++
++@dataclass
++class MambaCopySpec:
++    """
++    Data class specifying the memory-copy parameters for Mamba states used for
++    prefix caching in align mode.
++
++    Attributes:
++        start_addr (int): Starting address for the memory copy operation.
++        num_elements (int): Number of elements to copy from the starting address.
++    """
++
++    start_addr: int
++    num_elements: int
++
++
++MambaStateCopyFunc: TypeAlias = Callable[
++    [torch.Tensor, list[int], int, int], MambaCopySpec
++]
++"""
++Type alias for a function that computes a MambaCopySpec for copying state slices.
++Parameters:
++  state: torch.Tensor - the Mamba state tensor (e.g., conv or temporal states).
++  block_ids: list[int] - the list of block indices for the state to copy.
++  cur_block_idx: int - current block index within `block_ids` to copy from.
++  num_accepted_tokens: int - number of accepted tokens used to compute the copy offset.
++      Range: 1 .. 1 + num_speculative_tokens (inclusive).
++"""
++
++
++def get_conv_copy_spec(
++    state: torch.Tensor,
++    block_ids: list[int],
++    cur_block_idx: int,
++    num_accepted_tokens: int,
++) -> MambaCopySpec:
++    """Return a MambaCopySpec for copying a convolutional state slice."""
++    src_block_id = block_ids[cur_block_idx]
++    src_state = state[src_block_id, num_accepted_tokens - 1 :]
++    return MambaCopySpec(
++        start_addr=src_state.data_ptr(), num_elements=src_state.numel()
++    )
++
++
++def get_temporal_copy_spec(
++    state: torch.Tensor,
++    block_ids: list[int],
++    cur_block_idx: int,
++    num_accepted_tokens: int,
++) -> MambaCopySpec:
++    """Return a MambaCopySpec for copying a temporal state slice."""
++    src_block_id = block_ids[cur_block_idx + num_accepted_tokens - 1]
++    src_state = state[src_block_id]
++    return MambaCopySpec(
++        start_addr=src_state.data_ptr(), num_elements=src_state.numel()
++    )
++
++
++get_full_copy_spec = get_temporal_copy_spec
++
++
++class MambaStateCopyFuncCalculator:
++    @classmethod
++    def linear_attention_state_copy_func(cls):
++        return (get_temporal_copy_spec,)
++
++    @classmethod
++    def mamba1_state_copy_func(cls):
++        return (get_conv_copy_spec, get_temporal_copy_spec)
++
++    @classmethod
++    def mamba2_state_copy_func(cls):
++        return get_conv_copy_spec, get_temporal_copy_spec
++
++    @classmethod
++    def short_conv_state_copy_func(cls):
++        return (get_conv_copy_spec,)
++
++    @classmethod
++    def gated_delta_net_state_copy_func(cls):
++        return (get_conv_copy_spec, get_temporal_copy_spec)
++
++    @classmethod
++    def kda_state_copy_func(cls):
++        return (
++            get_conv_copy_spec,
++            get_conv_copy_spec,
++            get_conv_copy_spec,
++            get_temporal_copy_spec,
++        )
 diff --git a/vllm/model_executor/layers/mla.py b/vllm/model_executor/layers/mla.py
 index 65541d2a4..bf0957cd1 100644
 --- a/vllm/model_executor/layers/mla.py
@@ -3543,7 +5147,7 @@ index 1c0c35bf6..9ebdcaa50 100644
          w13_weight = torch.nn.Parameter(
              torch.empty(
 diff --git a/vllm/model_executor/layers/quantization/ipex_quant.py b/vllm/model_executor/layers/quantization/ipex_quant.py
-index 475bd8536..0f548843c 100644
+index 475bd8536..b5b405485 100644
 --- a/vllm/model_executor/layers/quantization/ipex_quant.py
 +++ b/vllm/model_executor/layers/quantization/ipex_quant.py
 @@ -1,20 +1,27 @@
@@ -3576,7 +5180,7 @@ index 475bd8536..0f548843c 100644
      UnquantizedLinearMethod,
  )
  from vllm.model_executor.layers.quantization import (
-@@ -28,9 +35,16 @@ from vllm.model_executor.layers.quantization.fp8 import (
+@@ -28,9 +35,22 @@ from vllm.model_executor.layers.quantization.fp8 import (
      Fp8OnlineMoEMethod,
  )
  from vllm.model_executor.layers.quantization.gptq import GPTQLinearMethod
@@ -3589,12 +5193,18 @@ index 475bd8536..0f548843c 100644
  from vllm.platforms import current_platform
 +from vllm.scalar_type import scalar_types
 +from vllm.transformers_utils.config import get_safetensors_params_metadata
++from vllm.distributed.parallel_state import get_tensor_model_parallel_rank
 +from vllm.utils.collection_utils import is_list_of
 +from vllm.utils.math_utils import round_up
++from custom_esimd_kernels_vllm import (
++      esimd_gemv_fp8_pert,
++      esimd_gemv_fp8_pert_fused2,
++      esimd_gemv_fp8_pert_fused3,
++)
  
  MIN_IPEX_VERSION = "2.6.0"
  
-@@ -50,20 +64,28 @@ class IPEXConfig(QuantizationConfig):
+@@ -50,20 +70,28 @@ class IPEXConfig(QuantizationConfig):
          method: str,
          weight_bits: int,
          group_size: int,
@@ -3625,7 +5235,7 @@ index 475bd8536..0f548843c 100644
  
          if self.weight_bits not in [4]:
              raise ValueError(
-@@ -75,12 +97,24 @@ class IPEXConfig(QuantizationConfig):
+@@ -75,12 +103,24 @@ class IPEXConfig(QuantizationConfig):
              raise ValueError(
                  f"IPEX quantization supports [awq, gptq], but got {self.method}."
              )
@@ -3651,7 +5261,7 @@ index 475bd8536..0f548843c 100644
          )
  
      @classmethod
-@@ -104,6 +138,8 @@ class IPEXConfig(QuantizationConfig):
+@@ -104,6 +144,8 @@ class IPEXConfig(QuantizationConfig):
  
      @classmethod
      def from_config(cls, config: dict[str, Any]) -> "IPEXConfig":
@@ -3660,7 +5270,7 @@ index 475bd8536..0f548843c 100644
          method = cls.get_from_keys(config, ["quant_method"]).lower()
          if method == "awq":
              weight_bits = cls.get_from_keys(config, ["w_bit", "bits"])
-@@ -111,24 +147,44 @@ class IPEXConfig(QuantizationConfig):
+@@ -111,24 +153,44 @@ class IPEXConfig(QuantizationConfig):
              modules_to_not_convert = cls.get_from_keys_or(
                  config, ["modules_to_not_convert"], None
              )
@@ -3709,7 +5319,7 @@ index 475bd8536..0f548843c 100644
          )
  
      @classmethod
-@@ -145,9 +201,7 @@ class IPEXConfig(QuantizationConfig):
+@@ -145,9 +207,7 @@ class IPEXConfig(QuantizationConfig):
  
          return None
  
@@ -3720,7 +5330,7 @@ index 475bd8536..0f548843c 100644
          if isinstance(layer, LinearBase):
              if self.method == "awq":
                  if is_layer_skipped(
-@@ -159,9 +213,41 @@ class IPEXConfig(QuantizationConfig):
+@@ -159,9 +219,41 @@ class IPEXConfig(QuantizationConfig):
                      return UnquantizedLinearMethod()
                  return IPEXAWQLinearMethod(self)
              if self.method == "gptq":
@@ -3763,7 +5373,7 @@ index 475bd8536..0f548843c 100644
  
  class IPEXGPTQLinearMethod(GPTQLinearMethod):
      """GPTQ linear method using IPEX for the CPU/XPU backend."""
-@@ -217,7 +303,7 @@ class IPEXGPTQLinearMethod(GPTQLinearMethod):
+@@ -217,7 +309,7 @@ class IPEXGPTQLinearMethod(GPTQLinearMethod):
                  bias=bias,
                  group_size=self.quant_config.group_size,
                  quant_method=IPEXConfig.IPEX_QUANT_METHOD_MAP["gptq"],
@@ -3772,7 +5382,7 @@ index 475bd8536..0f548843c 100644
              )
          )
  
-@@ -288,7 +374,7 @@ class IPEXAWQLinearMethod(AWQLinearMethod):
+@@ -288,7 +380,7 @@ class IPEXAWQLinearMethod(AWQLinearMethod):
                  bias=bias,
                  group_size=self.quant_config.group_size,
                  quant_method=IPEXConfig.IPEX_QUANT_METHOD_MAP["awq"],  # type: ignore
@@ -3781,19 +5391,24 @@ index 475bd8536..0f548843c 100644
              )
          )
  
-@@ -317,6 +403,8 @@ class XPUFp8LinearMethod(Fp8LinearMethod):
+@@ -317,6 +409,9 @@ class XPUFp8LinearMethod(Fp8LinearMethod):
              replace_parameter(layer, "weight", qweight.data)
              replace_parameter(layer, "weight_scale", weight_scale.data)
              layer.input_scale = None
++            # print(f"[FP8 QUANT] weight={layer.weight.shape} scale={layer.weight_scale.shape} dtype={layer.weight_scale.dtype}")
 +        elif self.block_quant:
 +            super().process_weights_after_loading(layer)
  
      def apply(
          self,
-@@ -324,8 +412,21 @@ class XPUFp8LinearMethod(Fp8LinearMethod):
+@@ -324,12 +419,62 @@ class XPUFp8LinearMethod(Fp8LinearMethod):
          x: torch.Tensor,
          bias: torch.Tensor | None = None,
      ) -> torch.Tensor:
++        # _debug = (x.shape[0] == 1
++        #           and get_tensor_model_parallel_rank() == 0)
++        # if _debug:
++        #     print("================================================Begin ============================================")
 +        if self.block_quant:
 +            return self.w8a8_block_fp8_linear.apply(
 +            input=x,
@@ -3805,14 +5420,55 @@ index 475bd8536..0f548843c 100644
 +        
          weight = layer.weight.data
          weight_scale = layer.weight_scale.data
+-        output = torch.ops.torch_ipex.fp8_gemm_w8a16(
+-            x, weight, True, weight_scale, bias
+-        )
+-        return output
 +        # In case of pooler models, pooled_data may change to head_dtype like float
 +        # which fp8_gemm_w8a16 doesn't support
 +        if x.dtype == torch.float:
 +            x = x.to(torch.bfloat16)
-         output = torch.ops.torch_ipex.fp8_gemm_w8a16(
-             x, weight, True, weight_scale, bias
-         )
-@@ -337,13 +438,76 @@ class XPUFp8MoEMethod(Fp8OnlineMoEMethod):
++        # out = torch.empty((x.shape[0], weight.shape[0]), dtype=torch.float16, device=x.device)
++        # esimd_gemv_fp8_pert(x, weight, weight_scale
++        #                         , out)
++
++        # if _debug:
++        #     print(x.shape)
++        # if False:
++        if x.shape[0] == 1:
++            # print("Invoke here...........#############################################")
++            out = torch.empty((x.shape[0], weight.shape[0]), dtype=torch.float16, device=x.device)
++            esimd_gemv_fp8_pert(x, weight, weight_scale
++                                , out)
++            return out
++        else:
++            output = torch.ops._xpu_C.fp8_gemm_w8a16(
++                x, weight.t(), weight_scale, bias
++            )
++            return output
++            # if _debug:
++            #     print("[for debug only] output shape after fp8_gemm_w8a16:", output.shape)
++        
++        # assert out.shape == output.shape, f"Output shape mismatch between esimd_gemv_fp8_pert and fp8_gemm_w8a16: {out.shape} vs {output.shape}"
++        # if x.shape[0] == 1:
++        #     has_nan = torch.isnan(out).any().item()
++        #     assert not has_nan, f"NaN detected in esimd_gemv_fp8_pert output! shape={out.shape}"
++
++        #     max_diff = (out.float() - output.float()).abs().max().item()
++        #     ref_max = output.float().abs().max().item()
++        #     rel_err = (max_diff / ref_max) if ref_max > 1e-6 else 0
++        #     ok = max_diff < 0.5 or rel_err < 0.05
++        #     status = "PASS" if ok else "FAIL"
++        #     # print(f"[{status}] max_diff={max_diff:.4f}, rel_err={rel_err:.4f}, ref_max={ref_max:.4f}")
++        #     assert ok, f"Output mismatch between esimd_gemv_fp8_pert and fp8_gemm_w8a16: max_diff={max_diff:.4f}, rel_err={rel_err:.4f}, ref_max={ref_max:.4f}"
++        # if x.shape[0] == 1:
++        #     return out
++        # else:
++        #     return output
+ 
+ 
+ class XPUFp8MoEMethod(Fp8OnlineMoEMethod):
+@@ -337,13 +482,76 @@ class XPUFp8MoEMethod(Fp8OnlineMoEMethod):
          super().__init__(quant_config, layer)
          self.quant_config = quant_config
  
@@ -3891,7 +5547,7 @@ index 475bd8536..0f548843c 100644
  
              # Re-initialize w13_scale because we directly quantize
              # merged w13 weights and generate a single scaling factor.
-@@ -364,6 +528,8 @@ class XPUFp8MoEMethod(Fp8OnlineMoEMethod):
+@@ -364,6 +572,8 @@ class XPUFp8MoEMethod(Fp8OnlineMoEMethod):
                  )
              replace_parameter(layer, "w13_weight", w13_weight)
              replace_parameter(layer, "w2_weight", w2_weight)
@@ -3900,7 +5556,7 @@ index 475bd8536..0f548843c 100644
  
          import intel_extension_for_pytorch as ipex
  
-@@ -401,3 +567,211 @@ class XPUFp8MoEMethod(Fp8OnlineMoEMethod):
+@@ -401,3 +611,211 @@ class XPUFp8MoEMethod(Fp8OnlineMoEMethod):
              layer.num_expert_group,
              custom_routing_function=layer.custom_routing_function,
          )
@@ -4114,13 +5770,14 @@ index 475bd8536..0f548843c 100644
 +        return res
 diff --git a/vllm/model_executor/layers/quantization/sym_int4.py b/vllm/model_executor/layers/quantization/sym_int4.py
 new file mode 100644
-index 000000000..f2686cf7f
+index 000000000..ef3fcaffc
 --- /dev/null
 +++ b/vllm/model_executor/layers/quantization/sym_int4.py
-@@ -0,0 +1,419 @@
+@@ -0,0 +1,420 @@
 +# SPDX-License-Identifier: Apache-2.0
 +
 +from typing import Any, Dict, List, Optional, Tuple, Callable, Union
++from concurrent.futures import ThreadPoolExecutor
 +from vllm.model_executor.layers.quantization.base_config import (
 +    QuantizationConfig, QuantizeMethodBase)
 +from vllm.model_executor.layers.linear import (LinearBase, LinearMethodBase,
@@ -4184,9 +5841,17 @@ index 000000000..f2686cf7f
 +                         out_scale: torch.Tensor,
 +                         out_features: int,
 +                         in_features: int,
-+                         block_size: int = QK4_GROUP_SIZE):
++                         block_size: int = QK4_GROUP_SIZE,
++                         transpose: bool = True):
 +    """
 +    Shared implementation for quantizing a tensor using the C library.
++
++    Args:
++        transpose: If True (default), transpose the output tensors. The C code
++            fills row-wise [out_features, ...], and some callers (Linear) need
++            the transposed layout. MoE callers that want the original
++            [out_features, ...] layout should pass transpose=False to avoid a
++            redundant transpose-then-transpose-back.
 +    """
 +    # Assertions
 +    assert weight.dim() == 2
@@ -4211,13 +5876,12 @@ index 000000000..f2686cf7f
 +    # Call C function with the new block_size parameter
 +    clib.quantize_q4_0_to_qweight_and_scale(src, qweight, scale, out_features, in_features, block_size)
 +
-+    # Transpose logic (as per original implementation requirement)
-+    # The C code fills row-wise, but IPEX/PyTorch logic here seems to want column-major 
-+    # or specific layout for the final parameter, so we transpose results.
-+    out_qweight_ret = out_qweight.transpose(0, 1).contiguous()
-+    out_scale_ret = out_scale.transpose(0, 1).contiguous()
++    if transpose:
++        # Transpose for callers that need column-major layout (e.g. Linear)
++        out_qweight = out_qweight.transpose(0, 1).contiguous()
++        out_scale = out_scale.transpose(0, 1).contiguous()
 +
-+    return out_qweight_ret, out_scale_ret
++    return out_qweight, out_scale
 +
 +# ==============================================================================
 +#  Classes
@@ -4460,43 +6124,36 @@ index 000000000..f2686cf7f
 +        w13_scales  = torch.empty(E, 2 * d_ff, d_model // QK4_GROUP_SIZE, dtype=torch.float16, device="cpu")
 +        w2_scales   = torch.empty(E, d_model,    d_ff // QK4_GROUP_SIZE, dtype=torch.float16, device="cpu")
 +
-+        # Quantize per expert
++        # Quantize per expert (parallelized across experts)
 +        num_loop = getattr(layer, "local_num_experts", E)
 +
-+        for e in range(num_loop):
++        def _quantize_expert(e):
 +            # Ensure fp32 contiguous
-+            w13_e = layer.w13_weight[e].float().contiguous().to("cpu")  # [2*d_ff, d_model]
-+            w2_e  = layer.w2_weight[e].float().contiguous().to("cpu")   # [d_model, d_ff]
++            w13_e = layer.w13_weight[e].float().contiguous().to("cpu")
++            w2_e  = layer.w2_weight[e].float().contiguous().to("cpu")
 +
-+            # --- w13 ---
-+            q13_buf = torch.zeros((2 * d_ff, d_model // QK4_PACK_FACTOR),  dtype=torch.int32,  device="cpu")
++            # --- w13 --- (transpose=False: C output is already [out, in//8])
++            q13_buf = torch.zeros((2 * d_ff, d_model // QK4_PACK_FACTOR), dtype=torch.int32, device="cpu")
 +            s13_buf = torch.zeros((2 * d_ff, d_model // QK4_GROUP_SIZE), dtype=torch.float16, device="cpu")
-+
-+            # Use extracted function, pass QK4_GROUP_SIZE
-+            q13_inT, s13_inT = ggml_quantize_tensor(
-+                w13_e, q13_buf, s13_buf, 2 * d_ff, d_model, block_size=QK4_GROUP_SIZE
++            q13, s13 = ggml_quantize_tensor(
++                w13_e, q13_buf, s13_buf, 2 * d_ff, d_model,
++                block_size=QK4_GROUP_SIZE, transpose=False,
 +            )
-+
-+            q13 = q13_inT.transpose(0, 1).contiguous()  # [2*d_ff, d_model//8]
-+            s13 = s13_inT.transpose(0, 1).contiguous()  # [2*d_ff, d_model//64]
-+
 +            w13_qweight[e].copy_(q13)
 +            w13_scales[e].copy_(s13)
 +
 +            # --- w2 ---
-+            q2_buf = torch.zeros((d_model, d_ff // QK4_PACK_FACTOR),  dtype=torch.int32,  device="cpu")
++            q2_buf = torch.zeros((d_model, d_ff // QK4_PACK_FACTOR), dtype=torch.int32, device="cpu")
 +            s2_buf = torch.zeros((d_model, d_ff // QK4_GROUP_SIZE), dtype=torch.float16, device="cpu")
-+
-+            q2_inT, s2_inT = ggml_quantize_tensor(
-+                w2_e, q2_buf, s2_buf, d_model, d_ff, block_size=QK4_GROUP_SIZE
++            q2, s2 = ggml_quantize_tensor(
++                w2_e, q2_buf, s2_buf, d_model, d_ff,
++                block_size=QK4_GROUP_SIZE, transpose=False,
 +            )
-+
-+            q2 = q2_inT.transpose(0, 1).contiguous()  # [d_model, d_ff//8]
-+            s2 = s2_inT.transpose(0, 1).contiguous()  # [d_model, d_ff//64]
-+
-+
 +            w2_qweight[e].copy_(q2)
 +            w2_scales[e].copy_(s2)
++
++        with ThreadPoolExecutor() as executor:
++            list(executor.map(_quantize_expert, range(num_loop)))
 +
 +        # Move to XPU
 +        w13_qweight = w13_qweight.to("xpu")
@@ -4770,11 +6427,117 @@ index 08d7a851a..9c165d870 100644
  
  
  _MODEL_ARCH_BY_HASH = dict[int, tuple[type[nn.Module], str]]()
+diff --git a/vllm/model_executor/models/bamba.py b/vllm/model_executor/models/bamba.py
+index 22631bbc5..a7de8e7cf 100644
+--- a/vllm/model_executor/models/bamba.py
++++ b/vllm/model_executor/models/bamba.py
+@@ -24,6 +24,8 @@ from vllm.model_executor.layers.linear import (
+ from vllm.model_executor.layers.logits_processor import LogitsProcessor
+ from vllm.model_executor.layers.mamba.mamba_mixer2 import MambaMixer2
+ from vllm.model_executor.layers.mamba.mamba_utils import (
++    MambaStateCopyFunc,
++    MambaStateCopyFuncCalculator,
+     MambaStateDtypeCalculator,
+     MambaStateShapeCalculator,
+ )
+@@ -455,6 +457,10 @@ class BambaForCausalLM(
+             conv_kernel=hf_config.mamba_d_conv,
+         )
+ 
++    @classmethod
++    def get_mamba_state_copy_func(cls) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:
++        return MambaStateCopyFuncCalculator.mamba2_state_copy_func()
++
+     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+         config = vllm_config.model_config.hf_config
+         self.vllm_config = vllm_config
 diff --git a/vllm/model_executor/models/config.py b/vllm/model_executor/models/config.py
-index e51a110ce..58ab0dca5 100644
+index e51a110ce..d585c9b9f 100644
 --- a/vllm/model_executor/models/config.py
 +++ b/vllm/model_executor/models/config.py
-@@ -410,6 +410,9 @@ class HybridAttentionMambaModelConfig(VerifyAndUpdateConfig):
+@@ -330,26 +330,54 @@ class MambaModelConfig(VerifyAndUpdateConfig):
+         cache_config = vllm_config.cache_config
+ 
+         if cache_config.enable_prefix_caching:
+-            if model_config.supports_mamba_prefix_caching:
+-                logger.info(
+-                    "Warning: Prefix caching is currently enabled. "
+-                    "Its support for Mamba layers is experimental. "
+-                    "Please report any issues you may observe."
++            if cache_config.mamba_cache_mode == "none":
++                cache_config.mamba_cache_mode = (
++                    "all" if model_config.supports_mamba_prefix_caching else "align"
+                 )
+-                # By default, mamba block size will be set to max_model_len (see
+-                # below). When enabling prefix caching, we align mamba block size
+-                # to the block size as the basic granularity for prefix caching.
+-                if cache_config.mamba_block_size is None:
+-                    cache_config.mamba_block_size = cache_config.block_size
+-            else:
+-                logger.info(
+-                    "Hybrid or mamba-based model detected without "
+-                    "support for prefix caching: disabling."
++                logger.warning(
++                    "Mamba cache mode is set to '%s' for %s by default "
++                    "when prefix caching is enabled",
++                    cache_config.mamba_cache_mode,
++                    model_config.architecture,
+                 )
+-                cache_config.enable_prefix_caching = False
+-
+-        if cache_config.mamba_block_size is None:
+-            cache_config.mamba_block_size = model_config.max_model_len
++            if (
++                cache_config.mamba_cache_mode == "all"
++                and not model_config.supports_mamba_prefix_caching
++            ):
++                cache_config.mamba_cache_mode = "align"
++                logger.warning(
++                    "Hybrid or mamba-based model detected without support "
++                    "for prefix caching with Mamba cache 'all' mode: "
++                    "falling back to 'align' mode."
++                )
++            if cache_config.mamba_cache_mode == "align":
++                assert vllm_config.scheduler_config.enable_chunked_prefill, (
++                    "Chunked prefill is required for mamba cache mode 'align'."
++                )
++                assert not vllm_config.speculative_config, (
++                    "Mamba cache mode 'align' is currently not compatible "
++                    "with speculative decoding."
++                )
++            logger.info(
++                "Warning: Prefix caching in Mamba cache '%s' "
++                "mode is currently enabled. "
++                "Its support for Mamba layers is experimental. "
++                "Please report any issues you may observe.",
++                cache_config.mamba_cache_mode,
++            )
++            # By default, mamba block size will be set to max_model_len (see
++            # below). When enabling prefix caching, we align mamba block size
++            # to the block size as the basic granularity for prefix caching.
++            if cache_config.mamba_block_size is None:
++                cache_config.mamba_block_size = cache_config.block_size
++        else:
++            if cache_config.mamba_cache_mode != "none":
++                cache_config.mamba_cache_mode = "none"
++                logger.warning(
++                    "Mamba cache mode is set to 'none' when prefix caching is disabled"
++                )
++            if cache_config.mamba_block_size is None:
++                cache_config.mamba_block_size = model_config.max_model_len
+ 
+ 
+ class HybridAttentionMambaModelConfig(VerifyAndUpdateConfig):
+@@ -398,7 +426,7 @@ class HybridAttentionMambaModelConfig(VerifyAndUpdateConfig):
+                 dtype=kv_cache_dtype,
+             ).page_size_bytes
+         else:
+-            kernel_block_alignment_size = 16
++            kernel_block_alignment_size = 64 if current_platform.is_xpu() else 16
+             if (
+                 current_platform.is_device_capability_family(100)
+                 and model_config.get_head_size() == 256
+@@ -410,6 +438,9 @@ class HybridAttentionMambaModelConfig(VerifyAndUpdateConfig):
                  # https://github.com/flashinfer-ai/flashinfer/issues/1993 reports that`
                  # head size 256 and block size 16 is not supported on blackwell.
                  kernel_block_alignment_size = 32
@@ -4784,6 +6547,49 @@ index e51a110ce..58ab0dca5 100644
              attn_page_size_1_token = FullAttentionSpec(
                  block_size=1,
                  num_kv_heads=model_config.get_num_kv_heads(parallel_config),
+@@ -426,7 +457,7 @@ class HybridAttentionMambaModelConfig(VerifyAndUpdateConfig):
+         mamba_page_size = MambaSpec(
+             shapes=model_cls.get_mamba_state_shape_from_config(vllm_config),
+             dtypes=model_cls.get_mamba_state_dtype_from_config(vllm_config),
+-            block_size=model_config.max_model_len,
++            block_size=-1,  # block_size doesn't matter for mamba page size
+         ).page_size_bytes
+ 
+         # Model may be marked as is_hybrid
+@@ -435,7 +466,7 @@ class HybridAttentionMambaModelConfig(VerifyAndUpdateConfig):
+         if mamba_page_size == 0:
+             return
+ 
+-        if cache_config.enable_prefix_caching:
++        if cache_config.mamba_cache_mode == "all":
+             # With prefix caching, select attention block size to
+             # optimize for mamba kernel performance
+ 
+@@ -468,6 +499,10 @@ class HybridAttentionMambaModelConfig(VerifyAndUpdateConfig):
+                 mamba_page_size, kernel_block_alignment_size * attn_page_size_1_token
+             )
+ 
++        # Round up attn_block_size to the next power of 2 if needed
++        if attn_block_size & (attn_block_size - 1) != 0:
++            attn_block_size = 1 << attn_block_size.bit_length()
++
+         # override attention block size if either (a) the
+         # user has not set it or (b) the user has set it
+         # too small.
+@@ -479,6 +514,13 @@ class HybridAttentionMambaModelConfig(VerifyAndUpdateConfig):
+                 attn_block_size,
+             )
+ 
++        # By default, mamba block size will be set to max_model_len.
++        # When enabling prefix caching and using align mamba cache
++        # mode, we align mamba block size to the block size as the
++        # basic granularity for prefix caching.
++        if cache_config.mamba_cache_mode == "align":
++            cache_config.mamba_block_size = cache_config.block_size
++
+         # compute new attention page size
+         attn_page_size = cache_config.block_size * attn_page_size_1_token
+ 
 diff --git a/vllm/model_executor/models/deepencoder.py b/vllm/model_executor/models/deepencoder.py
 index b3e5d920e..3fa2aa29a 100644
 --- a/vllm/model_executor/models/deepencoder.py
@@ -5659,6 +7465,30 @@ index 75be587ee..19a55225c 100644
  
              final_hidden_states = self.text_experts(
                  hidden_states=hidden_states, router_logits=text_router_logits
+diff --git a/vllm/model_executor/models/falcon_h1.py b/vllm/model_executor/models/falcon_h1.py
+index bfb6b1a1f..49722b6d7 100644
+--- a/vllm/model_executor/models/falcon_h1.py
++++ b/vllm/model_executor/models/falcon_h1.py
+@@ -24,6 +24,8 @@ from vllm.model_executor.layers.linear import (
+ from vllm.model_executor.layers.logits_processor import LogitsProcessor
+ from vllm.model_executor.layers.mamba.mamba_mixer2 import MambaMixer2
+ from vllm.model_executor.layers.mamba.mamba_utils import (
++    MambaStateCopyFunc,
++    MambaStateCopyFuncCalculator,
+     MambaStateDtypeCalculator,
+     MambaStateShapeCalculator,
+ )
+@@ -551,6 +553,10 @@ class FalconH1ForCausalLM(
+             conv_kernel=hf_config.mamba_d_conv,
+         )
+ 
++    @classmethod
++    def get_mamba_state_copy_func(cls) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:
++        return MambaStateCopyFuncCalculator.mamba2_state_copy_func()
++
+     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+         config = vllm_config.model_config.hf_config
+         self.vllm_config = vllm_config
 diff --git a/vllm/model_executor/models/glm4.py b/vllm/model_executor/models/glm4.py
 index 06da2a8b3..c714cf6c7 100644
 --- a/vllm/model_executor/models/glm4.py
@@ -6870,6 +8700,30 @@ index 297237fd1..fa4f1278e 100644
          )
          self.output_dropout = torch.nn.Dropout(config.dropout_prob)
  
+diff --git a/vllm/model_executor/models/granitemoehybrid.py b/vllm/model_executor/models/granitemoehybrid.py
+index 3434716b8..0b601b4b8 100644
+--- a/vllm/model_executor/models/granitemoehybrid.py
++++ b/vllm/model_executor/models/granitemoehybrid.py
+@@ -19,6 +19,8 @@ from vllm.model_executor.layers.linear import QKVParallelLinear, RowParallelLine
+ from vllm.model_executor.layers.logits_processor import LogitsProcessor
+ from vllm.model_executor.layers.mamba.mamba_mixer2 import MambaMixer2
+ from vllm.model_executor.layers.mamba.mamba_utils import (
++    MambaStateCopyFunc,
++    MambaStateCopyFuncCalculator,
+     MambaStateDtypeCalculator,
+     MambaStateShapeCalculator,
+ )
+@@ -641,6 +643,10 @@ class GraniteMoeHybridForCausalLM(
+             conv_kernel=hf_config.mamba_d_conv,
+         )
+ 
++    @classmethod
++    def get_mamba_state_copy_func(cls) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:
++        return MambaStateCopyFuncCalculator.mamba2_state_copy_func()
++
+     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+         super().__init__()
+ 
 diff --git a/vllm/model_executor/models/idefics2_vision_model.py b/vllm/model_executor/models/idefics2_vision_model.py
 index c78ad6479..ce1bddd27 100644
 --- a/vllm/model_executor/models/idefics2_vision_model.py
@@ -6915,10 +8769,38 @@ index c78ad6479..ce1bddd27 100644
          return attn_output
  
 diff --git a/vllm/model_executor/models/interfaces.py b/vllm/model_executor/models/interfaces.py
-index a8a476abb..0770c87be 100644
+index a8a476abb..b346c2148 100644
 --- a/vllm/model_executor/models/interfaces.py
 +++ b/vllm/model_executor/models/interfaces.py
-@@ -953,6 +953,22 @@ class SupportsTranscription(Protocol):
+@@ -23,6 +23,7 @@ from vllm.config import ModelConfig, SpeechToTextConfig
+ from vllm.inputs import TokensPrompt
+ from vllm.inputs.data import PromptType
+ from vllm.logger import init_logger
++from vllm.model_executor.layers.mamba.mamba_utils import MambaStateCopyFunc
+ from vllm.model_executor.layers.quantization import QuantizationConfig
+ from vllm.utils.func_utils import supports_kw
+ 
+@@ -636,6 +637,19 @@ class IsHybrid(Protocol):
+         """
+         ...
+ 
++    @classmethod
++    def get_mamba_state_copy_func(cls) -> tuple[MambaStateCopyFunc, ...]:
++        """Calculate copy-function callables for each Mamba state.
++
++        Returns:
++            A tuple of MambaStateCopyFunc callables that correspond, in order,
++            to the Mamba states produced by the model. Each callable accepts
++            (state, block_ids, cur_block_idx, num_accepted_tokens) and returns
++            a MambaCopySpec describing the memory-copy parameters for prefix
++            caching in align mode.
++        """
++        ...
++
+ 
+ @overload
+ def is_hybrid(model: object) -> TypeIs[IsHybrid]: ...
+@@ -953,6 +967,22 @@ class SupportsTranscription(Protocol):
          """
          return None
  
@@ -6986,6 +8868,167 @@ index 048bc49ea..06788045f 100644
              text_config = config.text_config
              llm_quant_config = getattr(text_config, "quantization_config", None)
              if (not quant_config.modules_to_not_convert) and (
+diff --git a/vllm/model_executor/models/jamba.py b/vllm/model_executor/models/jamba.py
+index 91b58a83e..eeca3cf78 100644
+--- a/vllm/model_executor/models/jamba.py
++++ b/vllm/model_executor/models/jamba.py
+@@ -24,6 +24,8 @@ from vllm.model_executor.layers.linear import (
+ from vllm.model_executor.layers.logits_processor import LogitsProcessor
+ from vllm.model_executor.layers.mamba.mamba_mixer import MambaMixer
+ from vllm.model_executor.layers.mamba.mamba_utils import (
++    MambaStateCopyFunc,
++    MambaStateCopyFuncCalculator,
+     MambaStateDtypeCalculator,
+     MambaStateShapeCalculator,
+ )
+@@ -558,6 +560,10 @@ class JambaForCausalLM(
+             conv_kernel=hf_config.mamba_d_conv,
+         )
+ 
++    @classmethod
++    def get_mamba_state_copy_func(cls) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:
++        return MambaStateCopyFuncCalculator.mamba1_state_copy_func()
++
+     def compute_logits(
+         self,
+         hidden_states: torch.Tensor,
+diff --git a/vllm/model_executor/models/kimi_linear.py b/vllm/model_executor/models/kimi_linear.py
+index d149c3642..f3ec5b759 100644
+--- a/vllm/model_executor/models/kimi_linear.py
++++ b/vllm/model_executor/models/kimi_linear.py
+@@ -26,6 +26,8 @@ from vllm.model_executor.layers.linear import (
+ )
+ from vllm.model_executor.layers.logits_processor import LogitsProcessor
+ from vllm.model_executor.layers.mamba.mamba_utils import (
++    MambaStateCopyFunc,
++    MambaStateCopyFuncCalculator,
+     MambaStateDtypeCalculator,
+     MambaStateShapeCalculator,
+ )
+@@ -544,6 +546,14 @@ class KimiLinearForCausalLM(
+             num_spec=num_spec,
+         )
+ 
++    @classmethod
++    def get_mamba_state_copy_func(
++        cls,
++    ) -> tuple[
++        MambaStateCopyFunc, MambaStateCopyFunc, MambaStateCopyFunc, MambaStateCopyFunc
++    ]:
++        return MambaStateCopyFuncCalculator.kda_state_copy_func()
++
+     def compute_logits(
+         self,
+         hidden_states: torch.Tensor,
+diff --git a/vllm/model_executor/models/lfm2.py b/vllm/model_executor/models/lfm2.py
+index 142ad3d6d..b4d5ae415 100644
+--- a/vllm/model_executor/models/lfm2.py
++++ b/vllm/model_executor/models/lfm2.py
+@@ -20,6 +20,8 @@ from vllm.model_executor.layers.linear import (
+ )
+ from vllm.model_executor.layers.logits_processor import LogitsProcessor
+ from vllm.model_executor.layers.mamba.mamba_utils import (
++    MambaStateCopyFunc,
++    MambaStateCopyFuncCalculator,
+     MambaStateDtypeCalculator,
+     MambaStateShapeCalculator,
+ )
+@@ -455,14 +457,19 @@ class Lfm2ForCausalLM(
+             conv_kernel=hf_config.conv_L_cache,
+         )
+ 
++    @classmethod
++    def get_mamba_state_copy_func(cls) -> tuple[MambaStateCopyFunc]:
++        return MambaStateCopyFuncCalculator.short_conv_state_copy_func()
++
+     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+         config = vllm_config.model_config.hf_config
+         quant_config = vllm_config.quant_config
+         cache_config = vllm_config.cache_config
+-
+-        assert not cache_config.enable_prefix_caching, (
+-            "Lfm2 currently does not support prefix caching"
+-        )
++        if cache_config.mamba_cache_mode == "all":
++            raise NotImplementedError(
++                "Lfm2 currently does not support 'all' prefix caching, "
++                "please use '--mamba-cache-mode=align' instead"
++            )
+ 
+         super().__init__()
+         self.config = config
+diff --git a/vllm/model_executor/models/lfm2_moe.py b/vllm/model_executor/models/lfm2_moe.py
+index 6677eb9f9..fbac52acf 100644
+--- a/vllm/model_executor/models/lfm2_moe.py
++++ b/vllm/model_executor/models/lfm2_moe.py
+@@ -25,6 +25,8 @@ from vllm.model_executor.layers.linear import (
+ )
+ from vllm.model_executor.layers.logits_processor import LogitsProcessor
+ from vllm.model_executor.layers.mamba.mamba_utils import (
++    MambaStateCopyFunc,
++    MambaStateCopyFuncCalculator,
+     MambaStateDtypeCalculator,
+     MambaStateShapeCalculator,
+ )
+@@ -636,6 +638,10 @@ class Lfm2MoeForCausalLM(
+             conv_kernel=hf_config.conv_L_cache,
+         )
+ 
++    @classmethod
++    def get_mamba_state_copy_func(cls) -> tuple[MambaStateCopyFunc]:
++        return MambaStateCopyFuncCalculator.short_conv_state_copy_func()
++
+     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+         config = vllm_config.model_config.hf_config
+         quant_config = vllm_config.quant_config
+diff --git a/vllm/model_executor/models/mamba.py b/vllm/model_executor/models/mamba.py
+index aa16640a9..85212feca 100644
+--- a/vllm/model_executor/models/mamba.py
++++ b/vllm/model_executor/models/mamba.py
+@@ -16,6 +16,8 @@ from vllm.model_executor.layers.layernorm import RMSNorm
+ from vllm.model_executor.layers.logits_processor import LogitsProcessor
+ from vllm.model_executor.layers.mamba.mamba_mixer import MambaMixer
+ from vllm.model_executor.layers.mamba.mamba_utils import (
++    MambaStateCopyFunc,
++    MambaStateCopyFuncCalculator,
+     MambaStateDtypeCalculator,
+     MambaStateShapeCalculator,
+ )
+@@ -261,6 +263,10 @@ class MambaForCausalLM(
+             conv_kernel=hf_config.conv_kernel,
+         )
+ 
++    @classmethod
++    def get_mamba_state_copy_func(cls) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:
++        return MambaStateCopyFuncCalculator.mamba1_state_copy_func()
++
+     def copy_inputs_before_cuda_graphs(self, input_buffers, **kwargs):
+         return self.mamba_cache.copy_inputs_before_cuda_graphs(input_buffers, **kwargs)
+ 
+diff --git a/vllm/model_executor/models/mamba2.py b/vllm/model_executor/models/mamba2.py
+index 5fcfa9431..ed363df21 100644
+--- a/vllm/model_executor/models/mamba2.py
++++ b/vllm/model_executor/models/mamba2.py
+@@ -15,6 +15,8 @@ from vllm.model_executor.layers.layernorm import RMSNorm
+ from vllm.model_executor.layers.logits_processor import LogitsProcessor
+ from vllm.model_executor.layers.mamba.mamba_mixer2 import MambaMixer2
+ from vllm.model_executor.layers.mamba.mamba_utils import (
++    MambaStateCopyFunc,
++    MambaStateCopyFuncCalculator,
+     MambaStateDtypeCalculator,
+     MambaStateShapeCalculator,
+ )
+@@ -228,6 +230,10 @@ class Mamba2ForCausalLM(
+             conv_kernel=hf_config.conv_kernel,
+         )
+ 
++    @classmethod
++    def get_mamba_state_copy_func(cls) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:
++        return MambaStateCopyFuncCalculator.mamba2_state_copy_func()
++
+     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+         config = vllm_config.model_config.hf_config
+ 
 diff --git a/vllm/model_executor/models/minicpmv.py b/vllm/model_executor/models/minicpmv.py
 index 930ff737b..5cbcc0300 100644
 --- a/vllm/model_executor/models/minicpmv.py
@@ -7082,6 +9125,63 @@ index 930ff737b..5cbcc0300 100644
  
  
  _SUPPORT_VERSION = {
+diff --git a/vllm/model_executor/models/minimax_text_01.py b/vllm/model_executor/models/minimax_text_01.py
+index 955a73ff1..44417c98b 100644
+--- a/vllm/model_executor/models/minimax_text_01.py
++++ b/vllm/model_executor/models/minimax_text_01.py
+@@ -35,6 +35,8 @@ from vllm.model_executor.layers.linear import (
+ from vllm.model_executor.layers.logits_processor import LogitsProcessor
+ from vllm.model_executor.layers.mamba.linear_attn import MiniMaxText01LinearAttention
+ from vllm.model_executor.layers.mamba.mamba_utils import (
++    MambaStateCopyFunc,
++    MambaStateCopyFuncCalculator,
+     MambaStateDtypeCalculator,
+     MambaStateShapeCalculator,
+ )
+@@ -1006,3 +1008,7 @@ class MiniMaxText01ForCausalLM(nn.Module, HasInnerState, IsHybrid):
+             tp_size=parallel_config.tensor_parallel_size,
+             head_dim=hf_config.head_dim,
+         )
++
++    @classmethod
++    def get_mamba_state_copy_func(cls) -> tuple[MambaStateCopyFunc]:
++        return MambaStateCopyFuncCalculator.linear_attention_state_copy_func()
+diff --git a/vllm/model_executor/models/nano_nemotron_vl.py b/vllm/model_executor/models/nano_nemotron_vl.py
+index a88496eca..161f4bb4d 100644
+--- a/vllm/model_executor/models/nano_nemotron_vl.py
++++ b/vllm/model_executor/models/nano_nemotron_vl.py
+@@ -1723,3 +1723,7 @@ class NemotronH_Nano_VL_V2(
+         temp_vllm_config = copy.deepcopy(vllm_config)
+         temp_vllm_config.model_config.hf_config = text_config
+         return NemotronHForCausalLM.get_mamba_state_dtype_from_config(temp_vllm_config)
++
++    @classmethod
++    def get_mamba_state_copy_func(cls):
++        return NemotronHForCausalLM.get_mamba_state_copy_func()
+diff --git a/vllm/model_executor/models/nemotron_h.py b/vllm/model_executor/models/nemotron_h.py
+index aff1d5fd4..679d21b1e 100644
+--- a/vllm/model_executor/models/nemotron_h.py
++++ b/vllm/model_executor/models/nemotron_h.py
+@@ -45,6 +45,8 @@ from vllm.model_executor.layers.linear import (
+ from vllm.model_executor.layers.logits_processor import LogitsProcessor
+ from vllm.model_executor.layers.mamba.mamba_mixer2 import MambaMixer2
+ from vllm.model_executor.layers.mamba.mamba_utils import (
++    MambaStateCopyFunc,
++    MambaStateCopyFuncCalculator,
+     MambaStateDtypeCalculator,
+     MambaStateShapeCalculator,
+ )
+@@ -806,6 +808,10 @@ class NemotronHForCausalLM(
+             conv_kernel=hf_config.conv_kernel,
+         )
+ 
++    @classmethod
++    def get_mamba_state_copy_func(cls) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:
++        return MambaStateCopyFuncCalculator.mamba2_state_copy_func()
++
+     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+         config = vllm_config.model_config.hf_config
+         self.vllm_config = vllm_config
 diff --git a/vllm/model_executor/models/phi4mm_audio.py b/vllm/model_executor/models/phi4mm_audio.py
 index 493fdb465..bedd6812e 100644
 --- a/vllm/model_executor/models/phi4mm_audio.py
@@ -7112,6 +9212,30 @@ index 493fdb465..bedd6812e 100644
              if masks is not None:
                  hs_mask_nc = masks & enc_streaming_mask_nc
              else:
+diff --git a/vllm/model_executor/models/plamo2.py b/vllm/model_executor/models/plamo2.py
+index 45512d23d..24df17963 100644
+--- a/vllm/model_executor/models/plamo2.py
++++ b/vllm/model_executor/models/plamo2.py
+@@ -27,6 +27,8 @@ from vllm.model_executor.layers.linear import (
+ from vllm.model_executor.layers.logits_processor import LogitsProcessor
+ from vllm.model_executor.layers.mamba.abstract import MambaBase
+ from vllm.model_executor.layers.mamba.mamba_utils import (
++    MambaStateCopyFunc,
++    MambaStateCopyFuncCalculator,
+     MambaStateDtypeCalculator,
+     MambaStateShapeCalculator,
+ )
+@@ -899,6 +901,10 @@ class Plamo2ForCausalLM(
+             conv_kernel=hf_config.mamba_d_conv,
+         )
+ 
++    @classmethod
++    def get_mamba_state_copy_func(cls) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:
++        return MambaStateCopyFuncCalculator.mamba2_state_copy_func()
++
+     def compute_logits(
+         self,
+         hidden_states: torch.Tensor,
 diff --git a/vllm/model_executor/models/qwen2_5_vl.py b/vllm/model_executor/models/qwen2_5_vl.py
 index 6e9e46368..99cfb30de 100644
 --- a/vllm/model_executor/models/qwen2_5_vl.py
@@ -7125,7 +9249,7 @@ index 6e9e46368..99cfb30de 100644
  
          self.apply_rotary_emb = ApplyRotaryEmb(enforce_enable=True)
 diff --git a/vllm/model_executor/models/qwen2_vl.py b/vllm/model_executor/models/qwen2_vl.py
-index 3b0dce7fc..4627f6954 100644
+index 3b0dce7fc..e785eca41 100644
 --- a/vllm/model_executor/models/qwen2_vl.py
 +++ b/vllm/model_executor/models/qwen2_vl.py
 @@ -329,6 +329,7 @@ class Qwen2VisionAttention(nn.Module):
@@ -7136,12 +9260,44 @@ index 3b0dce7fc..4627f6954 100644
          )
  
          self.apply_rotary_emb = ApplyRotaryEmb(enforce_enable=True)
+@@ -870,8 +871,8 @@ class Qwen2VLProcessingInfo(BaseProcessingInfo):
+                 height=image_height,
+                 width=image_width,
+                 factor=patch_size * merge_size,
+-                min_pixels=image_processor.min_pixels,
+-                max_pixels=image_processor.max_pixels,
++                min_pixels=image_processor.size["shortest_edge"],
++                max_pixels=image_processor.size["longest_edge"],
+             )
+             preprocessed_size = ImageSize(width=resized_width, height=resized_height)
+         else:
+@@ -921,7 +922,7 @@ class Qwen2VLProcessingInfo(BaseProcessingInfo):
+         )
+         return num_video_tokens
+ 
+-    def get_image_size_with_most_features(self) -> ImageSize:
++    def get_image_size_with_most_features(self, max_pixels: int | None = None) -> ImageSize:
+         # NOTE: Simply processing a huge size with _get_vision_info might not give a
+         # size that maximizes the number of featrues, i.e., the number of (merged)
+         # patches. This is because the number of patches limits the allowed aspect
+@@ -939,8 +940,9 @@ class Qwen2VLProcessingInfo(BaseProcessingInfo):
+         vision_config = hf_config.vision_config
+         patch_size = vision_config.patch_size
+         merge_size = vision_config.spatial_merge_size
+-        image_processor = self.get_image_processor()
+-        max_pixels = image_processor.max_pixels or image_processor.size["longest_edge"]
++        if max_pixels is None:
++            image_processor = self.get_image_processor()
++            max_pixels = image_processor.size["longest_edge"]
+         unit = patch_size * merge_size
+         max_seq_len = max_pixels // (unit * unit)
+ 
 diff --git a/vllm/model_executor/models/qwen3_5.py b/vllm/model_executor/models/qwen3_5.py
 new file mode 100644
-index 000000000..68e83d66e
+index 000000000..b3166d444
 --- /dev/null
 +++ b/vllm/model_executor/models/qwen3_5.py
-@@ -0,0 +1,1152 @@
+@@ -0,0 +1,1510 @@
 +# SPDX-License-Identifier: Apache-2.0
 +# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 +
@@ -7168,10 +9324,14 @@ index 000000000..68e83d66e
 +# limitations under the License.
 +"""Inference-only Qwen3.5 Series compatible with HuggingFace weights."""
 +
++import os
++import time
 +import typing
 +from collections.abc import Callable, Iterable
 +
 +import torch
++from custom_esimd_kernels_vllm import esimd_qkv_split_norm_rope
++from custom_esimd_kernels_vllm import esimd_gdn_conv_fused, esimd_gdn_conv_fused_seq
 +from einops import rearrange
 +from torch import nn
 +from transformers.activations import ACT2FN
@@ -7214,8 +9374,8 @@ index 000000000..68e83d66e
 +    mamba_v2_sharded_weight_loader,
 +)
 +from vllm.model_executor.layers.mamba.mamba_utils import (
-+    # MambaStateCopyFunc,
-+    # MambaStateCopyFuncCalculator,
++    MambaStateCopyFunc,
++    MambaStateCopyFuncCalculator,
 +    MambaStateDtypeCalculator,
 +    MambaStateShapeCalculator,
 +)
@@ -7332,33 +9492,22 @@ index 000000000..68e83d66e
 +        )
 +        self.conv1d.weight.data = self.conv1d.weight.data.unsqueeze(1)
 +
-+        self.in_proj_qkv = MergedColumnParallelLinear(
++        # Merge QKV+Z into single projection for better performance
++        self.in_proj_qkvz = MergedColumnParallelLinear(
 +            input_size=self.hidden_size,
-+            output_sizes=[self.key_dim, self.key_dim, self.value_dim],
++            output_sizes=[self.key_dim, self.key_dim, self.value_dim, self.value_dim],
 +            bias=False,
 +            quant_config=quant_config,
-+            prefix=f"{prefix}.in_proj_qkv",
++            prefix=f"{prefix}.in_proj_qkvz",
 +        )
-+        self.in_proj_z = ColumnParallelLinear(
++
++        # Merge B+A into single projection
++        self.in_proj_ba = MergedColumnParallelLinear(
 +            input_size=self.hidden_size,
-+            output_size=self.value_dim,
-+            bias=False,
-+            quant_config=quant_config,
-+            prefix=f"{prefix}.in_proj_z",
-+        )
-+        self.in_proj_b = ColumnParallelLinear(
-+            input_size=self.hidden_size,
-+            output_size=self.num_v_heads,
++            output_sizes=[self.num_v_heads, self.num_v_heads],
 +            bias=False,
 +            quant_config=quant_config,
 +            prefix=f"{prefix}.in_proj_ba",
-+        )
-+        self.in_proj_a = ColumnParallelLinear(
-+            input_size=self.hidden_size,
-+            output_size=self.num_v_heads,
-+            bias=False,
-+            quant_config=quant_config,
-+            prefix=f"{prefix}.in_proj_a",
 +        )
 +
 +        query_key_settings = (self.key_dim, 0, False)
@@ -7419,6 +9568,82 @@ index 000000000..68e83d66e
 +            raise ValueError(f"Duplicate layer name: {prefix}")
 +        compilation_config.static_forward_context[prefix] = self
 +
++        self.conv_bias_zeros = torch.zeros(
++            self.conv_dim // self.tp_size,
++            dtype=torch.float16,
++            device=current_platform.current_device(),
++        )
++
++        # Pre-allocate decode buffers to avoid per-forward allocation overhead
++        _dev = current_platform.current_device()
++        # qkvz buffer: [1, (key_dim * 2 + value_dim * 2) // tp_size]
++        self._decode_qkvz_buf = torch.empty(
++            (1, (self.key_dim * 2 + self.value_dim * 2) // self.tp_size),
++            dtype=torch.float16, device=_dev)
++        # ba buffer: [1, (num_v_heads * 2) // tp_size]
++        self._decode_ba_buf = torch.empty(
++            (1, (self.num_v_heads * 2) // self.tp_size),
++            dtype=torch.float16, device=_dev)
++        self._decode_attn_out_buf = torch.zeros(
++            (1, self.num_v_heads // self.tp_size, self.head_v_dim),
++            dtype=torch.float16, device=_dev)
++        self._decode_z_out_buf = torch.empty(
++            (1, self.num_v_heads // self.tp_size, self.head_v_dim),
++            dtype=torch.float16, device=_dev)
++
++        # Pre-cache values that don't change between forward calls
++        self._cached_conv_weights = None  # lazily cached after first forward
++        self._cached_nk_tp = self.num_k_heads // self.tp_size
++        self._cached_nv_tp = self.num_v_heads // self.tp_size
++        self._cached_attn_scale = float(self.head_k_dim ** -0.5)
++
++        # FP8 ESIMD projection kernels (GEMV/GEMM for input projection)
++        self._use_esimd_proj = hasattr(self.in_proj_qkvz, 'weight_scale')
++
++        # Fused norm + out_proj GEMV for decode (FP8 only)
++        # Always allocate: used by both forward_xpu and forward_xpu_with_precomputed_proj
++        self._use_fused_out_proj = hasattr(self.out_proj, 'weight_scale')
++        self._decode_outproj_buf = torch.empty(
++            (1, self.hidden_size),
++            dtype=torch.float16, device=_dev)
++        self._norm_weight_fp16 = None  # lazily cached after weights loaded
++
++        # Pre-compute gather indices to convert GEMV output from
++        # sequential [q|k|v|z] to GQA-interleaved [q_g0|k_g0|v_g0|z_g0|...]
++        # This replaces the per-forward split+reshape+cat with a single gather.
++        nk_tp = self._cached_nk_tp
++        vpg = self.num_v_heads // self.num_k_heads
++        dk = self.head_k_dim
++        dv = self.head_v_dim
++        qs = self.key_dim // self.tp_size
++        ks = qs
++        vs = self.value_dim // self.tp_size
++        qkvs = qs + ks + vs  # offset where z starts
++        idx_qkvz = []
++        for g in range(nk_tp):
++            idx_qkvz.extend(range(g * dk, (g + 1) * dk))
++            idx_qkvz.extend(range(qs + g * dk, qs + (g + 1) * dk))
++            idx_qkvz.extend(range(qs + ks + g * vpg * dv,
++                                  qs + ks + (g + 1) * vpg * dv))
++            idx_qkvz.extend(range(qkvs + g * vpg * dv,
++                                  qkvs + (g + 1) * vpg * dv))
++        self._gather_qkvz = torch.tensor(idx_qkvz, dtype=torch.long, device=_dev)
++
++        nv_tp = self._cached_nv_tp
++        idx_ba = []
++        for g in range(nk_tp):
++            idx_ba.extend(range(g * vpg, (g + 1) * vpg))
++            idx_ba.extend(range(nv_tp + g * vpg, nv_tp + (g + 1) * vpg))
++        self._gather_ba = torch.tensor(idx_ba, dtype=torch.long, device=_dev)
++
++    def fix_query_key_value_ordering(
++        self,
++        mixed_qkvz: torch.Tensor,
++        mixed_ba: torch.Tensor,
++    ):
++        raise NotImplementedError(
++            "Qwen3.5 Series dont need to fix query key value ordering"
++        )
 +    def fix_query_key_value_ordering(
 +        self,
 +        mixed_qkv,
@@ -7440,6 +9665,10 @@ index 000000000..68e83d66e
 +        else:
 +            self.forward_cuda(hidden_states, output)
 +
++    _attn_profile_data = {}
++    _attn_profile_count = 0
++    _PROFILE_ATTN = os.environ.get("PROFILE_ATTN", "0") == "1"
++
 +    def forward_xpu(
 +        self,
 +        hidden_states: torch.Tensor,
@@ -7451,108 +9680,289 @@ index 000000000..68e83d66e
 +        2. Core attention (XPU kernel)
 +        3. Output projection
 +        """
++        _PROFILE_ATTN = Qwen3_5GatedDeltaNet._PROFILE_ATTN
++
 +        num_tokens = hidden_states.size(0)
++        is_decode = (num_tokens == 1)
 +
 +        # ============================================================
 +        # Part 1: Input Projection
 +        # ============================================================
-+        mixed_qkv, _ = self.in_proj_qkv(hidden_states)
-+        z_raw, _ = self.in_proj_z(hidden_states)
-+        b_raw, _ = self.in_proj_b(hidden_states)
-+        a_raw, _ = self.in_proj_a(hidden_states)
++        if _PROFILE_ATTN and is_decode:
++            torch.xpu.synchronize()
++            _t0 = time.perf_counter()
 +
-+        # Rearrange separate projections to GQA-interleaved format
-+        # expected by the XPU kernel.
-+        # Layout per k_head group: [q, k, v_group, z_group]
-+        num_k_groups = self.num_k_heads // self.tp_size
-+        v_per_group = self.num_v_heads // self.num_k_heads
-+        q_dim = self.key_dim // self.tp_size
-+        k_dim = self.key_dim // self.tp_size
++        if is_decode and self._use_esimd_proj:
++            # M=1, FP8: single fused GEMV for qkvz + ba projections
++            from custom_esimd_kernels_vllm import esimd_gemv_fp8_pert, esimd_gemv_fp8_pert_fused2
++            qkvz_merged = self._decode_qkvz_buf
++            ba_merged = self._decode_ba_buf
++            esimd_gemv_fp8_pert_fused2(
++                hidden_states,
++                self.in_proj_qkvz.weight,
++                self.in_proj_qkvz.weight_scale,
++                qkvz_merged,
++                self.in_proj_ba.weight,
++                self.in_proj_ba.weight_scale,
++                ba_merged,
++            )
++            projected_states_qkvz = qkvz_merged
++            projected_states_ba = ba_merged
++        elif is_decode:
++            # M=1, non-FP8: standard Linear, keep sequential layout
++            # (esimd_gdn_conv_fused_seq expects sequential [q|k|v|z])
++            qkvz_merged, _ = self.in_proj_qkvz(hidden_states)
++            ba_merged, _ = self.in_proj_ba(hidden_states)
++            projected_states_qkvz = qkvz_merged
++            projected_states_ba = ba_merged
++        elif num_tokens <= 64 and self._use_esimd_proj:
++            # M=2-64, FP8: ESIMD GEMM, gather to interleaved for prefill kernel
++            from custom_esimd_kernels_vllm import esimd_gemm_fp8_pert
++            N_qkvz = self.in_proj_qkvz.weight.shape[0]
++            N_ba = self.in_proj_ba.weight.shape[0]
++            qkvz_merged = torch.empty(
++                (num_tokens, N_qkvz), dtype=torch.float16, device=hidden_states.device)
++            ba_merged = torch.empty(
++                (num_tokens, N_ba), dtype=torch.float16, device=hidden_states.device)
++            esimd_gemm_fp8_pert(
++                hidden_states, self.in_proj_qkvz.weight,
++                self.in_proj_qkvz.weight_scale, qkvz_merged)
++            esimd_gemm_fp8_pert(
++                hidden_states, self.in_proj_ba.weight,
++                self.in_proj_ba.weight_scale, ba_merged)
++            projected_states_qkvz = qkvz_merged[:, self._gather_qkvz]
++            projected_states_ba = ba_merged[:, self._gather_ba]
++        else:
++            # Fallback: standard Linear, gather to interleaved for prefill kernel
++            qkvz_merged, _ = self.in_proj_qkvz(hidden_states)
++            ba_merged, _ = self.in_proj_ba(hidden_states)
++            projected_states_qkvz = qkvz_merged[:, self._gather_qkvz]
++            projected_states_ba = ba_merged[:, self._gather_ba]
 +
-+        q = mixed_qkv[..., :q_dim].reshape(
-+            num_tokens, num_k_groups, self.head_k_dim)
-+        k = mixed_qkv[..., q_dim:q_dim + k_dim].reshape(
-+            num_tokens, num_k_groups, self.head_k_dim)
-+        v = mixed_qkv[..., q_dim + k_dim:].reshape(
-+            num_tokens, num_k_groups, v_per_group * self.head_v_dim)
-+        z = z_raw.reshape(
-+            num_tokens, num_k_groups, v_per_group * self.head_v_dim)
-+
-+        projected_states_qkvz = torch.cat(
-+            [q, k, v, z], dim=-1
-+        ).reshape(num_tokens, -1).contiguous()
-+
-+        b = b_raw.reshape(num_tokens, num_k_groups, v_per_group)
-+        a = a_raw.reshape(num_tokens, num_k_groups, v_per_group)
-+        projected_states_ba = torch.cat(
-+            [b, a], dim=-1
-+        ).reshape(num_tokens, -1).contiguous()
++        if _PROFILE_ATTN and is_decode:
++            torch.xpu.synchronize()
++            _t_proj = (time.perf_counter() - _t0) * 1e6
 +
 +        # ============================================================
 +        # Part 2: Core Attention (XPU Kernel)
 +        # ============================================================
 +        forward_context = get_forward_context()
 +        attn_metadata = forward_context.attn_metadata
-+        core_attn_out = torch.zeros(
-+            (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
-+            dtype=hidden_states.dtype,
-+            device=hidden_states.device,
-+        )
-+        z_out = torch.empty_like(core_attn_out)
++        if is_decode:
++            core_attn_out = self._decode_attn_out_buf
++            z_out = self._decode_z_out_buf
++        else:
++            core_attn_out = torch.zeros(
++                (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
++                dtype=hidden_states.dtype,
++                device=hidden_states.device,
++            )
++            z_out = torch.empty_like(core_attn_out)
 +        if attn_metadata is not None:
 +            attn_metadata = attn_metadata[self.prefix]
-+
-+            # TODO: xpu does not support this param yet
-+            spec_sequence_masks = attn_metadata.spec_sequence_masks
-+            if spec_sequence_masks is not None:
-+                raise NotImplementedError(
-+                    "XPU gdn_attention does not yet support 'spec_sequence_masks'."
-+                )
-+
-+            conv_weights = self.conv1d.weight.view(
-+                self.conv1d.weight.size(0), self.conv1d.weight.size(2)
-+            )
 +
 +            self_kv_cache = self.kv_cache[forward_context.virtual_engine]
 +            conv_state = self_kv_cache[0]
 +            ssm_state = self_kv_cache[1]
 +
-+            torch.ops._xpu_C.gdn_attention(
-+                core_attn_out,
-+                z_out,
-+                projected_states_qkvz,
-+                projected_states_ba,
-+                self.num_k_heads,
-+                self.num_v_heads,
-+                self.head_k_dim,
-+                self.head_v_dim,
-+                conv_state=conv_state,
-+                ssm_state=ssm_state,
-+                conv_weights=conv_weights,
-+                conv_bias=self.conv1d.bias,
-+                activation=self.activation,
-+                A_log=self.A_log,
-+                dt_bias=self.dt_bias,
-+                num_prefills=attn_metadata.num_prefills,
-+                num_decodes=attn_metadata.num_decodes,
-+                has_initial_state=attn_metadata.has_initial_state,
-+                non_spec_query_start_loc=attn_metadata.non_spec_query_start_loc,
-+                non_spec_state_indices_tensor=attn_metadata.non_spec_state_indices_tensor,
-+                num_actual_tokens=attn_metadata.num_actual_tokens,
-+                tp_size=self.tp_size,
-+            )
++            # Cache conv_weights view (shape doesn't change)
++            if self._cached_conv_weights is None:
++                self._cached_conv_weights = self.conv1d.weight.view(
++                    self.conv1d.weight.size(0), self.conv1d.weight.size(2)
++                )
++            conv_weights = self._cached_conv_weights
++
++            if is_decode:
++                # Decode: fused ESIMD kernel
++                N_dec = attn_metadata.num_decodes
++                state_idx = attn_metadata.non_spec_state_indices_tensor[:N_dec]
++
++                if _PROFILE_ATTN:
++                    torch.xpu.synchronize()
++                    _t0 = time.perf_counter()
++
++                esimd_gdn_conv_fused_seq(
++                    projected_states_qkvz,
++                    conv_state,
++                    conv_weights,
++                    self.conv_bias_zeros,
++                    state_idx,
++                    self.A_log,
++                    self.dt_bias,
++                    projected_states_ba,
++                    ssm_state,
++                    state_idx,
++                    core_attn_out,
++                    z_out,
++                    N_dec,
++                    self._cached_nk_tp,
++                    self._cached_nv_tp,
++                    self.head_k_dim,
++                    self.head_v_dim,
++                    self._cached_attn_scale,
++                )
++
++                if _PROFILE_ATTN:
++                    torch.xpu.synchronize()
++                    _t_gdn = (time.perf_counter() - _t0) * 1e6
++
++            else:
++                # Prefill: XPU C++ kernel
++                spec_sequence_masks = attn_metadata.spec_sequence_masks
++                if spec_sequence_masks is not None:
++                    raise NotImplementedError(
++                        "XPU gdn_attention does not yet support 'spec_sequence_masks'."
++                    )
++
++                torch.ops._xpu_C.gdn_attention(
++                    core_attn_out,
++                    z_out,
++                    projected_states_qkvz,
++                    projected_states_ba,
++                    self.num_k_heads,
++                    self.num_v_heads,
++                    self.head_k_dim,
++                    self.head_v_dim,
++                    conv_state=conv_state,
++                    ssm_state=ssm_state,
++                    conv_weights=conv_weights,
++                    conv_bias=self.conv1d.bias,
++                    activation=self.activation,
++                    A_log=self.A_log,
++                    dt_bias=self.dt_bias,
++                    num_prefills=attn_metadata.num_prefills,
++                    num_decodes=attn_metadata.num_decodes,
++                    has_initial_state=attn_metadata.has_initial_state,
++                    non_spec_query_start_loc=attn_metadata.non_spec_query_start_loc,
++                    non_spec_state_indices_tensor=attn_metadata.non_spec_state_indices_tensor,
++                    num_actual_tokens=attn_metadata.num_actual_tokens,
++                    tp_size=self.tp_size,
++                )
 +
 +        # ============================================================
 +        # Part 3: Output Projection
 +        # ============================================================
-+        z_shape_og = z_out.shape
-+        # Reshape input data into 2D tensor
-+        core_attn_out = core_attn_out.reshape(-1, core_attn_out.shape[-1])
-+        z_out = z_out.reshape(-1, z_out.shape[-1])
-+        core_attn_out = self.norm(core_attn_out, z_out)
-+        core_attn_out = core_attn_out.reshape(z_shape_og)
-+        core_attn_out = rearrange(core_attn_out, "... h d -> ... (h d)")
-+        output[:num_tokens], _ = self.out_proj(core_attn_out)
++        if _PROFILE_ATTN and is_decode:
++            torch.xpu.synchronize()
++            _t0 = time.perf_counter()
++
++        if is_decode and self._use_fused_out_proj:
++            # Decode fast path: fused RMSNormGated + out_proj GEMV (single kernel)
++            from custom_esimd_kernels_vllm import esimd_norm_gemv_fp8_pert
++            from vllm.distributed import tensor_model_parallel_all_reduce
++            nv_tp = self._cached_nv_tp
++            hv = self.head_v_dim
++            if self._norm_weight_fp16 is None:
++                self._norm_weight_fp16 = self.norm.weight.data.half()
++            esimd_norm_gemv_fp8_pert(
++                core_attn_out.view(nv_tp, hv),
++                z_out.view(nv_tp, hv),
++                self._norm_weight_fp16,
++                self.out_proj.weight,
++                self.out_proj.weight_scale,
++                self._decode_outproj_buf,
++                nv_tp, hv, self.norm.eps,
++            )
++            output[:1] = tensor_model_parallel_all_reduce(
++                self._decode_outproj_buf)
++        elif is_decode:
++            # Decode non-FP8 fallback
++            nv_tp = self._cached_nv_tp
++            hv = self.head_v_dim
++            core_attn_out_2d = core_attn_out.view(nv_tp, hv)
++            z_out_2d = z_out.view(nv_tp, hv)
++            core_attn_out_2d = self.norm(core_attn_out_2d, z_out_2d)
++            core_attn_out_flat = core_attn_out_2d.view(1, nv_tp * hv)
++            output[:1], _ = self.out_proj(core_attn_out_flat)
++        else:
++            z_shape_og = z_out.shape
++            # Reshape input data into 2D tensor
++            core_attn_out = core_attn_out.reshape(-1, core_attn_out.shape[-1])
++            z_out = z_out.reshape(-1, z_out.shape[-1])
++            core_attn_out = self.norm(core_attn_out, z_out)
++            core_attn_out = core_attn_out.reshape(z_shape_og)
++            core_attn_out = rearrange(core_attn_out, "... h d -> ... (h d)")
++            output[:num_tokens], _ = self.out_proj(core_attn_out)
++
++        if _PROFILE_ATTN and is_decode:
++            torch.xpu.synchronize()
++            _t_out = (time.perf_counter() - _t0) * 1e6
++
++            key = f"L{self.layer_idx}_{self.prefix.split('.')[-1]}"
++            if key not in Qwen3_5GatedDeltaNet._attn_profile_data:
++                Qwen3_5GatedDeltaNet._attn_profile_data[key] = {"proj": [], "gdn": [], "out": [], "count": 0}
++            pd = Qwen3_5GatedDeltaNet._attn_profile_data[key]
++            pd["proj"].append(_t_proj)
++            pd["gdn"].append(_t_gdn)
++            pd["out"].append(_t_out)
++            pd["count"] += 1
++
++            Qwen3_5GatedDeltaNet._attn_profile_count += 1
++            total_keys = len(Qwen3_5GatedDeltaNet._attn_profile_data)
++            if total_keys > 0 and Qwen3_5GatedDeltaNet._attn_profile_count % (total_keys * 20) == 0:
++                print(f"\n[ATTN_PROFILE] === Step {pd['count']} summary (last 20) ===")
++                sum_proj = sum_gdn = sum_out = 0
++                for k in sorted(Qwen3_5GatedDeltaNet._attn_profile_data.keys()):
++                    d = Qwen3_5GatedDeltaNet._attn_profile_data[k]
++                    n = min(len(d["proj"]), 20)
++                    p = sum(d["proj"][-20:]) / n
++                    g = sum(d["gdn"][-20:]) / n
++                    o = sum(d["out"][-20:]) / n
++                    sum_proj += p; sum_gdn += g; sum_out += o
++                    print(f"[ATTN_PROFILE] {k:30s} proj={p:>7.1f}us  gdn={g:>7.1f}us  out={o:>7.1f}us  total={p+g+o:>7.1f}us")
++                print(f"[ATTN_PROFILE] {'SUM':30s} proj={sum_proj:>7.1f}us  gdn={sum_gdn:>7.1f}us  out={sum_out:>7.1f}us  total={sum_proj+sum_gdn+sum_out:>7.1f}us")
++                print(f"[ATTN_PROFILE] {'(ms)':30s} proj={sum_proj/1000:>7.2f}ms  gdn={sum_gdn/1000:>7.2f}ms  out={sum_out/1000:>7.2f}ms  total={(sum_proj+sum_gdn+sum_out)/1000:>7.2f}ms")
++                print()
++
++    def forward_xpu_with_precomputed_proj(
++        self,
++        projected_states_qkvz: torch.Tensor,
++        projected_states_ba: torch.Tensor,
++        output: torch.Tensor,
++    ):
++        """Decode-only fast path: input projection already done by caller.
++        Uses sequential [q|k|v|z] layout with esimd_gdn_conv_fused_seq."""
++        from custom_esimd_kernels_vllm import esimd_norm_gemv_fp8_pert
++        from vllm.distributed import tensor_model_parallel_all_reduce
++
++        # Part 2: Core Attention
++        forward_context = get_forward_context()
++        attn_metadata = forward_context.attn_metadata
++        core_attn_out = self._decode_attn_out_buf
++        core_attn_out.zero_()
++        z_out = self._decode_z_out_buf
++        if attn_metadata is not None:
++            attn_metadata = attn_metadata[self.prefix]
++            self_kv_cache = self.kv_cache[forward_context.virtual_engine]
++            conv_state = self_kv_cache[0]
++            ssm_state = self_kv_cache[1]
++            if self._cached_conv_weights is None:
++                self._cached_conv_weights = self.conv1d.weight.view(
++                    self.conv1d.weight.size(0), self.conv1d.weight.size(2))
++            N_dec = attn_metadata.num_decodes
++            state_idx = attn_metadata.non_spec_state_indices_tensor[:N_dec]
++            esimd_gdn_conv_fused_seq(
++                projected_states_qkvz, conv_state,
++                self._cached_conv_weights, self.conv_bias_zeros, state_idx,
++                self.A_log, self.dt_bias, projected_states_ba,
++                ssm_state, state_idx, core_attn_out, z_out,
++                N_dec, self._cached_nk_tp, self._cached_nv_tp,
++                self.head_k_dim, self.head_v_dim, self._cached_attn_scale,
++            )
++
++        # Part 3: Output Projection (fused norm + GEMV)
++        nv_tp = self._cached_nv_tp
++        hv = self.head_v_dim
++        if self._norm_weight_fp16 is None:
++            self._norm_weight_fp16 = self.norm.weight.data.half()
++        esimd_norm_gemv_fp8_pert(
++            core_attn_out.view(nv_tp, hv), z_out.view(nv_tp, hv),
++            self._norm_weight_fp16,
++            self.out_proj.weight, self.out_proj.weight_scale,
++            self._decode_outproj_buf, nv_tp, hv, self.norm.eps,
++        )
++        output[:1] = tensor_model_parallel_all_reduce(
++            self._decode_outproj_buf)
 +
 +    def forward_cuda(
 +        self,
@@ -7570,12 +9980,17 @@ index 000000000..68e83d66e
 +        # ============================================================
 +        # Part 1: Input Projection
 +        # ============================================================
-+        mixed_qkv, _ = self.in_proj_qkv(hidden_states)
-+        z, _ = self.in_proj_z(hidden_states)
-+        z = z.reshape(z.size(0), -1, self.head_v_dim)
-+        b, _ = self.in_proj_b(hidden_states)
-+        a, _ = self.in_proj_a(hidden_states)
++        qkvz_merged, _ = self.in_proj_qkvz(hidden_states)
++        ba_merged, _ = self.in_proj_ba(hidden_states)
 +
++        # Split merged outputs
++        qkv_size = (self.key_dim * 2 + self.value_dim) // self.tp_size
++        mixed_qkv = qkvz_merged[:, :qkv_size]
++        z = qkvz_merged[:, qkv_size:qkv_size + self.value_dim // self.tp_size]
++        z = z.reshape(z.size(0), -1, self.head_v_dim)
++
++        ba, _ = self.in_proj_ba(hidden_states)
++        b, a = ba.chunk(2, dim=-1)
 +        b = b.contiguous()
 +        a = a.contiguous()
 +
@@ -7693,6 +10108,71 @@ index 000000000..68e83d66e
 +                ),
 +            )
 +
++        # Detect dense MLP with FP8 quantization for ESIMD fast path
++        self._dense_mlp_fp8 = (
++            isinstance(self.mlp, Qwen3NextMLP)
++            and self.mlp.expert_gate is None
++            and quant_config is not None
++            and quant_config.get_name() == "fp8"
++            and os.environ.get("DISABLE_ESIMD_DENSE", "0") != "1"
++        )
++        if self._dense_mlp_fp8:
++            _dev = current_platform.current_device()
++            tp_size = get_tensor_model_parallel_world_size()
++            _inter_tp = config.intermediate_size // tp_size
++            _hidden = config.hidden_size
++            # Pre-allocate decode buffers (bsz=1)
++            self._dense_gate_up_buf = torch.empty(
++                1, 2 * _inter_tp, dtype=torch.float16, device=_dev)
++            self._dense_down_buf = torch.empty(
++                1, _hidden, dtype=torch.float16, device=_dev)
++            self._dense_normed_buf = torch.empty(
++                1, _hidden, dtype=torch.float16, device=_dev)
++            # Lazily cached after weights are loaded
++            self._dense_post_norm_w_fp16 = None
++
++        # Detect MoE with FP8 for ESIMD fused norm+router path
++        self._moe_fp8 = (
++            isinstance(self.mlp, Qwen3NextSparseMoeBlock)
++            and hasattr(self.mlp, 'use_fp8')
++            and self.mlp.use_fp8
++        )
++        if self._moe_fp8:
++            _dev = current_platform.current_device()
++            n_exp = self.mlp.gate.weight.shape[0]
++            self._post_norm_w_fp16 = None  # lazily cached
++            self._router_buf = torch.empty(
++                1, n_exp, dtype=torch.float16, device=_dev)
++            self._normed_buf = torch.empty(
++                1, config.hidden_size, dtype=torch.float16, device=_dev)
++
++        # Detect fused input_norm + input_proj opportunity (FP8, decode)
++        _is_fp8 = (quant_config is not None
++                    and quant_config.get_name() == "fp8")
++        self._fused_input_norm = (
++            _is_fp8 and not self.layer_scale
++            and os.environ.get("DISABLE_ESIMD_FUSED_INPUT", "0") != "1"
++        )
++        if self._fused_input_norm:
++            _dev = current_platform.current_device()
++            _hidden = config.hidden_size
++            self._input_norm_w_fp16 = None  # lazily cached
++            if self.layer_type == "linear_attention":
++                # GDN: norm + fused 2-GEMV (in_proj_qkvz + in_proj_ba)
++                _qkvz_sz = self.linear_attn.in_proj_qkvz.weight.shape[0]
++                _ba_sz = self.linear_attn.in_proj_ba.weight.shape[0]
++                self._fused_qkvz_buf = torch.empty(
++                    1, _qkvz_sz, dtype=torch.float16, device=_dev)
++                self._fused_ba_buf = torch.empty(
++                    1, _ba_sz, dtype=torch.float16, device=_dev)
++            elif self.layer_type == "full_attention":
++                # Full Attn: norm + qkv_proj GEMV
++                _qkv_sz = self.self_attn.qkv_proj.weight.shape[0]
++                self._fused_qkv_buf = torch.empty(
++                    1, _qkv_sz, dtype=torch.float16, device=_dev)
++                self._fused_normed_buf = torch.empty(
++                    1, _hidden, dtype=torch.float16, device=_dev)
++
 +
 +@support_torch_compile(
 +    dynamic_arg_dims={
@@ -7774,11 +10254,18 @@ index 000000000..68e83d66e
 +    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
 +        stacked_params_mapping = [
 +            # (param_name, shard_name, shard_id)
++            # self attention
 +            ("qkv_proj", "q_proj", "q"),
 +            ("qkv_proj", "k_proj", "k"),
 +            ("qkv_proj", "v_proj", "v"),
++            # mlp
 +            ("gate_up_proj", "gate_proj", 0),
 +            ("gate_up_proj", "up_proj", 1),
++            # GDN
++            ("in_proj_qkvz", "in_proj_qkv", (0, 1, 2)),
++            ("in_proj_qkvz", "in_proj_z", 3),
++            ("in_proj_ba", "in_proj_b", 0),
++            ("in_proj_ba", "in_proj_a", 1),
 +        ]
 +
 +        params_dict = dict(self.named_parameters())
@@ -7832,8 +10319,25 @@ index 000000000..68e83d66e
 +                if name not in params_dict:
 +                    continue
 +                param = params_dict[name]
-+                weight_loader = param.weight_loader
-+                weight_loader(param, loaded_weight, shard_id)
++
++                # Use weight_loader_v2 for tuple shard_id (GDN projections)
++                if isinstance(shard_id, tuple):
++                    # For MergedColumnParallelLinear params, we need to use weight_loader_v2
++                    # Get the parent module that has weight_loader_v2
++                    parent_module_name = ".".join(name.split(".")[:-1])
++                    if parent_module_name:
++                        parent_module = dict(self.named_modules()).get(parent_module_name)
++                        if parent_module and hasattr(parent_module, "weight_loader_v2"):
++                            parent_module.weight_loader_v2(param, loaded_weight, shard_id)
++                        else:
++                            weight_loader = param.weight_loader
++                            weight_loader(param, loaded_weight, shard_id)
++                    else:
++                        weight_loader = param.weight_loader
++                        weight_loader(param, loaded_weight, shard_id)
++                else:
++                    weight_loader = param.weight_loader
++                    weight_loader(param, loaded_weight, shard_id)
 +                break
 +            else:
 +                is_expert_weight = False
@@ -7851,7 +10355,7 @@ index 000000000..68e83d66e
 +                        # loaded_weight = loaded_weight.transpose(-1, -2)
 +                        if "experts.gate_up_proj" in name:
 +                            loaded_weight = loaded_weight.chunk(2, dim=-2)
-+                            
++
 +                            if is_padding_needed:
 +                                shape0 = loaded_weight[0].shape[1]
 +                                target_size = round_up(shape0, 1024)
@@ -7956,6 +10460,9 @@ index 000000000..68e83d66e
 +            "v_proj",
 +        ],
 +        "gate_up_proj": ["gate_proj", "up_proj"],
++        # GDN fused projections.
++        "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
++        "in_proj_ba": ["in_proj_b", "in_proj_a"],
 +    }
 +
 +    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
@@ -7965,9 +10472,11 @@ index 000000000..68e83d66e
 +        cache_config = vllm_config.cache_config
 +
 +        scheduler_config = vllm_config.scheduler_config
-+        assert not cache_config.enable_prefix_caching, (
-+            "Qwen3Next currently does not support prefix caching"
-+        )
++        if cache_config.mamba_cache_mode == "all":
++            raise NotImplementedError(
++                "Qwen3_5 currently does not support 'all' prefix caching, "
++                "please use '--mamba-cache-mode=align' instead"
++            )
 +        self.quant_config = vllm_config.quant_config
 +
 +        super().__init__()
@@ -8051,6 +10560,11 @@ index 000000000..68e83d66e
 +    dummy_inputs=Qwen3VLDummyInputsBuilder,
 +)
 +class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid):
++    packed_modules_mapping = Qwen3VLForConditionalGeneration.packed_modules_mapping | {
++        "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
++        "in_proj_ba": ["in_proj_b", "in_proj_a"],
++    }
++
 +    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
 +        # protocols have not __init__ method, so we need to use nn.Module.__init__
 +        nn.Module.__init__(self)
@@ -8196,9 +10710,9 @@ index 000000000..68e83d66e
 +            num_spec,
 +        )
 +
-+    # @classmethod
-+    # def get_mamba_state_copy_func(cls) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:
-+    #     return MambaStateCopyFuncCalculator.gated_delta_net_state_copy_func()
++    @classmethod
++    def get_mamba_state_copy_func(cls) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:
++        return MambaStateCopyFuncCalculator.gated_delta_net_state_copy_func()
 +
 +
 +########################################################
@@ -9477,10 +11991,48 @@ index f2f354604..ad88271b9 100644
                  if weight_name not in name:
                      continue
 diff --git a/vllm/model_executor/models/qwen3_next.py b/vllm/model_executor/models/qwen3_next.py
-index 0f73a7746..b4bca126e 100644
+index 0f73a7746..40d872ee7 100644
 --- a/vllm/model_executor/models/qwen3_next.py
 +++ b/vllm/model_executor/models/qwen3_next.py
-@@ -104,7 +104,7 @@ class Qwen3NextSparseMoeBlock(nn.Module):
+@@ -2,10 +2,20 @@
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ """Inference-only Qwen3Next model."""
+ 
++import os
+ from collections.abc import Iterable
+ from itertools import islice
+ 
+ import torch
++from custom_esimd_kernels_vllm import moe_ops
++from custom_esimd_kernels_vllm import esimd_gemv_fp8_pert
++from custom_esimd_kernels_vllm import esimd_gemv_fp8_pert_fused2
++from custom_esimd_kernels_vllm import esimd_gemm_fp8_pert
++from custom_esimd_kernels_vllm import esimd_norm_gemv_fp8_pert
++from custom_esimd_kernels_vllm import esimd_resadd_norm_gemv_fp8_pert
++from custom_esimd_kernels_vllm import esimd_resadd_norm_gemv2_fp8_pert
++from custom_esimd_kernels_vllm import esimd_qkv_split_norm_rope
++from custom_esimd_kernels_vllm import esimd_gdn_conv_fused
+ from einops import rearrange
+ from torch import nn
+ from transformers.activations import ACT2FN
+@@ -26,6 +36,7 @@ from vllm.distributed import (
+     get_tensor_model_parallel_rank,
+     get_tensor_model_parallel_world_size,
+     tensor_model_parallel_all_gather,
++    tensor_model_parallel_all_reduce,
+ )
+ from vllm.forward_context import ForwardContext, get_forward_context
+ from vllm.logger import init_logger
+@@ -49,6 +60,8 @@ from vllm.model_executor.layers.logits_processor import LogitsProcessor
+ from vllm.model_executor.layers.mamba.abstract import MambaBase
+ from vllm.model_executor.layers.mamba.mamba_mixer2 import mamba_v2_sharded_weight_loader
+ from vllm.model_executor.layers.mamba.mamba_utils import (
++    MambaStateCopyFunc,
++    MambaStateCopyFuncCalculator,
+     MambaStateDtypeCalculator,
+     MambaStateShapeCalculator,
+ )
+@@ -104,10 +117,15 @@ class Qwen3NextSparseMoeBlock(nn.Module):
      def __init__(self, vllm_config: VllmConfig, prefix: str = ""):
          super().__init__()
  
@@ -9489,7 +12041,15 @@ index 0f73a7746..b4bca126e 100644
          parallel_config = vllm_config.parallel_config
          quant_config = vllm_config.quant_config
  
-@@ -175,7 +175,7 @@ class Qwen3NextSparseMoeBlock(nn.Module):
++        # Check if FP8 quantization is enabled
++        self.use_fp8 = False
++        if quant_config is not None:
++            self.use_fp8 = quant_config.get_name() == "fp8"
++
+         self.tp_size = get_tensor_model_parallel_world_size()
+ 
+         self.ep_group = get_ep_group().device_group
+@@ -175,7 +193,7 @@ class Qwen3NextSparseMoeBlock(nn.Module):
              hidden_size=config.hidden_size,
              intermediate_size=config.moe_intermediate_size,
              reduce_results=False,
@@ -9498,7 +12058,101 @@ index 0f73a7746..b4bca126e 100644
              quant_config=quant_config,
              prefix=f"{prefix}.experts",
              enable_eplb=self.enable_eplb,
-@@ -441,6 +441,98 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
+@@ -184,12 +202,53 @@ class Qwen3NextSparseMoeBlock(nn.Module):
+             routing_method_type=RoutingMethodType.Renormalize,
+         )
+ 
++        # Cache env flag and init attribute for precomputed router logits
++        self._esimd_moe_enabled = (
++            self.use_fp8
++            and os.environ.get("DISABLE_ESIMD_MOE", "0") != "1"
++        )
++        self._precomputed_router_logits = None
++
+     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+         # NOTE: hidden_states can have either 1D or 2D shape.
+         orig_shape = hidden_states.shape
+         num_tokens, hidden_dim = hidden_states.shape
+         hidden_states = hidden_states.view(-1, hidden_dim)
+ 
++        if num_tokens <= 128 and self._esimd_moe_enabled:
++            x = hidden_states
++
++            # Use precomputed router logits if available (from fused norm+router)
++            logits = self._precomputed_router_logits
++            if logits is not None:
++                self._precomputed_router_logits = None
++            else:
++                logits = moe_ops.moe_router_forward(
++                    x, self.gate.weight, self.gate.weight_scale)
++
++            # Single C++ call: topk + up + down_routed + down_finalize
++            final_hidden_states = moe_ops.moe_forward_full(
++                x, logits,
++                self.experts.w13_weight, self.experts.w13_weight_scale,
++                self.shared_expert.gate_up_proj.weight,
++                self.shared_expert.gate_up_proj.weight_scale,
++                self.experts.w2_weight, self.experts.w2_weight_scale,
++                self.shared_expert.down_proj.weight,
++                self.shared_expert.down_proj.weight_scale,
++                self.shared_expert_gate.weight if self.shared_expert is not None else None,
++                self.experts.top_k, 1, self.n_routed_experts)
++
++            if self.is_sequence_parallel:
++                final_hidden_states = tensor_model_parallel_all_gather(
++                    final_hidden_states, 0
++                )
++                final_hidden_states = final_hidden_states[:num_tokens]
++            elif self.tp_size > 1:
++                final_hidden_states = self.experts.maybe_all_reduce_tensor_model_parallel(
++                    final_hidden_states
++                )
++            return final_hidden_states.view(orig_shape)
++
+         if self.is_sequence_parallel:
+             hidden_states = sequence_parallel_chunk(hidden_states)
+ 
+@@ -366,6 +425,39 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
+         if prefix in compilation_config.static_forward_context:
+             raise ValueError(f"Duplicate layer name: {prefix}")
+         compilation_config.static_forward_context[prefix] = self
++        self.conv_bias_zeros = torch.zeros(
++            self.conv_dim // self.tp_size,
++            dtype=torch.float16,
++            device=current_platform.current_device(),
++        )
++
++        # Pre-allocate decode buffers to avoid per-forward allocation overhead
++        _dev = current_platform.current_device()
++        self._decode_qkvz_buf = torch.empty(
++            (1, self.projection_size_qkvz // self.tp_size),
++            dtype=torch.float16, device=_dev)
++        self._decode_ba_buf = torch.empty(
++            (1, self.projection_size_ba // self.tp_size),
++            dtype=torch.float16, device=_dev)
++        self._decode_attn_out_buf = torch.zeros(
++            (1, self.num_v_heads // self.tp_size, self.head_v_dim),
++            dtype=torch.float16, device=_dev)
++        self._decode_z_buf = torch.empty(
++            (1, self.num_v_heads // self.tp_size, self.head_v_dim),
++            dtype=torch.float16, device=_dev)
++
++        # Pre-allocated buffer for fused norm+GEMV output (out_proj)
++        self._decode_outproj_buf = torch.empty(
++            (1, self.hidden_size),
++            dtype=torch.float16, device=_dev)
++        # Cache fp16 norm weight (norm.weight is float32, kernel needs fp16)
++        self._norm_weight_fp16 = None  # lazily cached after weights loaded
++
++        # Pre-cache values that don't change between forward calls
++        self._cached_conv_weights = None  # lazily cached after first forward
++        self._cached_nk_tp = self.num_k_heads // self.tp_size
++        self._cached_nv_tp = self.num_v_heads // self.tp_size
++        self._cached_attn_scale = float(self.head_k_dim ** -0.5)
+ 
+     def fix_query_key_value_ordering(
+         self,
+@@ -441,6 +533,231 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
          self,
          hidden_states: torch.Tensor,
          output: torch.Tensor,
@@ -9507,6 +12161,7 @@ index 0f73a7746..b4bca126e 100644
 +            self.forward_xpu(hidden_states, output)
 +        else:
 +            self.forward_cuda(hidden_states, output)
++
 +
 +    def forward_xpu(
 +        self,
@@ -9520,75 +12175,207 @@ index 0f73a7746..b4bca126e 100644
 +        3. Output projection
 +        """
 +        num_tokens = hidden_states.size(0)
++        is_decode = (num_tokens == 1)
 +
 +        # ============================================================
 +        # Part 1: Input Projection
 +        # ============================================================
-+        projected_states_qkvz, _ = self.in_proj_qkvz(hidden_states)
-+        projected_states_ba, _ = self.in_proj_ba(hidden_states)
++        if is_decode:
++            # M=1: fused GEMV for two weight matrices (one kernel launch)
++            projected_states_qkvz = self._decode_qkvz_buf
++            projected_states_ba = self._decode_ba_buf
++            esimd_gemv_fp8_pert_fused2(
++                hidden_states,
++                self.in_proj_qkvz.weight,
++                self.in_proj_qkvz.weight_scale,
++                projected_states_qkvz,
++                self.in_proj_ba.weight,
++                self.in_proj_ba.weight_scale,
++                projected_states_ba,
++            )
++        elif num_tokens <= 64:
++            # M=2-64: ESIMD GEMM (auto-dispatches batched GEMV / WS / DPAS)
++            N_qkvz = self.in_proj_qkvz.weight.shape[0]
++            N_ba = self.in_proj_ba.weight.shape[0]
++            projected_states_qkvz = torch.empty(
++                (num_tokens, N_qkvz), dtype=torch.float16, device=hidden_states.device)
++            projected_states_ba = torch.empty(
++                (num_tokens, N_ba), dtype=torch.float16, device=hidden_states.device)
++            esimd_gemm_fp8_pert(
++                hidden_states, self.in_proj_qkvz.weight,
++                self.in_proj_qkvz.weight_scale, projected_states_qkvz)
++            esimd_gemm_fp8_pert(
++                hidden_states, self.in_proj_ba.weight,
++                self.in_proj_ba.weight_scale, projected_states_ba)
++        else:
++            # Fallback to standard ColumnParallelLinear
++            projected_states_qkvz, _ = self.in_proj_qkvz(hidden_states)
++            projected_states_ba, _ = self.in_proj_ba(hidden_states)
 +
 +        # ============================================================
 +        # Part 2: Core Attention
 +        # ============================================================
 +        forward_context = get_forward_context()
 +        attn_metadata: AttentionMetadata = forward_context.attn_metadata
-+        core_attn_out = torch.zeros(
-+            (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
-+            dtype=hidden_states.dtype,
-+            device=hidden_states.device,
-+        )
-+        z = torch.empty_like(core_attn_out)
++        # Use pre-allocated buffers only for bsz=1; otherwise allocate dynamically
++        if is_decode:
++            core_attn_out = self._decode_attn_out_buf
++            z = self._decode_z_buf
++        else:
++            core_attn_out = torch.zeros(
++                (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
++                dtype=hidden_states.dtype,
++                device=hidden_states.device,
++            )
++            z = torch.empty_like(core_attn_out)
 +        if attn_metadata is not None:
 +            attn_metadata = attn_metadata[self.prefix]
-+
-+            # TODO: xpu does not support this param yet
-+            spec_sequence_masks = attn_metadata.spec_sequence_masks
-+            assert spec_sequence_masks is None
-+
-+            conv_weights = self.conv1d.weight.view(
-+                self.conv1d.weight.size(0), self.conv1d.weight.size(2)
-+            )
 +
 +            self_kv_cache = self.kv_cache[forward_context.virtual_engine]
 +            conv_state = self_kv_cache[0]
 +            ssm_state = self_kv_cache[1]
 +
-+            torch.ops._xpu_C.gdn_attention(
-+                core_attn_out,
-+                z,
-+                projected_states_qkvz,
-+                projected_states_ba,
-+                self.num_k_heads,
-+                self.num_v_heads,
-+                self.head_k_dim,
-+                self.head_v_dim,
-+                conv_state=conv_state,
-+                ssm_state=ssm_state,
-+                conv_weights=conv_weights,
-+                conv_bias=self.conv1d.bias,
-+                activation=self.activation,
-+                A_log=self.A_log,
-+                dt_bias=self.dt_bias,
-+                num_prefills=attn_metadata.num_prefills,
-+                num_decodes=attn_metadata.num_decodes,
-+                has_initial_state=attn_metadata.has_initial_state,
-+                non_spec_query_start_loc=attn_metadata.non_spec_query_start_loc,
-+                non_spec_state_indices_tensor=attn_metadata.non_spec_state_indices_tensor,
-+                num_actual_tokens=attn_metadata.num_actual_tokens,
-+                tp_size=self.tp_size,
++            # Cache conv_weights view (shape doesn't change)
++            if self._cached_conv_weights is None:
++                self._cached_conv_weights = self.conv1d.weight.view(
++                    self.conv1d.weight.size(0), self.conv1d.weight.size(2)
++                )
++            conv_weights = self._cached_conv_weights
++
++            _use_esimd_gdn = (
++                attn_metadata.num_prefills == 0
++                and attn_metadata.num_decodes > 0
++                and attn_metadata.num_decodes <= 128
 +            )
 +
++            if _use_esimd_gdn:
++                N_dec = attn_metadata.num_decodes
++                state_idx = attn_metadata.non_spec_state_indices_tensor[:N_dec]
++
++                esimd_gdn_conv_fused(
++                    projected_states_qkvz,
++                    conv_state,
++                    conv_weights,
++                    self.conv_bias_zeros,
++                    state_idx,
++                    self.A_log,
++                    self.dt_bias,
++                    projected_states_ba,
++                    ssm_state,
++                    state_idx,
++                    core_attn_out,
++                    z,
++                    N_dec,
++                    self._cached_nk_tp,
++                    self._cached_nv_tp,
++                    self.head_k_dim,
++                    self.head_v_dim,
++                    self._cached_attn_scale,
++                )
++
++            else:
++                # Prefill: XPU C++ kernel
++                spec_sequence_masks = attn_metadata.spec_sequence_masks
++                assert spec_sequence_masks is None
++
++                torch.ops._xpu_C.gdn_attention(
++                    core_attn_out,
++                    z,
++                    projected_states_qkvz,
++                    projected_states_ba,
++                    self.num_k_heads,
++                    self.num_v_heads,
++                    self.head_k_dim,
++                    self.head_v_dim,
++                    conv_state=conv_state,
++                    ssm_state=ssm_state,
++                    conv_weights=conv_weights,
++                    conv_bias=self.conv1d.bias,
++                    activation=self.activation,
++                    A_log=self.A_log,
++                    dt_bias=self.dt_bias,
++                    num_prefills=attn_metadata.num_prefills,
++                    num_decodes=attn_metadata.num_decodes,
++                    has_initial_state=attn_metadata.has_initial_state,
++                    non_spec_query_start_loc=attn_metadata.non_spec_query_start_loc,
++                    non_spec_state_indices_tensor=attn_metadata.non_spec_state_indices_tensor,
++                    num_actual_tokens=attn_metadata.num_actual_tokens,
++                    tp_size=self.tp_size,
++                )
++
 +        # ============================================================
-+        # Part 3: Output Projection
++        # Part 3: Output Projection (forward_xpu)
 +        # ============================================================
-+        z_shape_og = z.shape
-+        # Reshape input data into 2D tensor
-+        core_attn_out = core_attn_out.reshape(-1, core_attn_out.shape[-1])
-+        z = z.reshape(-1, z.shape[-1])
-+        core_attn_out = self.norm(core_attn_out, z)
-+        core_attn_out = core_attn_out.reshape(z_shape_og)
-+        core_attn_out = rearrange(core_attn_out, "... h d -> ... (h d)")
-+        output[:num_tokens], _ = self.out_proj(core_attn_out)
++        if is_decode:
++            # Decode fast path: fused RMSNormGated + out_proj GEMV
++            nv_tp = self._cached_nv_tp
++            hv = self.head_v_dim
++            if self._norm_weight_fp16 is None:
++                self._norm_weight_fp16 = self.norm.weight.data.half()
++            esimd_norm_gemv_fp8_pert(
++                core_attn_out.view(nv_tp, hv),
++                z.view(nv_tp, hv),
++                self._norm_weight_fp16,
++                self.out_proj.weight,
++                self.out_proj.weight_scale,
++                self._decode_outproj_buf,
++                nv_tp, hv, self.norm.eps,
++            )
++            output[:1] = tensor_model_parallel_all_reduce(
++                self._decode_outproj_buf)
++        else:
++            z_shape_og = z.shape
++            core_attn_out = core_attn_out.reshape(-1, core_attn_out.shape[-1])
++            z = z.reshape(-1, z.shape[-1])
++            core_attn_out = self.norm(core_attn_out, z)
++            core_attn_out = core_attn_out.reshape(z_shape_og)
++            core_attn_out = rearrange(core_attn_out, "... h d -> ... (h d)")
++            output[:num_tokens], _ = self.out_proj(core_attn_out)
++
++    def forward_xpu_with_precomputed_proj(
++        self,
++        projected_states_qkvz: torch.Tensor,
++        projected_states_ba: torch.Tensor,
++        output: torch.Tensor,
++    ):
++        """Decode-only fast path: input projection already done by caller."""
++        # Part 2: Core Attention (reuse decode path from forward_xpu)
++        forward_context = get_forward_context()
++        attn_metadata: AttentionMetadata = forward_context.attn_metadata
++        core_attn_out = self._decode_attn_out_buf
++        z = self._decode_z_buf
++        if attn_metadata is not None:
++            attn_metadata = attn_metadata[self.prefix]
++            self_kv_cache = self.kv_cache[forward_context.virtual_engine]
++            conv_state = self_kv_cache[0]
++            ssm_state = self_kv_cache[1]
++            if self._cached_conv_weights is None:
++                self._cached_conv_weights = self.conv1d.weight.view(
++                    self.conv1d.weight.size(0), self.conv1d.weight.size(2))
++            N_dec = attn_metadata.num_decodes
++            state_idx = attn_metadata.non_spec_state_indices_tensor[:N_dec]
++            esimd_gdn_conv_fused(
++                projected_states_qkvz, conv_state,
++                self._cached_conv_weights, self.conv_bias_zeros, state_idx,
++                self.A_log, self.dt_bias, projected_states_ba,
++                ssm_state, state_idx, core_attn_out, z,
++                N_dec, self._cached_nk_tp, self._cached_nv_tp,
++                self.head_k_dim, self.head_v_dim, self._cached_attn_scale,
++            )
++
++        # Part 3: Output Projection (fused norm + GEMV)
++        nv_tp = self._cached_nv_tp
++        hv = self.head_v_dim
++        if self._norm_weight_fp16 is None:
++            self._norm_weight_fp16 = self.norm.weight.data.half()
++        esimd_norm_gemv_fp8_pert(
++            core_attn_out.view(nv_tp, hv), z.view(nv_tp, hv),
++            self._norm_weight_fp16,
++            self.out_proj.weight, self.out_proj.weight_scale,
++            self._decode_outproj_buf, nv_tp, hv, self.norm.eps,
++        )
++        output[:1] = tensor_model_parallel_all_reduce(
++            self._decode_outproj_buf)
 +
 +    def forward_cuda(
 +        self,
@@ -9597,7 +12384,491 @@ index 0f73a7746..b4bca126e 100644
      ):
          """
          Forward pass with three parts:
-@@ -965,7 +1057,7 @@ class Qwen3NextModel(nn.Module):
+@@ -778,42 +1095,204 @@ class Qwen3NextAttention(nn.Module):
+         self.q_norm = Qwen3NextRMSNorm(self.head_dim, eps=config.rms_norm_eps)
+         self.k_norm = Qwen3NextRMSNorm(self.head_dim, eps=config.rms_norm_eps)
+ 
++        # Cache env flag for ESIMD QKV kernel
++        self._esimd_qkv_enabled = (
++            os.environ.get("DISABLE_ESIMD_QKV", "0") != "1"
++        )
++
++        # FP8 detection: buffers always allocated for FP8 (used by both opt2 and opt3)
++        # Set DISABLE_ESIMD_ATTN_GEMV=1 to disable opt2 (qkv/o GEMV in forward)
++        self._is_fp8 = (
++            quant_config is not None
++            and quant_config.get_name() == "fp8"
++        )
++        self._use_esimd_attn_gemv = (
++            self._is_fp8
++            and os.environ.get("DISABLE_ESIMD_ATTN_GEMV", "0") != "1"
++        )
++        if self._is_fp8:
++            _dev = current_platform.current_device()
++            # qkv_proj output size (after TP sharding)
++            _qkv_out = self.q_size * (1 + self.attn_output_gate) + 2 * self.kv_size
++            self._decode_qkv_buf = torch.empty(
++                1, _qkv_out, dtype=torch.float16, device=_dev)
++            # o_proj output size
++            self._decode_o_buf = torch.empty(
++                1, config.hidden_size, dtype=torch.float16, device=_dev)
++
+     def forward(
+         self,
+         positions: torch.Tensor,
+         output: torch.Tensor,
+         hidden_states: torch.Tensor,
+     ):
+-        qkv, _ = self.qkv_proj(hidden_states)
++        _ntoks = hidden_states.shape[0]
++
++        # ---- qkv_proj: ESIMD GEMV (M=1) / GEMM (M=2-128) ----
++        if _ntoks == 1 and self._use_esimd_attn_gemv:
++            esimd_gemv_fp8_pert(
++                hidden_states,
++                self.qkv_proj.weight,
++                self.qkv_proj.weight_scale,
++                self._decode_qkv_buf)
++            qkv = self._decode_qkv_buf
++        elif _ntoks <= 128 and self._use_esimd_attn_gemv:
++            qkv = torch.empty(
++                _ntoks, self.qkv_proj.weight.shape[0],
++                dtype=torch.float16, device=hidden_states.device)
++            esimd_gemm_fp8_pert(
++                hidden_states,
++                self.qkv_proj.weight,
++                self.qkv_proj.weight_scale,
++                qkv)
++        else:
++            qkv, _ = self.qkv_proj(hidden_states)
++
++        # ---- QKV split + norm + RoPE ----
++        if _ntoks <= 128 and self._esimd_qkv_enabled:
++            # ESIMD fused kernel: split + RMSNorm + RoPE + sigmoid(gate)
++            q = torch.empty(
++                (_ntoks, self.q_size), dtype=torch.float16,
++                device=hidden_states.device,
++            )
++            gate = torch.empty(
++                (_ntoks, self.q_size), dtype=torch.float16,
++                device=hidden_states.device,
++            )
++            k = torch.empty(
++                (_ntoks, self.kv_size), dtype=torch.float16,
++                device=hidden_states.device,
++            )
++            v = torch.empty(
++                (_ntoks, self.kv_size), dtype=torch.float16,
++                device=hidden_states.device,
++            )
++            esimd_qkv_split_norm_rope(
++                qkv,
++                q, gate, k, v,
++                self.q_norm.weight,
++                self.k_norm.weight,
++                positions.to(torch.int32),
++                self.num_heads,
++                self.num_kv_heads,
++                self.attn_output_gate,
++                int(self.head_dim * getattr(self.config, "partial_rotary_factor", 1.0)),
++                self.rotary_emb.cos_sin_cache,
++            )
++        else:
++            if self.attn_output_gate:
++                q_gate, k, v = qkv.split(
++                    [self.q_size * 2, self.kv_size, self.kv_size], dim=-1
++                )
++                orig_shape = q_gate.shape[:-1]
++                q_gate = q_gate.view(*orig_shape, self.num_heads, -1)
++                q, gate = torch.chunk(q_gate, 2, dim=-1)
++                q = q.reshape(*orig_shape, -1)
++                gate = gate.reshape(*orig_shape, -1)
++            else:
++                q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+ 
+-        if self.attn_output_gate:
+-            q_gate, k, v = qkv.split(
+-                [self.q_size * 2, self.kv_size, self.kv_size], dim=-1
++            q = self.q_norm(q.view(-1, self.num_heads, self.head_dim)).view(
++                -1, self.num_heads * self.head_dim
++            )
++            k = self.k_norm(k.view(-1, self.num_kv_heads, self.head_dim)).view(
++                -1, self.num_kv_heads * self.head_dim
+             )
+-            orig_shape = q_gate.shape[:-1]
+-            q_gate = q_gate.view(*orig_shape, self.num_heads, -1)
+-            q, gate = torch.chunk(q_gate, 2, dim=-1)
+-            q = q.reshape(*orig_shape, -1)
+-            gate = gate.reshape(*orig_shape, -1)
++
++            q, k = self.rotary_emb(positions, q, k)
++
++            # Fallback path: gate needs sigmoid (ESIMD kernel already applies it)
++            if self.attn_output_gate:
++                gate = torch.sigmoid(gate)
++
++        attn_output = self.attn(q, k, v)
++
++        if self.attn_output_gate:
++            attn_output = attn_output * gate
++
++        # ---- o_proj: ESIMD GEMV (M=1) / GEMM (M=2-128) ----
++        if _ntoks == 1 and self._use_esimd_attn_gemv:
++            esimd_gemv_fp8_pert(
++                attn_output,
++                self.o_proj.weight,
++                self.o_proj.weight_scale,
++                self._decode_o_buf)
++            output[:1] = tensor_model_parallel_all_reduce(
++                self._decode_o_buf)
++        elif _ntoks <= 128 and self._use_esimd_attn_gemv:
++            o_out = torch.empty(
++                _ntoks, self.o_proj.weight.shape[0],
++                dtype=torch.float16, device=hidden_states.device)
++            esimd_gemm_fp8_pert(
++                attn_output,
++                self.o_proj.weight,
++                self.o_proj.weight_scale,
++                o_out)
++            output[:] = tensor_model_parallel_all_reduce(o_out)
+         else:
+-            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
++            output[:], _ = self.o_proj(attn_output)
+ 
+-        q = self.q_norm(q.view(-1, self.num_heads, self.head_dim)).view(
+-            -1, self.num_heads * self.head_dim
+-        )
+-        k = self.k_norm(k.view(-1, self.num_kv_heads, self.head_dim)).view(
+-            -1, self.num_kv_heads * self.head_dim
+-        )
++    def forward_with_precomputed_qkv(
++        self,
++        qkv: torch.Tensor,
++        positions: torch.Tensor,
++        output: torch.Tensor,
++    ):
++        """Decode-only fast path: qkv_proj already done by caller."""
++        if self._esimd_qkv_enabled:
++            # ESIMD fused kernel: split + RMSNorm + RoPE + sigmoid(gate)
++            q = torch.empty(
++                (1, self.q_size), dtype=torch.float16, device=qkv.device)
++            gate = torch.empty(
++                (1, self.q_size), dtype=torch.float16, device=qkv.device)
++            k = torch.empty(
++                (1, self.kv_size), dtype=torch.float16, device=qkv.device)
++            v = torch.empty(
++                (1, self.kv_size), dtype=torch.float16, device=qkv.device)
++            esimd_qkv_split_norm_rope(
++                qkv, q, gate, k, v,
++                self.q_norm.weight, self.k_norm.weight,
++                positions.to(torch.int32),
++                self.num_heads, self.num_kv_heads,
++                self.attn_output_gate,
++                int(self.head_dim * getattr(self.config, "partial_rotary_factor", 1.0)),
++                self.rotary_emb.cos_sin_cache,
++            )
++        else:
++            # Standard split + norm + RoPE fallback
++            if self.attn_output_gate:
++                q_gate, k, v = qkv.split(
++                    [self.q_size * 2, self.kv_size, self.kv_size], dim=-1)
++                orig_shape = q_gate.shape[:-1]
++                q_gate = q_gate.view(*orig_shape, self.num_heads, -1)
++                q, gate = torch.chunk(q_gate, 2, dim=-1)
++                q = q.reshape(*orig_shape, -1)
++                gate = gate.reshape(*orig_shape, -1)
++            else:
++                q, k, v = qkv.split(
++                    [self.q_size, self.kv_size, self.kv_size], dim=-1)
+ 
+-        q, k = self.rotary_emb(positions, q, k)
++            q = self.q_norm(q.view(-1, self.num_heads, self.head_dim)).view(
++                -1, self.num_heads * self.head_dim)
++            k = self.k_norm(k.view(-1, self.num_kv_heads, self.head_dim)).view(
++                -1, self.num_kv_heads * self.head_dim)
++            q, k = self.rotary_emb(positions, q, k)
++            if self.attn_output_gate:
++                gate = torch.sigmoid(gate)
+ 
+         attn_output = self.attn(q, k, v)
+ 
+         if self.attn_output_gate:
+-            gate = torch.sigmoid(gate)
+             attn_output = attn_output * gate
+ 
+-        output[:], _ = self.o_proj(attn_output)
++        # o_proj GEMV + all_reduce
++        esimd_gemv_fp8_pert(
++            attn_output,
++            self.o_proj.weight,
++            self.o_proj.weight_scale,
++            self._decode_o_buf)
++        output[:1] = tensor_model_parallel_all_reduce(
++            self._decode_o_buf)
+ 
+ 
+ class Qwen3NextDecoderLayer(nn.Module):
+@@ -900,6 +1379,74 @@ class Qwen3NextDecoderLayer(nn.Module):
+                 ),
+             )
+ 
++        # Detect dense MLP with FP8 quantization for ESIMD fast path
++        self._dense_mlp_fp8 = (
++            isinstance(self.mlp, Qwen3NextMLP)
++            and self.mlp.expert_gate is None
++            and quant_config is not None
++            and quant_config.get_name() == "fp8"
++            and os.environ.get("DISABLE_ESIMD_DENSE", "0") != "1"
++        )
++        if self._dense_mlp_fp8:
++            _dev = current_platform.current_device()
++            tp_size = get_tensor_model_parallel_world_size()
++            _inter_tp = config.intermediate_size // tp_size
++            _hidden = config.hidden_size
++            # Pre-allocate decode buffers (bsz=1)
++            self._dense_gate_up_buf = torch.empty(
++                1, 2 * _inter_tp, dtype=torch.float16, device=_dev)
++            self._dense_down_buf = torch.empty(
++                1, _hidden, dtype=torch.float16, device=_dev)
++            self._dense_normed_buf = torch.empty(
++                1, _hidden, dtype=torch.float16, device=_dev)
++            # Lazily cached after weights are loaded
++            self._dense_post_norm_w_fp16 = None
++
++        # Detect MoE with FP8 for ESIMD fused norm+router path
++        self._moe_fp8 = (
++            isinstance(self.mlp, Qwen3NextSparseMoeBlock)
++            and hasattr(self.mlp, 'use_fp8')
++            and self.mlp.use_fp8
++        )
++        if self._moe_fp8:
++            _dev = current_platform.current_device()
++            n_exp = self.mlp.gate.weight.shape[0]
++            self._post_norm_w_fp16 = None  # lazily cached
++            self._router_buf = torch.empty(
++                1, n_exp, dtype=torch.float16, device=_dev)
++            self._normed_buf = torch.empty(
++                1, config.hidden_size, dtype=torch.float16, device=_dev)
++
++        # Detect fused input_norm + input_proj opportunity (FP8, decode)
++        # Set DISABLE_ESIMD_FUSED_INPUT=1 to disable this optimization
++        _is_fp8 = (quant_config is not None
++                    and quant_config.get_name() == "fp8")
++        self._fused_input_norm = (
++            _is_fp8 and not self.layer_scale
++            and os.environ.get("DISABLE_ESIMD_FUSED_INPUT", "0") != "1"
++        )
++        if self._fused_input_norm:
++            _dev = current_platform.current_device()
++            _hidden = config.hidden_size
++            self._input_norm_w_fp16 = None  # lazily cached
++            if self.layer_type == "linear_attention":
++                # GDN: fuse norm + in_proj_qkvz + in_proj_ba (2 GEMVs)
++                tp_size = get_tensor_model_parallel_world_size()
++                _qkvz_sz = self.linear_attn.projection_size_qkvz // tp_size
++                _ba_sz = self.linear_attn.projection_size_ba // tp_size
++                self._fused_qkvz_buf = torch.empty(
++                    1, _qkvz_sz, dtype=torch.float16, device=_dev)
++                self._fused_ba_buf = torch.empty(
++                    1, _ba_sz, dtype=torch.float16, device=_dev)
++            elif self.layer_type == "full_attention":
++                # Full Attn: fuse norm + qkv_proj (1 GEMV)
++                _qkv_sz = self.self_attn.qkv_proj.weight.shape[0]
++                self._fused_qkv_buf = torch.empty(
++                    1, _qkv_sz, dtype=torch.float16, device=_dev)
++                # normed_out buffer (needed by kernel, not used later)
++                self._fused_normed_buf = torch.empty(
++                    1, _hidden, dtype=torch.float16, device=_dev)
++
+     def forward(
+         self,
+         hidden_states: torch.Tensor,
+@@ -907,27 +1454,78 @@ class Qwen3NextDecoderLayer(nn.Module):
+         positions: torch.Tensor = None,
+         **kwargs: object,
+     ):
+-        if residual is None:
+-            residual = hidden_states
+-            hidden_states = self.input_layernorm(hidden_states)
+-        else:
+-            hidden_states, residual = self.input_layernorm(hidden_states, residual)
++        n_tok = hidden_states.shape[0]
++
++        # ---- Fused input_norm + input_proj for decode (M=1) ----
++        if (n_tok == 1 and self._fused_input_norm
++                and residual is not None):
++            if self._input_norm_w_fp16 is None:
++                self._input_norm_w_fp16 = \
++                    (self.input_layernorm.weight.data + 1.0).half()
++            _eps = self.input_layernorm.variance_epsilon
++
++            if self.layer_type == "linear_attention":
++                # Separate norm + fused 2-GEMV (fused norm kernel inaccurate)
++                gdn = self.linear_attn
++                hidden_states, residual = self.input_layernorm(
++                    hidden_states, residual)
++                esimd_gemv_fp8_pert_fused2(
++                    hidden_states,
++                    gdn.in_proj_qkvz.weight,
++                    gdn.in_proj_qkvz.weight_scale,
++                    self._fused_qkvz_buf,
++                    gdn.in_proj_ba.weight,
++                    gdn.in_proj_ba.weight_scale,
++                    self._fused_ba_buf,
++                )
++                # Pass pre-computed projections; skip input_proj in GDN
++                self_attention_output = torch.empty_like(hidden_states)
++                gdn.forward_xpu_with_precomputed_proj(
++                    self._fused_qkvz_buf, self._fused_ba_buf,
++                    self_attention_output)
++
++            elif self.layer_type == "full_attention":
++                # Separate norm + ESIMD GEMV (fused kernel inaccurate for large N)
++                attn = self.self_attn
++                hidden_states, residual = self.input_layernorm(
++                    hidden_states, residual)
++                esimd_gemv_fp8_pert(
++                    hidden_states,
++                    attn.qkv_proj.weight,
++                    attn.qkv_proj.weight_scale,
++                    self._fused_qkv_buf)
++                self_attention_output = torch.empty_like(hidden_states)
++                attn.forward_with_precomputed_qkv(
++                    self._fused_qkv_buf, positions,
++                    self_attention_output)
++            else:
++                raise ValueError("Invalid layer_type")
++            hidden_states = self_attention_output
+ 
+-        self_attention_output = torch.empty_like(hidden_states)
+-        if self.layer_type == "linear_attention":
+-            self.linear_attn(
+-                hidden_states=hidden_states,
+-                output=self_attention_output,
+-            )
+-        elif self.layer_type == "full_attention":
+-            self.self_attn(
+-                hidden_states=hidden_states,
+-                output=self_attention_output,
+-                positions=positions,
+-            )
++        # ---- Standard path ----
+         else:
+-            raise ValueError("Invalid layer_type")
+-        hidden_states = self_attention_output
++            if residual is None:
++                residual = hidden_states
++                hidden_states = self.input_layernorm(hidden_states)
++            else:
++                hidden_states, residual = self.input_layernorm(
++                    hidden_states, residual)
++
++            self_attention_output = torch.empty_like(hidden_states)
++            if self.layer_type == "linear_attention":
++                self.linear_attn(
++                    hidden_states=hidden_states,
++                    output=self_attention_output,
++                )
++            elif self.layer_type == "full_attention":
++                self.self_attn(
++                    hidden_states=hidden_states,
++                    output=self_attention_output,
++                    positions=positions,
++                )
++            else:
++                raise ValueError("Invalid layer_type")
++            hidden_states = self_attention_output
+ 
+         if self.layer_scale:
+             if len(hidden_states.shape) == 2:
+@@ -939,9 +1537,83 @@ class Qwen3NextDecoderLayer(nn.Module):
+                     self.attn_layer_scale.to(hidden_states.dtype) + 1
+                 )
+ 
+-        # Fully Connected
+-        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+-        hidden_states = self.mlp(hidden_states)
++        n_tokens = hidden_states.shape[0]
++
++        # ---- Dense MLP ESIMD fast path (FP8 decode / small batch) ----
++        if (self._dense_mlp_fp8 and not self.layer_scale
++                and n_tokens <= 128):
++            if self._dense_post_norm_w_fp16 is None:
++                self._dense_post_norm_w_fp16 = \
++                    (self.post_attention_layernorm.weight.data + 1.0).half()
++
++            if n_tokens == 1:
++                # Decode: fused resadd + norm + gate_up GEMV (one kernel)
++                esimd_resadd_norm_gemv_fp8_pert(
++                    hidden_states, residual,
++                    self._dense_post_norm_w_fp16,
++                    self.mlp.gate_up_proj.weight,
++                    self.mlp.gate_up_proj.weight_scale,
++                    self._dense_gate_up_buf,
++                    self._dense_normed_buf,
++                    self.post_attention_layernorm.variance_epsilon,
++                )
++                # SiluAndMul
++                act_out = self.mlp.act_fn(self._dense_gate_up_buf)
++                # down_proj GEMV
++                esimd_gemv_fp8_pert(
++                    act_out,
++                    self.mlp.down_proj.weight,
++                    self.mlp.down_proj.weight_scale,
++                    self._dense_down_buf)
++                hidden_states = tensor_model_parallel_all_reduce(
++                    self._dense_down_buf)
++            else:
++                # Small batch (M=2-128): norm + ESIMD GEMM
++                hidden_states, residual = self.post_attention_layernorm(
++                    hidden_states, residual)
++                gate_up_out = torch.empty(
++                    n_tokens, self.mlp.gate_up_proj.weight.shape[0],
++                    dtype=torch.float16, device=hidden_states.device)
++                esimd_gemm_fp8_pert(
++                    hidden_states,
++                    self.mlp.gate_up_proj.weight,
++                    self.mlp.gate_up_proj.weight_scale,
++                    gate_up_out)
++                act_out = self.mlp.act_fn(gate_up_out)
++                down_out = torch.empty(
++                    n_tokens, self.mlp.down_proj.weight.shape[0],
++                    dtype=torch.float16, device=hidden_states.device)
++                esimd_gemm_fp8_pert(
++                    act_out,
++                    self.mlp.down_proj.weight,
++                    self.mlp.down_proj.weight_scale,
++                    down_out)
++                hidden_states = tensor_model_parallel_all_reduce(down_out)
++
++        # ---- MoE fused post_attn_norm + router for decode (bsz=1) ----
++        elif (n_tokens == 1 and self._moe_fp8 and not self.layer_scale):
++            if self._post_norm_w_fp16 is None:
++                self._post_norm_w_fp16 = \
++                    (self.post_attention_layernorm.weight.data + 1.0).half()
++            esimd_resadd_norm_gemv_fp8_pert(
++                hidden_states, residual,
++                self._post_norm_w_fp16,
++                self.mlp.gate.weight,
++                self.mlp.gate.weight_scale,
++                self._router_buf,
++                self._normed_buf,
++                self.post_attention_layernorm.variance_epsilon,
++            )
++            # Pass pre-computed router logits to MoE via attribute
++            self.mlp._precomputed_router_logits = self._router_buf
++            hidden_states = self._normed_buf
++            hidden_states = self.mlp(hidden_states)
++
++        # ---- Standard path ----
++        else:
++            hidden_states, residual = self.post_attention_layernorm(
++                hidden_states, residual)
++            hidden_states = self.mlp(hidden_states)
+ 
+         if self.layer_scale:
+             if len(hidden_states.shape) == 2:
+@@ -965,7 +1637,7 @@ class Qwen3NextModel(nn.Module):
      def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
          super().__init__()
  
@@ -9606,7 +12877,7 @@ index 0f73a7746..b4bca126e 100644
          parallel_config = vllm_config.parallel_config
  
          eplb_config = parallel_config.eplb_config
-@@ -1042,7 +1134,7 @@ class Qwen3NextModel(nn.Module):
+@@ -1042,7 +1714,7 @@ class Qwen3NextModel(nn.Module):
              ckpt_gate_proj_name="gate_proj",
              ckpt_down_proj_name="down_proj",
              ckpt_up_proj_name="up_proj",
@@ -9615,7 +12886,7 @@ index 0f73a7746..b4bca126e 100644
              num_redundant_experts=self.num_redundant_experts,
          )
  
-@@ -1201,7 +1293,7 @@ class Qwen3NextForCausalLM(
+@@ -1201,15 +1873,17 @@ class Qwen3NextForCausalLM(
      }
  
      def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
@@ -9624,7 +12895,20 @@ index 0f73a7746..b4bca126e 100644
          self.vllm_config = vllm_config
          self.model_config = vllm_config.model_config
          cache_config = vllm_config.cache_config
-@@ -1263,7 +1355,7 @@ class Qwen3NextForCausalLM(
+ 
+         scheduler_config = vllm_config.scheduler_config
+-        assert not cache_config.enable_prefix_caching, (
+-            "Qwen3Next currently does not support prefix caching"
+-        )
++        if cache_config.mamba_cache_mode == "all":
++            raise NotImplementedError(
++                "Qwen3Next currently does not support 'all' prefix caching, "
++                "please use '--mamba-cache-mode=align' instead"
++            )
+         self.quant_config = vllm_config.quant_config
+ 
+         super().__init__()
+@@ -1263,7 +1937,7 @@ class Qwen3NextForCausalLM(
          cls, vllm_config: "VllmConfig"
      ) -> tuple[tuple[int, int], tuple[int, int]]:
          parallel_config = vllm_config.parallel_config
@@ -9633,6 +12917,36 @@ index 0f73a7746..b4bca126e 100644
          tp_size = parallel_config.tensor_parallel_size
          num_spec = (
              vllm_config.speculative_config.num_speculative_tokens
+@@ -1280,6 +1954,10 @@ class Qwen3NextForCausalLM(
+             num_spec,
+         )
+ 
++    @classmethod
++    def get_mamba_state_copy_func(cls) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:
++        return MambaStateCopyFuncCalculator.gated_delta_net_state_copy_func()
++
+     def compute_logits(
+         self,
+         hidden_states: torch.Tensor,
+diff --git a/vllm/model_executor/models/qwen3_next_mtp.py b/vllm/model_executor/models/qwen3_next_mtp.py
+index 565fd7d8f..854d7f9a7 100644
+--- a/vllm/model_executor/models/qwen3_next_mtp.py
++++ b/vllm/model_executor/models/qwen3_next_mtp.py
+@@ -234,9 +234,11 @@ class Qwen3NextMTP(nn.Module, QwenNextMixtureOfExperts):
+         config = vllm_config.model_config.hf_config
+         self.vllm_config = vllm_config
+         cache_config = vllm_config.cache_config
+-        assert not cache_config.enable_prefix_caching, (
+-            "Qwen3NextMTP currently does not support prefix caching"
+-        )
++        if cache_config.mamba_cache_mode == "all":
++            raise NotImplementedError(
++                "Qwen3NextMTP currently does not support 'all' prefix caching, "
++                "please use '--mamba-cache-mode=align' instead"
++            )
+ 
+         self.quant_config = vllm_config.quant_config
+ 
 diff --git a/vllm/model_executor/models/qwen3_vl_moe.py b/vllm/model_executor/models/qwen3_vl_moe.py
 index 318680448..e89a4441f 100644
 --- a/vllm/model_executor/models/qwen3_vl_moe.py
@@ -9800,6 +13114,30 @@ index 1bda00653..d70addc8f 100644
              )
          else:
              self.attn = attn_cls(
+diff --git a/vllm/model_executor/models/zamba2.py b/vllm/model_executor/models/zamba2.py
+index b5132cd86..59a8520f7 100644
+--- a/vllm/model_executor/models/zamba2.py
++++ b/vllm/model_executor/models/zamba2.py
+@@ -32,6 +32,8 @@ from vllm.model_executor.layers.linear import (
+ from vllm.model_executor.layers.logits_processor import LogitsProcessor
+ from vllm.model_executor.layers.mamba.mamba_mixer2 import MambaMixer2
+ from vllm.model_executor.layers.mamba.mamba_utils import (
++    MambaStateCopyFunc,
++    MambaStateCopyFuncCalculator,
+     MambaStateDtypeCalculator,
+     MambaStateShapeCalculator,
+ )
+@@ -891,6 +893,10 @@ class Zamba2ForCausalLM(nn.Module, HasInnerState, IsHybrid, SupportsMambaPrefixC
+             conv_kernel=hf_config.mamba_d_conv,
+         )
+ 
++    @classmethod
++    def get_mamba_state_copy_func(cls) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:
++        return MambaStateCopyFuncCalculator.mamba2_state_copy_func()
++
+     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+         """Initialize the Zamba2 model for causal language modeling.
+ 
 diff --git a/vllm/multimodal/processing.py b/vllm/multimodal/processing.py
 index 8e3f32698..b8c4ba1af 100644
 --- a/vllm/multimodal/processing.py
@@ -9958,6 +13296,44 @@ index b2d7bf38d..1c0bc445f 100644
  
      @classmethod
      def is_data_center_gpu(cls) -> bool:
+diff --git a/vllm/profiler/wrapper.py b/vllm/profiler/wrapper.py
+index f891a88f9..256300932 100644
+--- a/vllm/profiler/wrapper.py
++++ b/vllm/profiler/wrapper.py
+@@ -144,6 +144,19 @@ TorchProfilerActivityMap = {
+ }
+ 
+ 
++def get_torch_profiler_trace_handler(
++    profiler_config: ProfilerConfig,
++    worker_name: str,
++):
++    if not profiler_config.torch_profiler_save_traces:
++        return None
++    return torch.profiler.tensorboard_trace_handler(
++        profiler_config.torch_profiler_dir,
++        worker_name=worker_name,
++        use_gzip=profiler_config.torch_profiler_use_gzip,
++    )
++
++
+ class TorchProfilerWrapper(WorkerProfiler):
+     def __init__(
+         self,
+@@ -179,10 +192,9 @@ class TorchProfilerWrapper(WorkerProfiler):
+             profile_memory=profiler_config.torch_profiler_with_memory,
+             with_stack=profiler_config.torch_profiler_with_stack,
+             with_flops=profiler_config.torch_profiler_with_flops,
+-            on_trace_ready=torch.profiler.tensorboard_trace_handler(
+-                torch_profiler_trace_dir,
+-                worker_name=worker_name,
+-                use_gzip=profiler_config.torch_profiler_use_gzip,
++            on_trace_ready=get_torch_profiler_trace_handler(
++                profiler_config,
++                worker_name,
+             ),
+         )
+ 
 diff --git a/vllm/tokenizers/bpe_qwen.py b/vllm/tokenizers/bpe_qwen.py
 new file mode 100644
 index 000000000..170f31d96
@@ -11042,6 +14418,19 @@ index 000000000..874acf967
 +    "validate_request_params",
 +    "BPEQwenTokenizer"
 +]
+diff --git a/vllm/utils/math_utils.py b/vllm/utils/math_utils.py
+index bdfa5fd2c..b3707c0a7 100644
+--- a/vllm/utils/math_utils.py
++++ b/vllm/utils/math_utils.py
+@@ -30,3 +30,8 @@ def round_up(x: int, y: int) -> int:
+ def round_down(x: int, y: int) -> int:
+     """Round down x to the nearest multiple of y."""
+     return (x // y) * y
++
++
++def largest_power_of_2_divisor(n: int) -> int:
++    """Return the largest power-of-2 that divides *n* (isolate lowest set bit)."""
++    return n & (-n)
 diff --git a/vllm/utils/network_utils.py b/vllm/utils/network_utils.py
 index 80ff0df28..7d01533cb 100644
 --- a/vllm/utils/network_utils.py
@@ -11077,6 +14466,37 @@ index 80ff0df28..7d01533cb 100644
  
      if scheme == "tcp" and not all((host, port)):
          # The host and port fields are required for tcp
+diff --git a/vllm/v1/attention/backend.py b/vllm/v1/attention/backend.py
+index 0fd3d6eb3..dc75478df 100644
+--- a/vllm/v1/attention/backend.py
++++ b/vllm/v1/attention/backend.py
+@@ -83,6 +83,26 @@ class AttentionBackend(ABC):
+     ) -> tuple[int, ...]:
+         raise NotImplementedError
+ 
++    @classmethod
++    def get_kv_cache_block_dim(
++        cls,
++        block_size: int,
++        num_kv_heads: int,
++        head_size: int,
++        cache_dtype_str: str = "auto",
++    ) -> int:
++        """Discover which tensor dim is the block index, since different
++        backends lay out dims differently."""
++        _S = 1234567
++        shape = cls.get_kv_cache_shape(
++            _S,
++            block_size,
++            num_kv_heads,
++            head_size,
++            cache_dtype_str=cache_dtype_str,
++        )
++        return shape.index(_S)
++
+     @staticmethod
+     def get_kv_cache_stride_order(
+         include_num_layers_dimension: bool = False,
 diff --git a/vllm/v1/attention/backends/fa_utils.py b/vllm/v1/attention/backends/fa_utils.py
 index 130d85efb..2f5eb177c 100644
 --- a/vllm/v1/attention/backends/fa_utils.py
@@ -11101,10 +14521,18 @@ index 130d85efb..2f5eb177c 100644
      if current_platform.is_xpu():
          return True
 diff --git a/vllm/v1/attention/backends/flash_attn.py b/vllm/v1/attention/backends/flash_attn.py
-index 6fec5001b..6942491f1 100755
+index 6fec5001b..e28bd677c 100755
 --- a/vllm/v1/attention/backends/flash_attn.py
 +++ b/vllm/v1/attention/backends/flash_attn.py
-@@ -19,6 +19,7 @@ from vllm.v1.attention.backend import (
+@@ -3,6 +3,7 @@
+ """Attention layer with FlashAttention."""
+ 
+ import copy
++import importlib
+ from dataclasses import dataclass
+ from typing import ClassVar
+ 
+@@ -19,6 +20,7 @@ from vllm.v1.attention.backend import (
  )
  from vllm.v1.attention.backends.fa_utils import (
      flash_attn_supports_fp8,
@@ -11112,7 +14540,7 @@ index 6fec5001b..6942491f1 100755
      get_flash_attn_version,
      is_flash_attn_varlen_func_available,
  )
-@@ -39,6 +40,7 @@ from vllm.logger import init_logger
+@@ -39,6 +41,7 @@ from vllm.logger import init_logger
  from vllm.model_executor.layers.batch_invariant import (
      vllm_is_batch_invariant,
  )
@@ -11120,7 +14548,16 @@ index 6fec5001b..6942491f1 100755
  from vllm.platforms.interface import DeviceCapability
  from vllm.utils.math_utils import cdiv
  from vllm.v1.attention.backend import (
-@@ -120,12 +122,20 @@ class FlashAttentionBackend(AttentionBackend):
+@@ -61,6 +64,8 @@ class FlashAttentionBackend(AttentionBackend):
+ 
+     @staticmethod
+     def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
++        if current_platform.is_xpu():
++            return [64]
+         vllm_config = get_current_vllm_config()
+         model_config = vllm_config.model_config
+         cache_config = vllm_config.cache_config
+@@ -120,12 +125,20 @@ class FlashAttentionBackend(AttentionBackend):
          # `stride_order` indicates the permutation that gets
          # us from `get_kv_cache_shape` to the actual memory layout we want.
          cache_layout = get_kv_cache_layout()
@@ -11143,7 +14580,7 @@ index 6fec5001b..6942491f1 100755
              # (num_blocks, num_kv_heads, num_layers, 2, block_size, head_size)
              return (2, 4, 0, 1, 3, 5)
          elif cache_layout == "HND":
-@@ -575,7 +585,7 @@ class FlashAttentionImpl(AttentionImpl):
+@@ -575,7 +588,7 @@ class FlashAttentionImpl(AttentionImpl):
                  "heads in the layer"
              )
  
@@ -11152,11 +14589,48 @@ index 6fec5001b..6942491f1 100755
  
      def forward(
          self,
+@@ -706,6 +719,28 @@ class FlashAttentionImpl(AttentionImpl):
+                 )
+                 return output
+             else:
++                if (
++                    current_platform.is_xpu()
++                    and attn_type == AttentionType.DECODER
++                    and attn_metadata.max_query_len == 1
++                ):
++                    try:
++                        eagle_ops = importlib.import_module("custom_esimd_kernels_vllm.eagle_ops")
++                    except ImportError:
++                        eagle_ops = None
++
++                    if eagle_ops is not None:
++                        eagle_ops.page_attn_decode(
++                            query[:num_actual_tokens],
++                            kv_cache,
++                            block_table,
++                            seqused_k,
++                            output[:num_actual_tokens],
++                            1,
++                            attn_metadata.max_seq_len,
++                        )
++                        return output
++
+                 sliding_window_size = (
+                     list(self.sliding_window)
+                     if self.sliding_window is not None
 diff --git a/vllm/v1/attention/backends/gdn_attn.py b/vllm/v1/attention/backends/gdn_attn.py
-index 426c17689..50845d0af 100644
+index 426c17689..78c35c26d 100644
 --- a/vllm/v1/attention/backends/gdn_attn.py
 +++ b/vllm/v1/attention/backends/gdn_attn.py
-@@ -93,11 +93,16 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
+@@ -16,6 +16,7 @@ from vllm.v1.attention.backend import (
+ from vllm.v1.attention.backends.utils import (
+     PAD_SLOT_ID,
+     compute_causal_conv1d_metadata,
++    mamba_get_block_table_tensor,
+     split_decodes_and_prefills,
+ )
+ from vllm.v1.kv_cache_interface import AttentionSpec, MambaSpec
+@@ -93,11 +94,16 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
          self.decode_cudagraph_max_bs = (
              self.vllm_config.scheduler_config.max_num_seqs * (self.num_spec + 1)
          )
@@ -11177,6 +14651,285 @@ index 426c17689..50845d0af 100644
  
          self.spec_state_indices_tensor = torch.empty(
              (self.decode_cudagraph_max_bs, self.num_spec + 1),
+@@ -153,6 +159,12 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
+         query_start_loc = m.query_start_loc
+         context_lens_tensor = m.compute_num_computed_tokens()
+         nums_dict, batch_ptr, token_chunk_offset_ptr = None, None, None
++        block_table_tensor = mamba_get_block_table_tensor(
++            m.block_table_tensor,
++            m.seq_lens,
++            self.kv_cache_spec,
++            self.vllm_config.cache_config.mamba_cache_mode,
++        )
+ 
+         if (
+             not self.use_spec_decode
+@@ -182,7 +194,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
+             spec_token_indx = None
+             non_spec_token_indx = None
+             spec_state_indices_tensor = None
+-            non_spec_state_indices_tensor = m.block_table_tensor[:, 0]
++            non_spec_state_indices_tensor = block_table_tensor[:, 0]
+             spec_query_start_loc = None
+             non_spec_query_start_loc = query_start_loc
+             num_accepted_tokens = None
+@@ -211,7 +223,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
+                 non_spec_token_indx = torch.empty(
+                     0, dtype=torch.int32, device=query_start_loc.device
+                 )
+-                spec_state_indices_tensor = m.block_table_tensor[:, : self.num_spec + 1]
++                spec_state_indices_tensor = block_table_tensor[:, : self.num_spec + 1]
+                 non_spec_state_indices_tensor = None
+                 spec_query_start_loc = query_start_loc
+                 non_spec_query_start_loc = None
+@@ -224,10 +236,10 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
+                 non_spec_token_indx = index[:num_non_spec_tokens]
+                 spec_token_indx = index[num_non_spec_tokens:]
+ 
+-                spec_state_indices_tensor = m.block_table_tensor[
++                spec_state_indices_tensor = block_table_tensor[
+                     spec_sequence_masks, : self.num_spec + 1
+                 ]
+-                non_spec_state_indices_tensor = m.block_table_tensor[
++                non_spec_state_indices_tensor = block_table_tensor[
+                     ~spec_sequence_masks, 0
+                 ]
+ 
+diff --git a/vllm/v1/attention/backends/linear_attn.py b/vllm/v1/attention/backends/linear_attn.py
+index 4ef565691..02551e704 100644
+--- a/vllm/v1/attention/backends/linear_attn.py
++++ b/vllm/v1/attention/backends/linear_attn.py
+@@ -11,7 +11,10 @@ from vllm.v1.attention.backend import (
+     AttentionMetadataBuilder,
+     CommonAttentionMetadata,
+ )
+-from vllm.v1.attention.backends.utils import split_decodes_and_prefills
++from vllm.v1.attention.backends.utils import (
++    mamba_get_block_table_tensor,
++    split_decodes_and_prefills,
++)
+ from vllm.v1.kv_cache_interface import AttentionSpec, MambaSpec
+ 
+ 
+@@ -57,7 +60,12 @@ class LinearAttentionMetadataBuilder(AttentionMetadataBuilder[LinearAttentionMet
+         query_start_loc = common_attn_metadata.query_start_loc
+         seq_lens = common_attn_metadata.seq_lens
+ 
+-        state_indices_tensor = common_attn_metadata.block_table_tensor[:, 0]
++        state_indices_tensor = mamba_get_block_table_tensor(
++            common_attn_metadata.block_table_tensor,
++            common_attn_metadata.seq_lens,
++            self.kv_cache_spec,
++            self.vllm_config.cache_config.mamba_cache_mode,
++        )[:, 0]
+ 
+         num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
+             split_decodes_and_prefills(
+diff --git a/vllm/v1/attention/backends/mamba_attn.py b/vllm/v1/attention/backends/mamba_attn.py
+index 0c55877a5..e76981faa 100644
+--- a/vllm/v1/attention/backends/mamba_attn.py
++++ b/vllm/v1/attention/backends/mamba_attn.py
+@@ -18,6 +18,7 @@ from vllm.v1.attention.backend import (
+ from vllm.v1.attention.backends.utils import (
+     PAD_SLOT_ID,
+     compute_causal_conv1d_metadata,
++    mamba_get_block_table_tensor,
+     split_decodes_and_prefills,
+ )
+ from vllm.v1.kv_cache_interface import AttentionSpec, MambaSpec
+@@ -41,11 +42,15 @@ class BaseMambaAttentionMetadata:
+ 
+     state_indices_tensor: torch.Tensor
+ 
+-    # The following tensors are only used for prefix caching and are None if disabled
++    # The following tensors are only used for prefix caching in all mode and
++    # are None if disabled
+     block_idx_last_scheduled_token: torch.Tensor | None
+     block_idx_first_scheduled_token_p: torch.Tensor | None
+     block_idx_last_computed_token: torch.Tensor | None
+ 
++    # The following tensor is only used for prefix caching in align mode
++    seq_lens: torch.Tensor
++
+     # The following attributes are for triton implementation of causal_conv1d
+     nums_dict: dict | None = None
+     batch_ptr: torch.Tensor | None = None
+@@ -78,7 +83,7 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
+                 self.compilation_config.max_cudagraph_capture_size,
+             )
+ 
+-        if self.vllm_config.cache_config.enable_prefix_caching:
++        if self.vllm_config.cache_config.mamba_cache_mode == "all":
+             self.state_indices_tensor = torch.empty(
+                 (
+                     self.decode_cudagraph_max_bs,
+@@ -198,7 +203,7 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
+         # for causal_conv1d
+         nums_dict, batch_ptr, token_chunk_offset_ptr = None, None, None
+ 
+-        if self.vllm_config.cache_config.enable_prefix_caching:
++        if self.vllm_config.cache_config.mamba_cache_mode == "all":
+             num_computed_tokens = common_attn_metadata.compute_num_computed_tokens()
+ 
+             # Return a tensor of shape (#requests, #max blocks)
+@@ -214,7 +219,12 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
+             )
+         else:
+             # Always return just a single block per each request:
+-            state_indices_tensor = common_attn_metadata.block_table_tensor[:, 0]
++            state_indices_tensor = mamba_get_block_table_tensor(
++                common_attn_metadata.block_table_tensor,
++                common_attn_metadata.seq_lens,
++                self.kv_cache_spec,
++                self.vllm_config.cache_config.mamba_cache_mode,
++            )[:, 0]
+ 
+         if num_prefills > 0:
+             if num_computed_tokens is None:
+@@ -236,7 +246,7 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
+                 compute_causal_conv1d_metadata(query_start_loc_p)
+             )
+ 
+-            if self.vllm_config.cache_config.enable_prefix_caching:
++            if self.vllm_config.cache_config.mamba_cache_mode == "all":
+                 assert num_computed_tokens is not None
+                 num_computed_tokens_p = num_computed_tokens[
+                     num_reqs - num_prefills : num_reqs
+@@ -255,7 +265,7 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
+             state_indices_tensor = self.state_indices_tensor[:num_decode_tokens]
+             state_indices_tensor[num_decodes:] = PAD_SLOT_ID
+ 
+-            if self.vllm_config.cache_config.enable_prefix_caching:
++            if self.vllm_config.cache_config.mamba_cache_mode == "all":
+                 self.block_idx_last_scheduled_token[:num_decodes].copy_(
+                     block_idx_last_scheduled_token, non_blocking=True
+                 )
+@@ -283,6 +293,7 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
+             block_idx_last_computed_token=block_idx_last_computed_token,
+             num_computed_tokens_p=num_computed_tokens_p,
+             num_reqs=num_reqs,
++            seq_lens=common_attn_metadata.seq_lens,
+             nums_dict=nums_dict,
+             batch_ptr=batch_ptr,
+             token_chunk_offset_ptr=token_chunk_offset_ptr,
+@@ -295,8 +306,16 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
+         slot_mapping: torch.Tensor,
+     ) -> M:
+         new_metadata = copy.copy(metadata)
+-        prefix_caching = self.vllm_config.cache_config.enable_prefix_caching
+-        state_indices_t = blk_table if prefix_caching else blk_table[:, 0]
++        state_indices_t = mamba_get_block_table_tensor(
++            blk_table,
++            metadata.seq_lens,
++            self.kv_cache_spec,
++            self.vllm_config.cache_config.mamba_cache_mode,
++        )
++        if self.vllm_config.cache_config.mamba_cache_mode in ("none", "align"):
++            # Only needs the block that saves the running state
++            state_indices_t = state_indices_t[:, 0]
++
+         num_reqs = blk_table.shape[0]
+ 
+         # For CUDA graphs, copy to persistent buffer
+diff --git a/vllm/v1/attention/backends/utils.py b/vllm/v1/attention/backends/utils.py
+index c549bf7b5..f10d3d080 100644
+--- a/vllm/v1/attention/backends/utils.py
++++ b/vllm/v1/attention/backends/utils.py
+@@ -18,6 +18,7 @@ from typing_extensions import runtime_checkable
+ 
+ from vllm.config import VllmConfig, get_layers_from_vllm_config
+ from vllm.utils.math_utils import cdiv
++from vllm.v1.kv_cache_interface import KVCacheSpec, MambaSpec
+ 
+ if TYPE_CHECKING:
+     from vllm.v1.core.sched.output import SchedulerOutput
+@@ -976,3 +977,72 @@ def get_dcp_local_seq_lens(
+     )
+     dcp_local_seq_lens = base + remainder
+     return dcp_local_seq_lens.squeeze(1)
++
++
++def extend_all_queries_by_1(
++    common_attn_metadata: CommonAttentionMetadata,
++    arange: torch.Tensor,
++    new_slot_mapping: torch.Tensor,
++) -> CommonAttentionMetadata:
++    """
++    Creates a new CommonAttentionMetadata with all query lengths increased by 1.
++    Also all seq lens are increased by 1.
++    This is useful e.g. in speculative decoding with draft models, where we
++    extend each sequence by 1 token.
++    The slot mapping is computed externally, as it requires more information.
++    """
++    cad = common_attn_metadata
++    # query start loc must be increased by [+0, +1, +2, ..., +batch_size]
++    new_query_start_loc = cad.query_start_loc + arange[: len(cad.query_start_loc)]
++    new_query_start_loc_cpu = cad.query_start_loc_cpu + torch.arange(
++        len(cad.query_start_loc_cpu), dtype=torch.int32
++    )
++    new_cad = cad.replace(
++        query_start_loc=new_query_start_loc,
++        query_start_loc_cpu=new_query_start_loc_cpu,
++        seq_lens=cad.seq_lens + 1,
++        # each request is extended by 1 token -> batch_size tokens are added
++        num_actual_tokens=cad.num_actual_tokens + cad.batch_size(),
++        # All query lens increase by 1, so max query len increases by 1
++        max_query_len=cad.max_query_len + 1,
++        max_seq_len=cad.max_seq_len + 1,
++        slot_mapping=new_slot_mapping,
++    )
++    return new_cad
++
++
++def mamba_get_block_table_tensor(
++    block_table: torch.Tensor,
++    seq_lens: torch.Tensor,
++    kv_cache_spec: KVCacheSpec,
++    mamba_cache_mode: str,
++) -> torch.Tensor:
++    """
++    Get the block table tensor for mamba kernels from the input
++    common_attn_metadata.block_table_tensor given different mamba cache modes.
++
++    - "all":   input  (#requests, cdiv(max_model_len, block_size));
++               output (#requests, cdiv(max_model_len, block_size)).
++
++    - "none":  input  (#requests, 1 + num_speculative_blocks);
++               output (#requests, 1 + num_speculative_blocks).
++
++    - "align": input  (#requests, cdiv(max_model_len, block_size));
++               output (#requests, 1 + num_speculative_blocks), which are the last
++               1 + num_speculative_blocks of each request.
++    """
++    if mamba_cache_mode in ("all", "none"):
++        return block_table
++    else:
++        assert isinstance(kv_cache_spec, MambaSpec)
++        # NOTE: For 0-length requests in CUDA graph, use a start_index of 0
++        # to handle the invalid block table.
++        start_indices = torch.clamp(
++            (seq_lens - 1) // kv_cache_spec.block_size,
++            min=0,
++        )
++        offsets = torch.arange(
++            1 + kv_cache_spec.num_speculative_blocks, device=block_table.device
++        )
++        indices_to_gather = start_indices.unsqueeze(1) + offsets
++        return torch.gather(block_table, 1, indices_to_gather)
+diff --git a/vllm/v1/core/block_pool.py b/vllm/v1/core/block_pool.py
+index cf93218a1..ce7e396d8 100644
+--- a/vllm/v1/core/block_pool.py
++++ b/vllm/v1/core/block_pool.py
+@@ -255,7 +255,8 @@ class BlockPool:
+         )
+         for i, blk in enumerate(new_full_blocks):
+             # Some blocks may be null blocks when enabling sparse attention like
+-            # sliding window attention. We skip null blocks here.
++            # sliding window attention, or Mamba models with prefix-caching in
++            # align mode. We skip null blocks here.
+             if blk.is_null:
+                 continue
+             assert blk.block_hash is None
 diff --git a/vllm/v1/core/encoder_cache_manager.py b/vllm/v1/core/encoder_cache_manager.py
 index d73c05d2c..43b44fdaf 100644
 --- a/vllm/v1/core/encoder_cache_manager.py
@@ -11218,6 +14971,116 @@ index d73c05d2c..43b44fdaf 100644
  
      def free_encoder_input(self, request: Request, input_id: int) -> None:
          num_encoder_embeds = request.get_num_encoder_embeds(input_id)
+diff --git a/vllm/v1/core/kv_cache_coordinator.py b/vllm/v1/core/kv_cache_coordinator.py
+index 4550e2b79..c72fbb7be 100644
+--- a/vllm/v1/core/kv_cache_coordinator.py
++++ b/vllm/v1/core/kv_cache_coordinator.py
+@@ -75,6 +75,7 @@ class KVCacheCoordinator(ABC):
+         new_computed_blocks: tuple[Sequence[KVCacheBlock], ...],
+         num_encoder_tokens: int,
+         total_computed_tokens: int,
++        num_tokens_main_model: int,
+     ) -> int:
+         """
+         Get the number of blocks needed to be allocated for the request.
+@@ -88,6 +89,9 @@ class KVCacheCoordinator(ABC):
+             num_encoder_tokens: The number of encoder tokens for allocating
+                 blocks for cross-attention.
+             total_computed_tokens: Include both local and external tokens.
++            num_tokens_main_model: The number of tokens for the main model (aka target
++                model in spec decode). w/o spec decode, it is num_tokens;
++                with spec decode, it is num_tokens - num_lookahead_tokens.
+ 
+         Returns:
+             The number of blocks to allocate.
+@@ -98,7 +102,7 @@ class KVCacheCoordinator(ABC):
+                 # For cross-attention, we issue a single static allocation
+                 # of blocks based on the number of encoder input tokens.
+                 num_blocks_to_allocate += manager.get_num_blocks_to_allocate(
+-                    request_id, num_encoder_tokens, [], 0
++                    request_id, num_encoder_tokens, [], 0, num_encoder_tokens
+                 )
+             else:
+                 num_blocks_to_allocate += manager.get_num_blocks_to_allocate(
+@@ -106,6 +110,7 @@ class KVCacheCoordinator(ABC):
+                     num_tokens,
+                     new_computed_blocks[i],
+                     total_computed_tokens,
++                    num_tokens_main_model,
+                 )
+         return num_blocks_to_allocate
+ 
+@@ -139,6 +144,7 @@ class KVCacheCoordinator(ABC):
+         self,
+         request_id: str,
+         num_tokens: int,
++        num_tokens_main_model: int,
+         num_encoder_tokens: int = 0,
+     ) -> tuple[list[KVCacheBlock], ...]:
+         """
+@@ -149,6 +155,9 @@ class KVCacheCoordinator(ABC):
+             request_id: The request ID.
+             num_tokens: The total number of tokens that need a slot (including
+                 tokens that are already allocated).
++            num_tokens_main_model: The number of tokens for the main model (aka target
++                model in spec decode). w/o spec decode, it is num_tokens;
++                with spec decode, it is num_tokens - num_lookahead_tokens.
+             num_encoder_tokens: The number of encoder tokens for allocating
+                 blocks for cross-attention.
+ 
+@@ -161,6 +170,7 @@ class KVCacheCoordinator(ABC):
+                 num_encoder_tokens
+                 if isinstance(manager, CrossAttentionManager)
+                 else num_tokens,
++                num_tokens_main_model,
+             )
+             for manager in self.single_type_managers
+         )
+diff --git a/vllm/v1/core/kv_cache_manager.py b/vllm/v1/core/kv_cache_manager.py
+index 2197107c1..a9778773f 100644
+--- a/vllm/v1/core/kv_cache_manager.py
++++ b/vllm/v1/core/kv_cache_manager.py
+@@ -307,8 +307,9 @@ class KVCacheManager:
+             num_local_computed_tokens + num_external_computed_tokens,
+             self.max_model_len,
+         )
++        num_tokens_main_model = total_computed_tokens + num_new_tokens
+         num_tokens_need_slot = min(
+-            total_computed_tokens + num_new_tokens + num_lookahead_tokens,
++            num_tokens_main_model + num_lookahead_tokens,
+             self.max_model_len,
+         )
+ 
+@@ -329,6 +330,7 @@ class KVCacheManager:
+             num_encoder_tokens=num_encoder_tokens,
+             total_computed_tokens=num_local_computed_tokens
+             + num_external_computed_tokens,
++            num_tokens_main_model=num_tokens_main_model,
+         )
+ 
+         if num_blocks_to_allocate > self.block_pool.get_num_free_blocks():
+@@ -349,7 +351,10 @@ class KVCacheManager:
+             )
+ 
+         new_blocks = self.coordinator.allocate_new_blocks(
+-            request.request_id, num_tokens_need_slot, num_encoder_tokens
++            request.request_id,
++            num_tokens_need_slot,
++            num_tokens_main_model,
++            num_encoder_tokens,
+         )
+ 
+         # P/D: delay caching blocks if we have to recv from
+@@ -483,3 +488,9 @@ class KVCacheManager:
+     ) -> KVCacheBlocks:
+         # Only create new KVCacheBlocks for non-empty blocks
+         return KVCacheBlocks(blocks) if any(blocks) else self.empty_kv_cache_blocks
++
++    def take_new_block_ids(self) -> list[int]:
++        ids: list[int] = []
++        for mgr in self.coordinator.single_type_managers:
++            ids.extend(mgr.take_new_block_ids())
++        return ids
 diff --git a/vllm/v1/core/kv_cache_utils.py b/vllm/v1/core/kv_cache_utils.py
 index 7f900bd9e..d8ee17f5f 100644
 --- a/vllm/v1/core/kv_cache_utils.py
@@ -11234,6 +15097,540 @@ index 7f900bd9e..d8ee17f5f 100644
  
      if is_kv_cache_type_attention_free(kv_cache_spec):
          # This returns an empty list to allow for the KVCacheManager to handle
+diff --git a/vllm/v1/core/sched/output.py b/vllm/v1/core/sched/output.py
+index 7e53f4f2e..530ba25df 100644
+--- a/vllm/v1/core/sched/output.py
++++ b/vllm/v1/core/sched/output.py
+@@ -238,6 +238,11 @@ class SchedulerOutput:
+     # EC Cache Connector metadata
+     ec_connector_metadata: ECConnectorMetadata | None = None
+ 
++    # Block IDs freshly allocated from the pool during this scheduling step.
++    # The worker zeros the corresponding GPU memory before the blocks are used,
++    # preventing stale NaN/data from corrupting attention or SSM computation.
++    new_block_ids_to_zero: list[int] | None = None
++
+     @classmethod
+     def make_empty(cls) -> "SchedulerOutput":
+         return cls(
+diff --git a/vllm/v1/core/sched/scheduler.py b/vllm/v1/core/sched/scheduler.py
+index bdd6d2a3c..10cb55fa6 100644
+--- a/vllm/v1/core/sched/scheduler.py
++++ b/vllm/v1/core/sched/scheduler.py
+@@ -224,6 +224,12 @@ class Scheduler(SchedulerInterface):
+         )
+         self.use_pp = self.parallel_config.pipeline_parallel_size > 1
+         self.use_v2_model_runner = envs.VLLM_USE_V2_MODEL_RUNNER
++
++        self.has_mamba_layers = kv_cache_config.has_mamba_layers
++        self.needs_kv_cache_zeroing = kv_cache_config.needs_kv_cache_zeroing
++        self.need_mamba_block_aligned_split = (
++            self.has_mamba_layers and self.cache_config.mamba_cache_mode == "align"
++        )
+         self.perf_metrics: ModelMetrics | None = None
+         if self.log_stats and vllm_config.observability_config.enable_mfu_metrics:
+             self.perf_metrics = ModelMetrics(vllm_config)
+@@ -249,6 +255,53 @@ class Scheduler(SchedulerInterface):
+                 instance_id=self.vllm_config.instance_id,
+             )
+ 
++    def _mamba_block_aligned_split(
++        self,
++        request: Request,
++        num_new_tokens: int,
++        num_new_local_computed_tokens: int = 0,
++        num_external_computed_tokens: int = 0,
++    ) -> int:
++        assert num_external_computed_tokens == 0, (
++            "External KV connector is not verified yet"
++        )
++        # TODO: need check for resume requests
++        if request.num_output_tokens == 0:  # prefill
++            # To enable block-aligned caching of the Mamba state, `num_new_tokens`
++            # must be a multiple of `block_size`.
++            # As an exception, if `num_new_tokens` is less than `block_size`, the
++            # state is simply not cached, requiring no special handling.
++            # Additionally, when Eagle mode is enabled, FullAttn prunes the last
++            # matching block. To prevent this from causing a Mamba cache miss, the
++            # last chunk must be larger than `block_size`.
++            block_size = self.cache_config.block_size
++            last_cache_position = (
++                request.num_prompt_tokens - request.num_prompt_tokens % block_size
++            )
++            # eagle prune
++            if self.use_eagle:
++                last_cache_position = max(last_cache_position - block_size, 0)
++            num_computed_tokens = (
++                request.num_computed_tokens
++                + num_new_local_computed_tokens
++                + num_external_computed_tokens
++            )
++            num_computed_tokens_after_sched = num_computed_tokens + num_new_tokens
++            if num_computed_tokens_after_sched < last_cache_position:
++                # align to block_size
++                num_new_tokens = num_new_tokens // block_size * block_size
++            elif (
++                num_computed_tokens
++                < last_cache_position
++                < num_computed_tokens_after_sched
++            ):
++                # force to cache the last chunk
++                num_new_tokens = last_cache_position - num_computed_tokens
++            else:
++                # prefill the last few tokens
++                pass
++        return num_new_tokens
++
+     def schedule(self) -> SchedulerOutput:
+         # NOTE(woosuk) on the scheduling algorithm:
+         # There's no "decoding phase" nor "prefill phase" in the scheduler.
+@@ -332,6 +385,11 @@ class Scheduler(SchedulerInterface):
+                     shift_computed_tokens=1 if self.use_eagle else 0,
+                 )
+ 
++            if self.need_mamba_block_aligned_split:
++                num_new_tokens = self._mamba_block_aligned_split(
++                    request, num_new_tokens
++                )
++
+             if num_new_tokens == 0:
+                 # The request cannot be scheduled because one of the following
+                 # reasons:
+@@ -342,6 +400,8 @@ class Scheduler(SchedulerInterface):
+                 #    its max_total_tokens or max_model_len.
+                 # 2. The encoder budget is exhausted.
+                 # 3. The encoder cache is exhausted.
++                # 4. Insufficient budget for a block-aligned chunk in hybrid
++                #    models with mamba cache mode \"align\".
+                 # NOTE(woosuk): Here, by doing `continue` instead of `break`,
+                 # we do not strictly follow the FCFS scheduling policy and
+                 # allow the lower-priority requests to be scheduled.
+@@ -600,6 +660,16 @@ class Scheduler(SchedulerInterface):
+                             # The request cannot be scheduled.
+                             break
+ 
++                if self.need_mamba_block_aligned_split:
++                    num_new_tokens = self._mamba_block_aligned_split(
++                        request,
++                        num_new_tokens,
++                        num_new_local_computed_tokens,
++                        num_external_computed_tokens,
++                    )
++                    if num_new_tokens == 0:
++                        break
++
+                 # Handles an edge case when P/D Disaggregation
+                 # is used with Spec Decoding where an
+                 # extra block gets allocated which
+@@ -759,6 +829,12 @@ class Scheduler(SchedulerInterface):
+         self.prev_step_scheduled_req_ids.clear()
+         self.prev_step_scheduled_req_ids.update(num_scheduled_tokens.keys())
+ 
++        new_block_ids_to_zero = (
++            (self.kv_cache_manager.take_new_block_ids() or None)
++            if self.needs_kv_cache_zeroing
++            else None
++        )
++
+         scheduler_output = SchedulerOutput(
+             scheduled_new_reqs=new_reqs_data,
+             scheduled_cached_reqs=cached_reqs_data,
+@@ -774,6 +850,7 @@ class Scheduler(SchedulerInterface):
+             # the previous and the current steps.
+             finished_req_ids=self.finished_req_ids,
+             free_encoder_mm_hashes=self.encoder_cache_manager.get_freed_mm_hashes(),
++            new_block_ids_to_zero=new_block_ids_to_zero,
+         )
+ 
+         # NOTE(Kuntai): this function is designed for multiple purposes:
+diff --git a/vllm/v1/core/single_type_kv_cache_manager.py b/vllm/v1/core/single_type_kv_cache_manager.py
+index aed5c0580..7d1c67951 100644
+--- a/vllm/v1/core/single_type_kv_cache_manager.py
++++ b/vllm/v1/core/single_type_kv_cache_manager.py
+@@ -51,6 +51,7 @@ class SingleTypeKVCacheManager(ABC):
+         self.kv_cache_spec = kv_cache_spec
+         self.block_pool = block_pool
+         self.enable_caching = enable_caching
++        self.new_block_ids: list[int] = []
+ 
+         # Mapping from request ID to blocks to track the blocks allocated
+         # for each request, so that we can free the blocks when the request
+@@ -66,12 +67,17 @@ class SingleTypeKVCacheManager(ABC):
+         self.kv_cache_group_id = kv_cache_group_id
+         self._null_block = block_pool.null_block
+ 
++    @classmethod
++    def _get_num_evictable_blocks(cls, blocks: Sequence[KVCacheBlock]):
++        return sum(blk.ref_cnt == 0 and not blk.is_null for blk in blocks)
++
+     def get_num_blocks_to_allocate(
+         self,
+         request_id: str,
+         num_tokens: int,
+         new_computed_blocks: Sequence[KVCacheBlock],
+         total_computed_tokens: int,
++        num_tokens_main_model: int,
+     ) -> int:
+         """
+         Get the number of blocks needed to be allocated for the request.
+@@ -84,6 +90,9 @@ class SingleTypeKVCacheManager(ABC):
+                 prefix caching.
+             total_computed_tokens: Include both local and external computed
+                 tokens.
++            num_tokens_main_model: The number of tokens for the main model (aka target
++                model in spec decode). w/o spec decode, it is num_tokens;
++                with spec decode, it is num_tokens - num_lookahead_tokens.
+ 
+         Returns:
+             The number of blocks to allocate.
+@@ -121,9 +130,8 @@ class SingleTypeKVCacheManager(ABC):
+         # If a computed block is an eviction candidate (in the free queue and
+         # ref_cnt == 0), it will be removed from the free queue when touched by
+         # the allocated request, so we must count it in the free-capacity check.
+-        num_evictable_blocks = sum(
+-            blk.ref_cnt == 0 and not blk.is_null
+-            for blk in new_computed_blocks[num_skipped_new_computed_blocks:]
++        num_evictable_blocks = self._get_num_evictable_blocks(
++            new_computed_blocks[num_skipped_new_computed_blocks:]
+         )
+         return num_new_blocks + num_evictable_blocks
+ 
+@@ -197,9 +205,11 @@ class SingleTypeKVCacheManager(ABC):
+                 cdiv(num_total_computed_tokens, self.block_size) - len(req_blocks)
+             )
+             req_blocks.extend(allocated_blocks)
++            if type(self.kv_cache_spec) is FullAttentionSpec:
++                self.new_block_ids.extend(b.block_id for b in allocated_blocks)
+ 
+     def allocate_new_blocks(
+-        self, request_id: str, num_tokens: int
++        self, request_id: str, num_tokens: int, num_tokens_main_model: int
+     ) -> list[KVCacheBlock]:
+         """
+         Allocate new blocks for the request to give it at least `num_tokens`
+@@ -209,7 +219,9 @@ class SingleTypeKVCacheManager(ABC):
+             request_id: The request ID.
+             num_tokens: The total number of tokens that need a slot (including
+                 tokens that are already allocated).
+-
++            num_tokens_main_model: The number of tokens for the main model (aka target
++                model in spec decode). w/o spec decode, it is num_tokens;
++                with spec decode, it is num_tokens - num_lookahead_tokens.
+         Returns:
+             The new allocated blocks.
+         """
+@@ -221,8 +233,16 @@ class SingleTypeKVCacheManager(ABC):
+         else:
+             new_blocks = self.block_pool.get_new_blocks(num_new_blocks)
+             req_blocks.extend(new_blocks)
++            if type(self.kv_cache_spec) is FullAttentionSpec:
++                self.new_block_ids.extend(b.block_id for b in new_blocks)
+             return new_blocks
+ 
++    def take_new_block_ids(self) -> list[int]:
++        """Drain and return block IDs allocated since the last call."""
++        ids = self.new_block_ids
++        self.new_block_ids = []
++        return ids
++
+     def cache_blocks(self, request: Request, num_tokens: int) -> None:
+         """
+         Cache the blocks for the request.
+@@ -450,12 +470,9 @@ class FullAttentionManager(SingleTypeKVCacheManager):
+ 
+ 
+ class SlidingWindowManager(SingleTypeKVCacheManager):
+-    def __init__(
+-        self, kv_cache_spec: SlidingWindowSpec, block_pool: BlockPool, **kwargs
+-    ) -> None:
+-        super().__init__(kv_cache_spec, block_pool, **kwargs)
++    def __init__(self, kv_cache_spec: SlidingWindowSpec, **kwargs) -> None:
++        super().__init__(kv_cache_spec, **kwargs)
+         self.sliding_window = kv_cache_spec.sliding_window
+-        self._null_block = block_pool.null_block
+ 
+     @classmethod
+     def find_longest_cache_hit(
+@@ -586,12 +603,9 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
+ 
+ 
+ class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
+-    def __init__(
+-        self, kv_cache_spec: ChunkedLocalAttentionSpec, block_pool: BlockPool, **kwargs
+-    ) -> None:
+-        super().__init__(kv_cache_spec, block_pool, **kwargs)
++    def __init__(self, kv_cache_spec: ChunkedLocalAttentionSpec, **kwargs) -> None:
++        super().__init__(kv_cache_spec, **kwargs)
+         self.attention_chunk_size = kv_cache_spec.attention_chunk_size
+-        self._null_block = block_pool.null_block
+ 
+     @classmethod
+     def find_longest_cache_hit(
+@@ -739,6 +753,17 @@ class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
+ 
+ 
+ class MambaManager(SingleTypeKVCacheManager):
++    def __init__(self, kv_cache_spec: MambaSpec, **kwargs) -> None:
++        super().__init__(kv_cache_spec, **kwargs)
++        self.mamba_cache_mode = kv_cache_spec.mamba_cache_mode
++        self.num_speculative_blocks: int = kv_cache_spec.num_speculative_blocks
++        if self.mamba_cache_mode == "align":
++            # Mapping from request ID to the index of the block
++            # allocated in the previous step
++            self.last_state_block_idx: dict[str, int] = {}
++            # The set of the requests that have been allocated blocks
++            self._allocated_block_reqs: set[str] = set()
++
+     @classmethod
+     def find_longest_cache_hit(
+         cls,
+@@ -787,6 +812,28 @@ class MambaManager(SingleTypeKVCacheManager):
+ 
+         return computed_blocks
+ 
++    def remove_skipped_blocks(self, request_id: str, num_computed_tokens: int) -> None:
++        assert isinstance(self.kv_cache_spec, MambaSpec)
++        super().remove_skipped_blocks(request_id, num_computed_tokens)
++        if self.mamba_cache_mode == "align":
++            # `last_state_block_idx` refers to the block index allocated two steps ago.
++            # The block allocated in the previous step is used to copy Mamba states
++            # into the block allocated in the current step; the earlier block is
++            # no longer needed and should be freed here.
++            last_state_block_idx = self.last_state_block_idx.get(request_id)
++            # Blocks allocated during prefill may be non-contiguous. Use
++            # `last_state_block_idx` to free the appropriate block and replace it
++            # with a null block.
++            if (
++                last_state_block_idx is not None
++                and last_state_block_idx
++                < cdiv(num_computed_tokens, self.block_size) - 1
++            ):
++                blocks = self.req_to_blocks[request_id]
++                if blocks[last_state_block_idx] != self._null_block:
++                    self.block_pool.free_blocks([blocks[last_state_block_idx]])
++                    blocks[last_state_block_idx] = self._null_block
++
+     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+         """
+         cascade attention is not supported by mamba
+@@ -799,31 +846,134 @@ class MambaManager(SingleTypeKVCacheManager):
+         num_tokens: int,
+         new_computed_blocks: Sequence[KVCacheBlock],
+         total_computed_tokens: int,
++        num_tokens_main_model: int,
+     ) -> int:
+-        # Allocate extra `num_speculative_blocks` blocks for
+-        # speculative decoding (MTP/EAGLE) with linear attention.
+         assert isinstance(self.kv_cache_spec, MambaSpec)
+-        if self.kv_cache_spec.num_speculative_blocks > 0:
+-            num_tokens += (
+-                self.kv_cache_spec.block_size
+-                * self.kv_cache_spec.num_speculative_blocks
++        if self.mamba_cache_mode != "align":
++            # Allocate extra `num_speculative_blocks` blocks for
++            # speculative decoding (MTP/EAGLE) with linear attention.
++            if self.num_speculative_blocks > 0:
++                num_tokens += (
++                    self.kv_cache_spec.block_size * self.num_speculative_blocks
++                )
++            return super().get_num_blocks_to_allocate(
++                request_id,
++                num_tokens,
++                new_computed_blocks,
++                total_computed_tokens,
++                num_tokens_main_model,
+             )
+-        return super().get_num_blocks_to_allocate(
+-            request_id, num_tokens, new_computed_blocks, total_computed_tokens
+-        )
++        else:
++            # We don't allocate blocks for lookahead tokens in align mode, because if
++            # x * block_size tokens are scheduled, num_tokens is
++            # x * block_size + num_lookahead_tokens and breaks the alignment.
++            # We can ignore lookahead tokens because current draft models don't have
++            # mamba layers.
++            num_tokens = num_tokens_main_model
++            num_required_blocks = (
++                cdiv(num_tokens, self.block_size) + self.num_speculative_blocks
++            )
++            num_new_blocks = (
++                num_required_blocks
++                - len(new_computed_blocks)
++                - len(self.req_to_blocks[request_id])
++            )
++            if num_new_blocks > 0:
++                if request_id in self._allocated_block_reqs:
++                    # Old request. Needs at most 1 more blocks as we can reuse the
++                    # speculative blocks in previous step.
++                    num_new_blocks = 1
++                else:
++                    # First prefill. Allocate 1 block for running state and the
++                    # speculative blocks.
++                    num_new_blocks = 1 + self.num_speculative_blocks
++
++            num_evictable_computed_blocks = self._get_num_evictable_blocks(
++                new_computed_blocks
++            )
++            return num_new_blocks + num_evictable_computed_blocks
+ 
+     def allocate_new_blocks(
+-        self, request_id: str, num_tokens: int
++        self, request_id: str, num_tokens: int, num_tokens_main_model: int
+     ) -> list[KVCacheBlock]:
+-        # Allocate extra `num_speculative_blocks` blocks for
+-        # speculative decoding (MTP/EAGLE) with linear attention.
+         assert isinstance(self.kv_cache_spec, MambaSpec)
+-        if self.kv_cache_spec.num_speculative_blocks > 0:
+-            num_tokens += (
+-                self.kv_cache_spec.block_size
+-                * self.kv_cache_spec.num_speculative_blocks
++        if self.mamba_cache_mode != "align":
++            # Allocate extra `num_speculative_blocks` blocks for
++            # speculative decoding (MTP/EAGLE) with linear attention.
++            if self.num_speculative_blocks > 0:
++                num_tokens += self.block_size * self.num_speculative_blocks
++            return super().allocate_new_blocks(
++                request_id, num_tokens, num_tokens_main_model
++            )
++        else:
++            # We don't allocate blocks for lookahead tokens in align mode, because if
++            # x * block_size tokens are scheduled, num_tokens is
++            # x * block_size + num_lookahead_tokens and breaks the alignment.
++            # We can ignore lookahead tokens because current draft models don't have
++            # mamba layers.
++            num_tokens = num_tokens_main_model
++            req_blocks: list[KVCacheBlock] = self.req_to_blocks[request_id]
++            num_required_blocks = (
++                cdiv(num_tokens, self.block_size) + self.num_speculative_blocks
+             )
+-        return super().allocate_new_blocks(request_id, num_tokens)
++            if num_required_blocks == len(req_blocks):
++                return []
++            else:
++                assert num_required_blocks > len(req_blocks), (
++                    "num_required_blocks "
++                    f"{num_required_blocks} < len(req_blocks) {len(req_blocks)}"
++                )
++                prev_block_len = len(req_blocks)
++                blocks_allocated = request_id in self._allocated_block_reqs
++                # Record the last state block
++                if blocks_allocated:
++                    # We always save the running state at the last
++                    # (1 + num_speculative_blocks) block
++                    self.last_state_block_idx[request_id] = (
++                        prev_block_len - 1 - self.num_speculative_blocks
++                    )
++                elif prev_block_len > 0:
++                    # When a new request hits the prefix cache, the last block
++                    # saves the hit state.
++                    self.last_state_block_idx[request_id] = prev_block_len - 1
++
++                num_skipped_blocks = (
++                    num_required_blocks - self.num_speculative_blocks - 1
++                )
++                # null blocks
++                if prev_block_len < num_skipped_blocks:
++                    req_blocks.extend(
++                        [
++                            self._null_block
++                            for _ in range(prev_block_len, num_skipped_blocks)
++                        ]
++                    )
++
++                if blocks_allocated:
++                    # reuse previous speculative blocks in this step
++                    for block_idx in range(
++                        prev_block_len - self.num_speculative_blocks, prev_block_len
++                    ):
++                        if block_idx < num_skipped_blocks:
++                            req_blocks.append(req_blocks[block_idx])
++                            req_blocks[block_idx] = self._null_block
++                        else:
++                            break
++                num_new_blocks = num_required_blocks - len(req_blocks)
++                if blocks_allocated:
++                    assert num_new_blocks <= 1
++                else:
++                    assert num_new_blocks <= self.num_speculative_blocks + 1
++                new_blocks = self.block_pool.get_new_blocks(num_new_blocks)
++                req_blocks.extend(new_blocks)
++                self._allocated_block_reqs.add(request_id)
++                return req_blocks[prev_block_len:]
++
++    def free(self, request_id: str) -> None:
++        if self.mamba_cache_mode == "align":
++            self._allocated_block_reqs.discard(request_id)
++            self.last_state_block_idx.pop(request_id, None)
++        super().free(request_id)
+ 
+     def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
+         """
+diff --git a/vllm/v1/engine/async_llm.py b/vllm/v1/engine/async_llm.py
+index 454e20ad1..4e7507bcd 100644
+--- a/vllm/v1/engine/async_llm.py
++++ b/vllm/v1/engine/async_llm.py
+@@ -23,6 +23,7 @@ from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
+ from vllm.outputs import PoolingRequestOutput, RequestOutput
+ from vllm.plugins.io_processors import get_io_processor
+ from vllm.pooling_params import PoolingParams
++from vllm.profiler.wrapper import get_torch_profiler_trace_handler
+ from vllm.sampling_params import SamplingParams
+ from vllm.tasks import SupportedTask
+ from vllm.tokenizers import TokenizerLike, cached_tokenizer_from_config
+@@ -178,10 +179,9 @@ class AsyncLLM(EngineClient):
+                     torch.profiler.ProfilerActivity.CPU,
+                 ],
+                 with_stack=vllm_config.profiler_config.torch_profiler_with_stack,
+-                on_trace_ready=torch.profiler.tensorboard_trace_handler(
+-                    profiler_dir,
+-                    worker_name=worker_name,
+-                    use_gzip=vllm_config.profiler_config.torch_profiler_use_gzip,
++                on_trace_ready=get_torch_profiler_trace_handler(
++                    vllm_config.profiler_config,
++                    worker_name,
+                 ),
+             )
+         else:
+diff --git a/vllm/v1/kv_cache_interface.py b/vllm/v1/kv_cache_interface.py
+index 5c9913bb0..15091c95c 100644
+--- a/vllm/v1/kv_cache_interface.py
++++ b/vllm/v1/kv_cache_interface.py
+@@ -276,6 +276,7 @@ class MambaSpec(KVCacheSpec):
+     dtypes: tuple[torch.dtype]
+     page_size_padded: int | None = None
+     mamba_type: str = "mamba2"
++    mamba_cache_mode: str = "none"
+     num_speculative_blocks: int = 0
+ 
+     @property
+@@ -290,8 +291,13 @@ class MambaSpec(KVCacheSpec):
+         return page_size
+ 
+     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
+-        max_model_len = vllm_config.model_config.max_model_len
+-        return cdiv(max_model_len, self.block_size) * self.page_size_bytes
++        if vllm_config.cache_config.mamba_cache_mode == "all":
++            max_model_len = vllm_config.model_config.max_model_len
++            return cdiv(max_model_len, self.block_size) * self.page_size_bytes
++        elif vllm_config.cache_config.mamba_cache_mode == "align":
++            return self.page_size_bytes * (2 + self.num_speculative_blocks)
++        else:
++            return self.page_size_bytes * (1 + self.num_speculative_blocks)
+ 
+ 
+ @dataclass(frozen=True)
+@@ -483,3 +489,11 @@ class KVCacheConfig:
+     For models with multiple types of attention, there will be multiple groups,
+     see `_get_kv_cache_config_uniform_page_size` for more details.
+     """
++
++    @property
++    def has_mamba_layers(self) -> bool:
++        return any(isinstance(g.kv_cache_spec, MambaSpec) for g in self.kv_cache_groups)
++
++    @property
++    def needs_kv_cache_zeroing(self) -> bool:
++        return self.has_mamba_layers
 diff --git a/vllm/v1/kv_offload/cpu.py b/vllm/v1/kv_offload/cpu.py
 index d07ef8ad0..51e84e59d 100644
 --- a/vllm/v1/kv_offload/cpu.py
@@ -11368,11 +15765,169 @@ index 9820f5109..3380637d6 100644
              ]:
                  self.model.config.image_token_index = target_model.config.image_token_id
              elif self.get_model_name(target_model) == "PixtralForConditionalGeneration":
+diff --git a/vllm/v1/worker/block_table.py b/vllm/v1/worker/block_table.py
+index 37ec0fb97..591f49761 100644
+--- a/vllm/v1/worker/block_table.py
++++ b/vllm/v1/worker/block_table.py
+@@ -8,6 +8,7 @@ from vllm.distributed import get_dcp_group, get_pcp_group
+ from vllm.logger import init_logger
+ from vllm.utils.math_utils import cdiv
+ from vllm.v1.utils import CpuGpuBuffer
++from vllm.v1.worker.cp_utils import get_total_cp_world_size
+ 
+ logger = init_logger(__name__)
+ 
+@@ -261,47 +262,45 @@ class MultiGroupBlockTable:
+         device: torch.device,
+         block_sizes: list[int],
+         kernel_block_sizes: list[int],
+-        num_speculative_tokens: int = 0,
++        max_num_blocks: list[int] | None = None,
+         cp_kv_cache_interleave_size: int = 1,
+     ) -> None:
+-        # Note(hc): each dcp rank only store
+-        # (max_model_len//dcp_world_size) tokens in kvcache,
+-        # so the block_size which used for calc max_num_blocks_per_req
+-        # must be multiplied by dcp_world_size.
+-        try:
+-            pcp_world_size = get_pcp_group().world_size
+-        except AssertionError:
+-            # PCP might not be initialized in testing
+-            pcp_world_size = 1
+-        try:
+-            dcp_world_size = get_dcp_group().world_size
+-        except AssertionError:
+-            # DCP might not be initialized in testing
+-            dcp_world_size = 1
+-
+         if len(kernel_block_sizes) != len(block_sizes):
+             raise ValueError(
+                 f"kernel_block_sizes length ({len(kernel_block_sizes)}) "
+                 f"must match block_sizes length ({len(block_sizes)})"
+             )
+-
+-        total_cp_world_size = dcp_world_size * pcp_world_size
++        if max_num_blocks is None:
++            # Note(hc): each dcp rank only store
++            # (max_model_len//dcp_world_size) tokens in kvcache,
++            # so the block_size which used for calc max_num_blocks_per_req
++            # must be multiplied by dcp_world_size.
++            total_cp_world_size = get_total_cp_world_size()
++            max_num_blocks = [
++                cdiv(max_model_len, block_size * total_cp_world_size)
++                for block_size in block_sizes
++            ]
++
++        if len(max_num_blocks) != len(block_sizes):
++            raise ValueError(
++                f"max_num_blocks length ({len(max_num_blocks)}) "
++                f"must match block_sizes length ({len(block_sizes)})"
++            )
+ 
+         self.block_tables = [
+             BlockTable(
+                 block_size,
+                 max_num_reqs,
+-                max(
+-                    cdiv(max_model_len, block_size * total_cp_world_size),
+-                    1 + num_speculative_tokens,
+-                ),
++                max_num_blocks_per_req,
+                 max_num_batched_tokens,
+                 pin_memory,
+                 device,
+                 kernel_block_size,
+                 cp_kv_cache_interleave_size,
+             )
+-            for block_size, kernel_block_size in zip(block_sizes, kernel_block_sizes)
++            for block_size, kernel_block_size, max_num_blocks_per_req in zip(
++                block_sizes, kernel_block_sizes, max_num_blocks
++            )
+         ]
+ 
+     def append_row(self, block_ids: tuple[list[int], ...], row_idx: int) -> None:
+diff --git a/vllm/v1/worker/cp_utils.py b/vllm/v1/worker/cp_utils.py
+index f666c739b..2c2e0b5cd 100644
+--- a/vllm/v1/worker/cp_utils.py
++++ b/vllm/v1/worker/cp_utils.py
+@@ -3,6 +3,7 @@
+ from typing import TYPE_CHECKING, Any, cast
+ 
+ from vllm.config import VllmConfig, get_layers_from_vllm_config
++from vllm.distributed import get_dcp_group, get_pcp_group
+ 
+ if TYPE_CHECKING:
+     from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+@@ -40,3 +41,17 @@ def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:
+                     f"but the impl {layer_impl.__class__.__name__} "
+                     "does not support PCP."
+                 )
++
++
++def get_total_cp_world_size():
++    try:
++        pcp_world_size = get_pcp_group().world_size
++    except AssertionError:
++        # PCP might not be initialized in testing
++        pcp_world_size = 1
++    try:
++        dcp_world_size = get_dcp_group().world_size
++    except AssertionError:
++        # DCP might not be initialized in testing
++        dcp_world_size = 1
++    return dcp_world_size * pcp_world_size
+diff --git a/vllm/v1/worker/gpu_input_batch.py b/vllm/v1/worker/gpu_input_batch.py
+index 662badeb5..c70970fdc 100644
+--- a/vllm/v1/worker/gpu_input_batch.py
++++ b/vllm/v1/worker/gpu_input_batch.py
+@@ -89,11 +89,11 @@ class InputBatch:
+         vocab_size: int,
+         block_sizes: list[int],  # The block_size of each kv cache group
+         kernel_block_sizes: list[int],
++        max_num_blocks_per_req: list[int] | None = None,
+         logitsprocs: LogitsProcessors | None = None,
+         logitsprocs_need_output_token_ids: bool = False,
+         is_spec_decode: bool = False,
+         is_pooling_model: bool = False,
+-        num_speculative_tokens: int = 0,
+         cp_kv_cache_interleave_size: int = 1,
+     ):
+         self.is_pooling_model = is_pooling_model
+@@ -146,7 +146,7 @@ class InputBatch:
+             device=device,
+             block_sizes=block_sizes,
+             kernel_block_sizes=kernel_block_sizes,
+-            num_speculative_tokens=num_speculative_tokens,
++            max_num_blocks=max_num_blocks_per_req,
+             cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
+         )
+ 
 diff --git a/vllm/v1/worker/gpu_model_runner.py b/vllm/v1/worker/gpu_model_runner.py
-index 525ad5db4..3da119bd9 100644
+index 525ad5db4..0e86e07ce 100644
 --- a/vllm/v1/worker/gpu_model_runner.py
 +++ b/vllm/v1/worker/gpu_model_runner.py
-@@ -431,6 +431,9 @@ class GPUModelRunner(
+@@ -154,7 +154,11 @@ from vllm.v1.spec_decode.ngram_proposer import NgramProposer
+ from vllm.v1.spec_decode.suffix_decoding import SuffixDecodingProposer
+ from vllm.v1.structured_output.utils import apply_grammar_bitmask
+ from vllm.v1.utils import CpuGpuBuffer, record_function_or_nullcontext
+-from vllm.v1.worker.cp_utils import check_attention_cp_compatibility
++from vllm.v1.worker import mamba_utils
++from vllm.v1.worker.cp_utils import (
++    check_attention_cp_compatibility,
++    get_total_cp_world_size,
++)
+ from vllm.v1.worker.dp_utils import coordinate_batch_across_dp
+ from vllm.v1.worker.ec_connector_model_runner_mixin import ECConnectorModelRunnerMixin
+ from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
+@@ -171,6 +175,7 @@ from vllm.v1.worker.workspace import lock_workspace
+ 
+ from .utils import (
+     AttentionGroup,
++    KVBlockZeroer,
+     MultiModalBudget,
+     add_kv_sharing_layers_to_kv_cache_groups,
+     bind_kv_cache,
+@@ -431,6 +436,9 @@ class GPUModelRunner(
          # NOTE(Jiayi): currently we put the entire draft model on
          # the last PP rank. This is not ideal if there are many
          # layers in the draft model.
@@ -11382,7 +15937,138 @@ index 525ad5db4..3da119bd9 100644
          if self.speculative_config and get_pp_group().is_last_rank:
              self.drafter: (
                  NgramProposer | SuffixDecodingProposer | EagleProposer | MedusaProposer
-@@ -4712,6 +4715,9 @@ class GPUModelRunner(
+@@ -683,6 +691,7 @@ class GPUModelRunner(
+         # Ephemeral state transferred between execute_model() and sample_tokens().
+         self.execute_model_state: ExecuteModelState | None = None
+         self.kv_connector_output: KVConnectorOutput | None = None
++        self.mamba_state_idx: dict[str, int] = {}
+         self.layerwise_nvtx_hooks_registered = False
+ 
+     def update_max_model_len(self, max_model_len: int) -> None:
+@@ -834,6 +843,46 @@ class GPUModelRunner(
+     def _sync_device(self) -> None:
+         torch.cuda.synchronize()
+ 
++    def _init_kv_zero_meta(self) -> None:
++        """One-time precomputation for _zero_block_ids.
++
++        Constructs a KVBlockZeroer with the runner's KV cache tensors,
++        config, attention backend, and kernel block sizes.
++        Called from gpu_worker.py outside the CuMem pool context.
++        """
++        # Find the attention backend from a non-Mamba attention group.
++        # Mamba backends do not implement get_kv_cache_shape, so we must
++        # use an attention backend (any AttentionSpec subclass).
++        backend: type[AttentionBackend] | None = None
++        for attn_group in self._attn_group_iterator():
++            if isinstance(attn_group.kv_cache_spec, AttentionSpec):
++                backend = attn_group.backend
++                break
++        if backend is None:
++            return  # No standard attention groups → nothing to zero.
++        self._kv_block_zeroer = KVBlockZeroer(
++            kv_caches=self.kv_caches,
++            kv_cache_config=self.kv_cache_config,
++            backend=backend,
++            kernel_block_sizes=self._kernel_block_sizes,
++        )
++
++    def _zero_block_ids(self, block_ids: list[int]) -> None:
++        if hasattr(self, "_kv_block_zeroer"):
++            self._kv_block_zeroer.zero(block_ids)
++        # Also zero Mamba/GDN state blocks — KVBlockZeroer only handles
++        # FullAttentionSpec, so MambaSpec blocks must be zeroed separately
++        # to prevent stale data from corrupting conv_state/ssm_state.
++        for group_idx, group in enumerate(self.kv_cache_config.kv_cache_groups):
++            if isinstance(group.kv_cache_spec, MambaSpec):
++                kv_cache = self.kv_caches[group_idx]
++                # Mamba kv_cache is a list of state tensors [conv_state, ssm_state]
++                state_list = kv_cache if isinstance(kv_cache, list) else [kv_cache]
++                for state_tensor in state_list:
++                    for bid in block_ids:
++                        if bid < state_tensor.shape[0]:
++                            state_tensor[bid].zero_()
++
+     def _update_states(self, scheduler_output: "SchedulerOutput") -> None:
+         """Update the cached states and the persistent batch with the scheduler
+         output.
+@@ -857,6 +906,11 @@ class GPUModelRunner(
+         for req_id in scheduler_output.finished_req_ids:
+             self.input_batch.remove_request(req_id)
+ 
++        # Zero GPU memory for freshly allocated cache blocks to prevent
++        # stale NaN/data from corrupting attention or SSM computation.
++        if scheduler_output.new_block_ids_to_zero:
++            self._zero_block_ids(scheduler_output.new_block_ids_to_zero)
++
+         # Free the cached encoder outputs.
+         for mm_hash in scheduler_output.free_encoder_mm_hashes:
+             self.encoder_cache.pop(mm_hash, None)
+@@ -1070,7 +1124,7 @@ class GPUModelRunner(
+         self.input_batch.refresh_metadata()
+ 
+     def _update_states_after_model_execute(
+-        self, output_token_ids: torch.Tensor
++        self, output_token_ids: torch.Tensor, scheduler_output: "SchedulerOutput"
+     ) -> None:
+         """Update the cached states after model execution.
+ 
+@@ -1106,6 +1160,16 @@ class GPUModelRunner(
+         )
+         for i, num_tokens in enumerate(num_accepted_tokens):
+             self.input_batch.num_accepted_tokens_cpu[i] = num_tokens
++        if self.cache_config.mamba_cache_mode == "align":
++            mamba_utils.postprocess_mamba(
++                scheduler_output,
++                self.kv_cache_config,
++                self.input_batch,
++                self.requests,
++                self.mamba_state_idx,
++                self.compilation_config.static_forward_context,
++                self.model.get_mamba_state_copy_func(),
++            )
+ 
+     def _init_mrope_positions(self, req_state: CachedRequestState):
+         model = self.get_model()
+@@ -2750,7 +2814,6 @@ class GPUModelRunner(
+             logits,
+             sampling_metadata,
+         )
+-        self._update_states_after_model_execute(sampler_output.sampled_token_ids)
+         return sampler_output
+ 
+     def _bookkeeping_sync(
+@@ -3236,6 +3299,18 @@ class GPUModelRunner(
+ 
+             pad_attn = cudagraph_mode == CUDAGraphMode.FULL
+ 
++            if self.cache_config.mamba_cache_mode == "align":
++                mamba_utils.preprocess_mamba(
++                    scheduler_output,
++                    self.kv_cache_config,
++                    self.cache_config,
++                    self.mamba_state_idx,
++                    self.input_batch,
++                    self.requests,
++                    self.compilation_config.static_forward_context,
++                    self.model.get_mamba_state_copy_func(),
++                )
++
+             use_spec_decode = len(scheduler_output.scheduled_spec_decode_tokens) > 0
+             ubatch_slices_attn = ubatch_slices_padded if pad_attn else ubatch_slices
+ 
+@@ -3414,6 +3489,10 @@ class GPUModelRunner(
+         with record_function_or_nullcontext("gpu_model_runner: sample"):
+             sampler_output = self._sample(logits, spec_decode_metadata)
+ 
++        self._update_states_after_model_execute(
++            sampler_output.sampled_token_ids, scheduler_output
++        )
++
+         self._draft_token_ids = None
+         self._draft_token_req_ids = None
+         self.input_batch.prev_sampled_token_ids = None
+@@ -4712,6 +4791,9 @@ class GPUModelRunner(
                          dummy_modality
                      ]
  
@@ -11392,7 +16078,7 @@ index 525ad5db4..3da119bd9 100644
                      logger.info(
                          "Encoder cache will be initialized with a budget of "
                          "%s tokens, and profiled with %s %s items of the "
-@@ -4743,7 +4749,7 @@ class GPUModelRunner(
+@@ -4743,7 +4825,7 @@ class GPUModelRunner(
          hidden_states, last_hidden_states = self._dummy_run(
              self.max_num_tokens, is_profile=True
          )
@@ -11401,11 +16087,88 @@ index 525ad5db4..3da119bd9 100644
              if self.is_pooling_model:
                  output = self._dummy_pooler_run(hidden_states)
              else:
+@@ -5297,6 +5379,24 @@ class GPUModelRunner(
+             for kv_cache_group in kv_cache_config.kv_cache_groups
+             if not isinstance(kv_cache_group.kv_cache_spec, EncoderOnlyAttentionSpec)
+         ]
++        max_num_blocks = []
++        max_model_len = max(self.max_model_len, self.max_encoder_len)
++        for i, kv_cache_group in enumerate(kv_cache_config.kv_cache_groups):
++            if isinstance(kv_cache_group.kv_cache_spec, EncoderOnlyAttentionSpec):
++                continue
++            max_num_blocks_per_req = cdiv(
++                max_model_len, block_sizes[i] * get_total_cp_world_size()
++            )
++            if isinstance(kv_cache_group.kv_cache_spec, MambaSpec):
++                mamba_blocks_per_req = (
++                    max_num_blocks_per_req
++                    if self.cache_config.enable_prefix_caching
++                    else 1
++                ) + kv_cache_group.kv_cache_spec.num_speculative_blocks
++                max_num_blocks_per_req = max(
++                    max_num_blocks_per_req, mamba_blocks_per_req
++                )
++            max_num_blocks.append(max_num_blocks_per_req)
+ 
+         if block_sizes != [self.cache_config.block_size] or kernel_block_sizes != [
+             self.cache_config.block_size
+@@ -5308,18 +5408,18 @@ class GPUModelRunner(
+             )
+             self.input_batch = InputBatch(
+                 max_num_reqs=self.max_num_reqs,
+-                max_model_len=max(self.max_model_len, self.max_encoder_len),
++                max_model_len=max_model_len,
+                 max_num_batched_tokens=self.max_num_tokens,
+                 device=self.device,
+                 pin_memory=self.pin_memory,
+                 vocab_size=self.model_config.get_vocab_size(),
+                 block_sizes=block_sizes,
+                 kernel_block_sizes=kernel_block_sizes,
++                max_num_blocks_per_req=max_num_blocks,
+                 is_spec_decode=bool(self.vllm_config.speculative_config),
+                 logitsprocs=self.input_batch.logitsprocs,
+                 logitsprocs_need_output_token_ids=self.input_batch.logitsprocs_need_output_token_ids,
+                 is_pooling_model=self.is_pooling_model,
+-                num_speculative_tokens=self.num_spec_tokens,
+             )
+ 
+     def _allocate_kv_cache_tensors(
+@@ -5638,6 +5738,7 @@ class GPUModelRunner(
+         # kernel_block_size 64 and split the 256-token-block to 4 blocks with 64
+         # tokens each.
+         kernel_block_sizes = self._prepare_kernel_block_sizes(kv_cache_config)
++        self._kernel_block_sizes = kernel_block_sizes
+ 
+         # create metadata builders
+         self.initialize_metadata_builders(kv_cache_config, kernel_block_sizes)
 diff --git a/vllm/v1/worker/gpu_worker.py b/vllm/v1/worker/gpu_worker.py
-index 562664524..3cc998c45 100644
+index 562664524..4a16a4b4d 100644
 --- a/vllm/v1/worker/gpu_worker.py
 +++ b/vllm/v1/worker/gpu_worker.py
-@@ -529,7 +529,7 @@ class Worker(WorkerBase):
+@@ -414,6 +414,22 @@ class Worker(WorkerBase):
+         else:
+             self.model_runner.initialize_kv_cache(kv_cache_config)
+ 
++        # Build KV-zero metadata outside the CuMem pool so the bookkeeping
++        # GPU tensors (seg_addrs, block-id buffers) use the standard PyTorch
++        # allocator and are not discarded during sleep/wake cycles.
++        if kv_cache_config.needs_kv_cache_zeroing and hasattr(
++            self.model_runner, "_init_kv_zero_meta"
++        ):
++            # if current_platform.is_xpu():
++            #     logger.warning_once(
++            #         "Skipping KV cache zero metadata initialization on XPU "
++            #         "because KVBlockZeroer uses device addresses that do "
++            #         "not fit the current XPU path. Newly allocated Mamba "
++            #         "KV blocks will not be proactively zeroed."
++            #     )
++            # else:
++            self.model_runner._init_kv_zero_meta()
++
+     def compile_or_warm_up_model(self) -> None:
+         warmup_sizes = []
+ 
+@@ -529,7 +545,7 @@ class Worker(WorkerBase):
              )
              if self.model_runner.is_pooling_model:
                  self.model_runner._dummy_pooler_run(hidden_states)
@@ -11414,11 +16177,449 @@ index 562664524..3cc998c45 100644
                  self.model_runner._dummy_sampler_run(hidden_states=last_hidden_states)
  
          # Reset the seed to ensure that the random state is not affected by
+diff --git a/vllm/v1/worker/mamba_utils.py b/vllm/v1/worker/mamba_utils.py
+new file mode 100644
+index 000000000..699419fd5
+--- /dev/null
++++ b/vllm/v1/worker/mamba_utils.py
+@@ -0,0 +1,246 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++import itertools
++from typing import Any
++
++import torch
++import triton
++import triton.language as tl
++
++from vllm.config import CacheConfig
++from vllm.model_executor.layers.mamba.mamba_utils import (
++    MambaStateCopyFunc,
++)
++from vllm.platforms import current_platform
++from vllm.v1.core.sched.output import SchedulerOutput
++from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
++from vllm.v1.worker.gpu_input_batch import CachedRequestState
++from vllm.v1.worker.lora_model_runner_mixin import GPUInputBatch
++
++
++@triton.jit
++def batch_memcpy_kernel(src_ptrs, dst_ptrs, sizes, BLOCK_SIZE: tl.constexpr):
++    pid = tl.program_id(0)
++
++    src_ptr = tl.load(src_ptrs + pid)
++    dst_ptr = tl.load(dst_ptrs + pid)
++    size = tl.load(sizes + pid)
++
++    offsets = tl.arange(0, BLOCK_SIZE)
++    for i in range(0, size, BLOCK_SIZE):
++        mask = (i + offsets) < size
++
++        curr_src_ptr = (src_ptr + i + offsets).to(tl.pointer_type(tl.uint8))
++        curr_dst_ptr = (dst_ptr + i + offsets).to(tl.pointer_type(tl.uint8))
++
++        data = tl.load(curr_src_ptr, mask=mask)
++        tl.store(curr_dst_ptr, data, mask=mask)
++
++
++def batch_memcpy(src_ptrs, dst_ptrs, sizes):
++    batch = src_ptrs.shape[0]
++    assert dst_ptrs.shape[0] == batch
++    assert sizes.shape[0] == batch
++
++    grid = (batch,)
++    BLOCK_SIZE = 1024
++    batch_memcpy_kernel[grid](src_ptrs, dst_ptrs, sizes, BLOCK_SIZE=BLOCK_SIZE)
++
++
++def get_mamba_groups(kv_cache_config: KVCacheConfig) -> tuple[list[int], MambaSpec]:
++    mamba_group_ids: list[int] = []
++    mamba_specs: list[MambaSpec] = []
++    for i in range(len(kv_cache_config.kv_cache_groups)):
++        kv_cache_spec = kv_cache_config.kv_cache_groups[i].kv_cache_spec
++        if isinstance(kv_cache_spec, MambaSpec):
++            mamba_group_ids.append(i)
++            mamba_specs.append(kv_cache_spec)
++    assert len(mamba_group_ids) > 0, "no mamba layers in the model"
++    assert all(mamba_specs[0] == spec for spec in mamba_specs)
++    return mamba_group_ids, mamba_specs[0]
++
++
++def collect_mamba_copy_meta(
++    src_state_list: list[int],
++    dest_state_list: list[int],
++    num_elements_list: list[int],
++    kv_cache_config: KVCacheConfig,
++    mamba_state_copy_funcs: tuple[MambaStateCopyFunc, ...],
++    mamba_group_ids: list[int],
++    src_block_idx: int,
++    dest_block_idx: int,
++    accept_token_bias: int,
++    req_state: CachedRequestState,
++    forward_context: dict[str, Any],
++):
++    if src_block_idx == dest_block_idx and accept_token_bias == 0:
++        return
++
++    for mamba_group_id in mamba_group_ids:
++        block_ids = req_state.block_ids[mamba_group_id]
++        dest_block_id = block_ids[dest_block_idx]
++        layer_names = kv_cache_config.kv_cache_groups[mamba_group_id].layer_names
++        for layer_name in layer_names:
++            attention = forward_context[layer_name]
++            kv_caches: list[torch.Tensor] = attention.kv_cache[0]
++            for state, state_copy_func in zip(kv_caches, mamba_state_copy_funcs):
++                copy_spec = state_copy_func(
++                    state, block_ids, src_block_idx, accept_token_bias + 1
++                )
++
++                src_state_list.append(copy_spec.start_addr)
++                dest_state_list.append(state[dest_block_id].data_ptr())
++                num_elements_list.append(copy_spec.num_elements * state.element_size())
++
++
++def do_mamba_copy_block(
++    src_state_list: list[int],
++    dest_state_list: list[int],
++    num_elements_list: list[int],
++):
++    if len(src_state_list) == 0:
++        return
++    assert len(src_state_list) == len(dest_state_list)
++    assert len(src_state_list) == len(num_elements_list)
++    device_type = current_platform.device_type
++    src_state_ptrs = torch.tensor(
++        src_state_list, device=device_type, dtype=torch.int64
++    )
++    dst_state_ptrs = torch.tensor(
++        dest_state_list, device=device_type, dtype=torch.int64
++    )
++    num_elements = torch.tensor(
++        num_elements_list, device=device_type, dtype=torch.int32
++    )
++
++    batch_memcpy(src_state_ptrs, dst_state_ptrs, num_elements)
++
++
++def preprocess_mamba(
++    scheduler_output: SchedulerOutput,
++    kv_cache_config: KVCacheConfig,
++    cache_config: CacheConfig,
++    mamba_state_idx: dict[str, int],
++    input_batch: GPUInputBatch,
++    requests: dict[str, CachedRequestState],
++    forward_context: dict[str, Any],
++    mamba_state_copy_funcs: tuple[MambaStateCopyFunc, ...],
++):
++    """
++    Copy the mamba state of previous step to the last
++    (1 + num_speculative_blocks) block.
++    """
++    mamba_group_ids, mamba_spec = get_mamba_groups(kv_cache_config)
++    num_speculative_blocks = mamba_spec.num_speculative_blocks
++    # TODO(Chen): we need to optimize this function a lot
++    assert cache_config.enable_prefix_caching
++    block_size = mamba_spec.block_size
++    finished_req_ids = scheduler_output.finished_req_ids
++    preempted_req_ids = scheduler_output.preempted_req_ids or set()
++    # We need to clear mamba_state_idx for resumed requests. When requests are
++    # force-preempted (e.g., during reset_prefix_cache / KV cache flush),
++    # they appear in resumed_req_ids without a corresponding entry in
++    # preempted_req_ids, leaving stale mamba_state_idx entries that can
++    # point to block indices beyond the new (smaller) block allocation.
++    resumed_req_ids = scheduler_output.scheduled_cached_reqs.resumed_req_ids
++    for req_id in itertools.chain(finished_req_ids, preempted_req_ids, resumed_req_ids):
++        mamba_state_idx.pop(req_id, None)
++
++    src_state_list: list[int] = []
++    dest_state_list: list[int] = []
++    num_elements_list: list[int] = []
++    for i, req_id in enumerate(input_batch.req_ids):
++        req_state = requests[req_id]
++        prev_state_idx = mamba_state_idx.get(req_id)
++        if prev_state_idx is None:
++            # new / resumed request, no previous state
++            # if num_computed_tokens is 0, prev_state_idx will be -1
++            prev_state_idx = (req_state.num_computed_tokens - 1) // block_size
++
++        num_blocks = len(req_state.block_ids[mamba_group_ids[0]])
++
++        # We always save the current running state at the last
++        # (1 + num_speculative_blocks) block.
++        # A corner case worth mention here: assume we have block_size = 4 and
++        # num_speculative_tokens = 2. The request is [A, B, C] and contains 2 draft
++        # tokens [draft 1, draft 2]. Then we will have:
++        # Block 0: [A, B, C, draft 1]
++        # Block 1: [draft 2, TOFILL, TOFILL, TOFILL]
++        # Block 2: speculative block
++        # Block 3: speculative block
++        # And use block 1 to save the running state.
++        curr_state_idx = num_blocks - 1 - num_speculative_blocks
++        mamba_state_idx[req_id] = curr_state_idx
++        if prev_state_idx != -1 and prev_state_idx != curr_state_idx:
++            collect_mamba_copy_meta(
++                src_state_list,
++                dest_state_list,
++                num_elements_list,
++                kv_cache_config,
++                mamba_state_copy_funcs,
++                mamba_group_ids,
++                prev_state_idx,
++                curr_state_idx,
++                input_batch.num_accepted_tokens_cpu[i] - 1,
++                req_state,
++                forward_context,
++            )
++            input_batch.num_accepted_tokens_cpu[i] = 1
++    do_mamba_copy_block(src_state_list, dest_state_list, num_elements_list)
++
++
++def postprocess_mamba(
++    scheduler_output: SchedulerOutput,
++    kv_cache_config: KVCacheConfig,
++    input_batch: GPUInputBatch,
++    requests: dict[str, CachedRequestState],
++    mamba_state_idx: dict[str, int],
++    forward_context: dict[str, Any],
++    mamba_state_copy_funcs: tuple[MambaStateCopyFunc, ...],
++):
++    """
++    If a blocks is converted from partial block to full block in this step, copy the
++    state from the block for running state to the new full block.
++    """
++    num_scheduled_tokens_dict = scheduler_output.num_scheduled_tokens
++    scheduled_spec_decode_tokens_dict = scheduler_output.scheduled_spec_decode_tokens
++    num_accepted_tokens_cpu = input_batch.num_accepted_tokens_cpu
++    # NOTE: can be optimized as this function always returns the same result
++    mamba_group_ids, mamba_spec = get_mamba_groups(kv_cache_config)
++    src_state_list: list[int] = []
++    dest_state_list: list[int] = []
++    num_elements_list: list[int] = []
++    for i, req_id in enumerate(input_batch.req_ids):
++        req_state = requests[req_id]
++        num_computed_tokens = req_state.num_computed_tokens
++        num_draft_tokens = len(scheduled_spec_decode_tokens_dict.get(req_id, []))
++        num_scheduled_tokens = num_scheduled_tokens_dict[req_id]
++        num_accepted_tokens = num_accepted_tokens_cpu[i]
++        num_tokens_running_state = (
++            num_computed_tokens + num_scheduled_tokens - num_draft_tokens
++        )
++        new_num_computed_tokens = num_tokens_running_state + num_accepted_tokens - 1
++        aligned_new_computed_tokens = (
++            new_num_computed_tokens // mamba_spec.block_size * mamba_spec.block_size
++        )
++        # TODO: how to ensure all blocks that cache_blocks called are cached here?
++        if aligned_new_computed_tokens >= num_tokens_running_state:
++            accept_token_bias = aligned_new_computed_tokens - num_tokens_running_state
++            src_block_idx = mamba_state_idx[req_id]
++            dest_block_idx = aligned_new_computed_tokens // mamba_spec.block_size - 1
++            collect_mamba_copy_meta(
++                src_state_list,
++                dest_state_list,
++                num_elements_list,
++                kv_cache_config,
++                mamba_state_copy_funcs,
++                mamba_group_ids,
++                src_block_idx,
++                dest_block_idx,
++                accept_token_bias,
++                req_state,
++                forward_context,
++            )
++            if src_block_idx == dest_block_idx:
++                num_accepted_tokens_cpu[i] = 1
++    do_mamba_copy_block(src_state_list, dest_state_list, num_elements_list)
 diff --git a/vllm/v1/worker/utils.py b/vllm/v1/worker/utils.py
-index 85acc1679..c2912e482 100644
+index 85acc1679..93d018e8e 100644
 --- a/vllm/v1/worker/utils.py
 +++ b/vllm/v1/worker/utils.py
-@@ -354,7 +354,8 @@ def bind_kv_cache(
+@@ -2,7 +2,10 @@
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ import math
+ from collections import defaultdict
++from collections.abc import Iterable
+ from dataclasses import dataclass, field
++from itertools import product as iprod
++from typing import Any
+ 
+ import torch
+ from typing_extensions import deprecated
+@@ -15,15 +18,173 @@ from vllm.model_executor.models.utils import extract_layer_index
+ from vllm.multimodal.cache import processor_only_cache_from_config
+ from vllm.multimodal.registry import MultiModalRegistry
+ from vllm.platforms import current_platform
++from vllm.triton_utils import tl, triton
++from vllm.utils.math_utils import largest_power_of_2_divisor
+ from vllm.utils.mem_utils import MemorySnapshot, format_gib
+ from vllm.v1.attention.backend import AttentionBackend
+ from vllm.v1.attention.backends.utils import AttentionMetadataBuilder
+ from vllm.v1.core.encoder_cache_manager import compute_mm_encoder_budget
+-from vllm.v1.kv_cache_interface import KVCacheGroupSpec, KVCacheSpec
++from vllm.v1.kv_cache_interface import (
++    AttentionSpec,
++    EncoderOnlyAttentionSpec,
++    FullAttentionSpec,
++    KVCacheConfig,
++    KVCacheGroupSpec,
++    KVCacheSpec,
++)
+ 
+ logger = init_logger(__name__)
+ 
+ 
++@triton.jit
++def _zero_kv_blocks_kernel(
++    seg_addrs_ptr,
++    block_ids_ptr,
++    n_blocks,
++    N_SEGS: tl.constexpr,
++    PAGE_SIZE_EL: tl.constexpr,
++    BLOCK_SIZE: tl.constexpr,
++):
++    """Zero KV cache blocks across all segments in a single launch.
++
++    Each segment is a contiguous region of one block's data.  For backends
++    where blocks are outermost (block_dim=0) there is one segment per
++    buffer.  For backends where K/V is outermost (block_dim=1) there are
++    two segments per buffer (one for K, one for V).
++
++    seg_addrs_ptr holds absolute byte addresses (int64) for each segment,
++    allowing segments to live in different CUDA allocations.
++
++    Programs are mapped as (block_index, seg_index, chunk_index).
++    """
++    pid = tl.program_id(0)
++    chunks = PAGE_SIZE_EL // BLOCK_SIZE
++    work_per_block = N_SEGS * chunks
++    block_index = pid // work_per_block
++    if block_index >= n_blocks:
++        return
++    remainder = pid % work_per_block
++    seg_index = remainder // chunks
++    chunk_index = remainder % chunks
++    block_id = tl.load(block_ids_ptr + block_index)
++    seg_addr = tl.load(seg_addrs_ptr + seg_index)
++    ptr = tl.cast(seg_addr, tl.pointer_type(tl.int32))
++    offset = (
++        block_id.to(tl.int64) * PAGE_SIZE_EL
++        + chunk_index.to(tl.int64) * BLOCK_SIZE
++    )
++    cols = tl.arange(0, BLOCK_SIZE).to(tl.int64)
++    tl.store(ptr + offset + cols, tl.zeros([BLOCK_SIZE], dtype=tl.int32))
++
++
++class KVBlockZeroer:
++    """Zeros newly-allocated KV-cache blocks via a Triton kernel.
++
++    The kernel writes int32 zeros which covers float16/bfloat16/fp8 values.
++    Construction is cheap; the expensive part (``zero``) is called only when
++    there are blocks to clear.
++    """
++
++    def __init__(
++        self,
++        kv_caches: list[torch.Tensor],
++        kv_cache_config: KVCacheConfig,
++        backend: type[AttentionBackend],
++        kernel_block_sizes: list[int] | list[int | None],
++    ) -> None:
++        # Collect per-group segment addresses and page sizes.
++        seg_addrs: list[int] = []
++        page_sizes_el: list[int] = []
++        block_dim: int | None = None
++        block_dim_resolved = False
++
++        for group_idx, group in enumerate(kv_cache_config.kv_cache_groups):
++            spec = group.kv_cache_spec
++            if not isinstance(spec, (FullAttentionSpec, EncoderOnlyAttentionSpec)):
++                continue
++
++            buf = kv_caches[group_idx]
++            kbs = kernel_block_sizes[group_idx]
++            num_kv_heads = spec.num_kv_heads
++            head_size = spec.head_size
++            block_size = kbs if kbs is not None else spec.block_size
++
++            # Resolve block_dim once from the first attention spec.
++            if not block_dim_resolved:
++                block_dim = backend.get_kv_cache_block_dim(
++                    block_size, num_kv_heads, head_size)
++                block_dim_resolved = True
++
++            if block_dim is None or block_dim == 0:
++                # Shape: [num_blocks, 2, block_size, num_kv_heads, head_size]
++                page_el = 2 * block_size * num_kv_heads * head_size
++                seg_addrs.append(buf.data_ptr())
++                page_sizes_el.append(page_el)
++            else:
++                # Shape: [2, num_blocks, block_size, num_kv_heads, head_size]
++                page_el = block_size * num_kv_heads * head_size
++                for kv_idx in range(2):
++                    seg_addrs.append(buf[kv_idx].data_ptr())
++                    page_sizes_el.append(page_el)
++
++        if not seg_addrs:
++            self._seg_addrs_t: torch.Tensor | None = None
++            return
++
++        page_size_el = page_sizes_el[0]
++        assert all(p == page_size_el for p in page_sizes_el), (
++            "All attention groups must have the same page size in elements"
++        )
++
++        # Convert to int32 element count (kernel writes int32).
++        assert (buf.element_size() * page_size_el) % 4 == 0
++        page_size_int32 = (buf.element_size() * page_size_el) // 4
++        block_size_triton = largest_power_of_2_divisor(page_size_int32)
++
++        self._seg_addrs_t = torch.tensor(
++            seg_addrs, dtype=torch.uint64, device=buf.device
++        )
++        self._n_segs = len(seg_addrs)
++        self._page_size_int32 = page_size_int32
++        self._block_size_triton = block_size_triton
++        self._max_block_ids = 512
++        self._block_ids_buf = torch.empty(
++            self._max_block_ids, dtype=torch.int32, device=buf.device
++        )
++
++    # ------------------------------------------------------------------
++
++    def zero(self, block_ids: Iterable[int]) -> None:
++        """Zero the listed block IDs across every segment."""
++        if self._seg_addrs_t is None:
++            return
++
++        ids = list(block_ids)
++        if not ids:
++            return
++
++        n = len(ids)
++        if n > self._max_block_ids:
++            self._max_block_ids = n
++            self._block_ids_buf = torch.empty(
++                n, dtype=torch.int32, device=self._seg_addrs_t.device
++            )
++
++        buf = self._block_ids_buf[:n]
++        buf.copy_(torch.tensor(ids, dtype=torch.int32))
++
++        chunks = self._page_size_int32 // self._block_size_triton
++        grid = (n * self._n_segs * chunks,)
++        _zero_kv_blocks_kernel[grid](
++            self._seg_addrs_t,
++            buf,
++            n,
++            N_SEGS=self._n_segs,
++            PAGE_SIZE_EL=self._page_size_int32,
++            BLOCK_SIZE=self._block_size_triton,
++        )
++
++
+ class MultiModalBudget:
+     """Helper class to calculate budget information for multi-modal models."""
+ 
+@@ -354,7 +515,8 @@ def bind_kv_cache(
                  # not in a way that's impacted by ignoring this.
                  pass
              else:


### PR DESCRIPTION
## Summary

- Add `custom-esimd-kernels-vllm` package: Intel ESIMD GPU kernels providing FP8 decode optimizations (fused GEMV, norm+projection fusion, GDN conv, MoE, Eagle speculative decoding)
- Update Dockerfile to build and install ESIMD kernels during image build
- Update `vllm_for_multi_arc.patch` to sync with `qwen3_next_fix_0324` branch, including Qwen3.5 FP8 fixes and ESIMD optimizations
- Add `.gitignore` for build artifacts

## Test plan

- [x] Docker image builds successfully
- [x] Qwen3.5-35B-A3B FP8 inference produces correct output
- [x] Qwen3-Coder-Next FP8 inference works as before