### PR TITLE
Fix page_attn_decode to support dynamic GQA ratio

### DIFF
--- a/vllm/custom-esimd-kernels-vllm/csrc/eagle/eagle.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/eagle/eagle.sycl
@@ -304,7 +304,7 @@ void page_attn_decode(
   TORCH_CHECK(block_table.dim() == 2);
   TORCH_CHECK(seq_lens.dim() == 1);
   TORCH_CHECK(kv_cache.dim() == 5);
-  TORCH_CHECK(query.dim() == 3, "query must be [num_tokens, num_q_heads, head_dim]");
+  TORCH_CHECK(query.dim() == 3, "query must be [batches, num_q_heads, head_dim]");
   TORCH_CHECK(query.scalar_type() == torch::kHalf);
   TORCH_CHECK(kv_cache.scalar_type() == torch::kHalf);
   TORCH_CHECK(out.scalar_type() == torch::kHalf);
@@ -319,6 +319,7 @@ void page_attn_decode(
   uint32_t batches = seq_lens.size(0);
   // Derive headQk from query tensor shape instead of hardcoding gqaRatio=4
   uint32_t headQk = query.size(1);
+  TORCH_CHECK(headV > 0, "num_kv_heads must be positive");
   uint32_t gqaRatio = headQk / headV;
   TORCH_CHECK(gqaRatio * headV == headQk, "num_q_heads must be a multiple of num_kv_heads");
   TORCH_CHECK(gqaRatio >= 4 && gqaRatio % 4 == 0, "gqaRatio must be a multiple of 4, got ", gqaRatio);

--- a/vllm/custom-esimd-kernels-vllm/csrc/eagle/eagle.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/eagle/eagle.sycl
@@ -177,17 +177,22 @@ void page_attention_forward_kernel(
   uint32_t pStride,
   uint32_t maxStride,
   uint32_t maxKvSeqLen,
+  uint32_t gqaRatio,
   const torch::Device& device) {
   uint32_t groupH, groupV, groupD;
-  groupH = headV;
+  uint32_t gqaGroups = gqaRatio / 4;
+  // Phase1: each work group of 4 threads handles 4 q-heads sharing one kv-head
+  // Total groups in dim0 = headV * gqaGroups (one group per 4-q-head chunk)
+  groupH = headV * gqaGroups;
   groupV = (maxKvSeqLen + 63) / 64;
   groupD = batches;
   sycl::range<3> globalPaPhase1(groupH * 4, groupV, groupD);
   sycl::range<3> localPaPhase1(4, 1, 1);
   sycl::nd_range<3> rangePaPhase1(globalPaPhase1, localPaPhase1);
 
+  // Phase2: each work group of 2 threads handles 4 q-heads for 16 output dims
   groupH = headDim / 16;
-  groupV = headV;
+  groupV = headV * gqaGroups;
   groupD = batches;
   sycl::range<3> globalPaPhase2(groupH * 2, groupV, groupD);
   sycl::range<3> localPaPhase2(2, 1, 1);
@@ -199,7 +204,7 @@ void page_attention_forward_kernel(
     cgh.parallel_for<class paPhase1Forward>(
       rangePaPhase1, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
         sdpaDecodeGqa4Phase1(qState, kvCache, (uint8_t*)pState, pMax, pageTable, kvSeqLens,
-          batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, idx);
+          batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, gqaRatio, idx);
       });
     };
 
@@ -207,7 +212,7 @@ void page_attention_forward_kernel(
     cgh.parallel_for<class paPhase2Forward>(
       rangePaPhase2, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
         sdpaDecodeGqa4Phase2((uint8_t*)pState, pMax, kvCache, out, pageTable, kvSeqLens,
-          batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, idx);
+          batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, gqaRatio, idx);
       });
     };
 
@@ -299,6 +304,7 @@ void page_attn_decode(
   TORCH_CHECK(block_table.dim() == 2);
   TORCH_CHECK(seq_lens.dim() == 1);
   TORCH_CHECK(kv_cache.dim() == 5);
+  TORCH_CHECK(query.dim() == 3, "query must be [num_tokens, num_q_heads, head_dim]");
   TORCH_CHECK(query.scalar_type() == torch::kHalf);
   TORCH_CHECK(kv_cache.scalar_type() == torch::kHalf);
   TORCH_CHECK(out.scalar_type() == torch::kHalf);
@@ -311,7 +317,11 @@ void page_attn_decode(
   uint32_t headV = kv_cache.size(totalDimsKv - 2);
   uint32_t pageSize = kv_cache.size(totalDimsKv - 3);
   uint32_t batches = seq_lens.size(0);
-  uint32_t headQk = headV << 2;
+  // Derive headQk from query tensor shape instead of hardcoding gqaRatio=4
+  uint32_t headQk = query.size(1);
+  uint32_t gqaRatio = headQk / headV;
+  TORCH_CHECK(gqaRatio * headV == headQk, "num_q_heads must be a multiple of num_kv_heads");
+  TORCH_CHECK(gqaRatio >= 4 && gqaRatio % 4 == 0, "gqaRatio must be a multiple of 4, got ", gqaRatio);
   uint32_t maxSeqLen = max_seq_len;
   uint32_t hiddenDimP = ((maxSeqLen + 63) / 64) * 64;
   uint32_t hiddenDimPMax = ((maxSeqLen + 63) / 64);
@@ -349,6 +359,7 @@ void page_attn_decode(
     hiddenDimP,
     hiddenDimPMax,
     maxSeqLen,
+    gqaRatio,
     kv_cache.device()
   );
 }

--- a/vllm/custom-esimd-kernels-vllm/csrc/eagle/page.attn.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/eagle/page.attn.h
@@ -16,24 +16,27 @@ ESIMD_INLINE void sdpaDecodeGqa4Phase1(
   uint32_t pStride,
   uint32_t maxStride,
   uint32_t headKv,
+  uint32_t gqaRatio,
   sycl::nd_item<3>& ndi) {
   constexpr uint32_t baseOffsetInc16[16] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
   constexpr float matMulQuantCoeff = 0.0625f;
-  constexpr uint32_t gqaRatio = 4;
   constexpr uint32_t headDim = 256;
   constexpr uint32_t maxPGroupOut = 128;
   constexpr uint32_t outputPerGroup = 64;
-  constexpr uint32_t slmSize = (4 * maxPGroupOut * gqaRatio * sizeof(float));
+  uint32_t slmSize = (4 * maxPGroupOut * 4 * sizeof(float));
   constexpr uint32_t loopCount = outputPerGroup / 16;
-  __ESIMD_NS::slm_init(slmSize);
+  __ESIMD_NS::slm_init<4 * 128 * 4 * sizeof(float)>();
   int localLinearId = ndi.get_local_id(0);
-  int globalLinearId0 = ndi.get_group(0); // [0, kvHead)
+  int globalLinearId0 = ndi.get_group(0); // [0, kvHead * gqaRatio/4)
   int globalLinearId1 = ndi.get_group(1); // [0, keSeqLen / 64)
   int globalLinearId2 = ndi.get_group(2); // [0, bs)
   int hh = localLinearId & 0x3;
   int vv = localLinearId >> 2;
   int batchIdx = globalLinearId2;
-  int qHeadIdx = globalLinearId0 * 4;
+  uint32_t gqaGroups = gqaRatio / 4;
+  int kvHeadIdx = globalLinearId0 / gqaGroups;
+  int qGroupIdx = globalLinearId0 % gqaGroups;
+  int qHeadIdx = kvHeadIdx * gqaRatio + qGroupIdx * 4;
   uint32_t pageTableSize = 1 << pageTableSizeLog2;
   uint32_t pageTableLoopMask = pageTableSize - 1;
   uint32_t kvSeqLen = batchKvSeqLen[batchIdx];
@@ -52,7 +55,7 @@ ESIMD_INLINE void sdpaDecodeGqa4Phase1(
   uint32_t outputMaxOffset = qHeadIdx * maxStride + globalLinearId1 + hh * maxStride + batchIdx * headQ * maxStride;
   uint32_t offsetQ = qHeadIdx * headDim * sizeof(fp16) + hh * 32 * sizeof(fp16) + batchIdx * headQ * headDim * sizeof(fp16);
   uint32_t baseCoordK = globalLinearId1 * outputPerGroup;
-  uint32_t offsetBaseK = hh * 32 * sizeof(fp16) + headDim * globalLinearId0 * sizeof(fp16);
+  uint32_t offsetBaseK = hh * 32 * sizeof(fp16) + headDim * kvHeadIdx * sizeof(fp16);
   uint32_t kvSeqOffset = baseCoordK;
 
   if (baseCoordK >= kvSeqLen) {
@@ -208,23 +211,26 @@ ESIMD_INLINE void sdpaDecodeGqa4Phase2(
   uint32_t pStride,
   uint32_t maxStride,
   uint32_t headKv,
+  uint32_t gqaRatio,
   sycl::nd_item<3>& ndi) {
-  constexpr uint32_t gqaRatio = 4;
   constexpr uint32_t headDim = 256;
   constexpr uint32_t maxPGroupOut = 128;
   constexpr uint32_t outputPerGroup = 64;
   constexpr float matMulQuantCoeff = 0.0625f;
-  constexpr uint32_t slmSizeOut = 2 * gqaRatio * 16 * sizeof(float);
-  constexpr uint32_t slmSizeSoftmaxSum = 2 * gqaRatio * sizeof(float);
+  constexpr uint32_t slmSizeOut = 2 * 4 * 16 * sizeof(float);
+  constexpr uint32_t slmSizeSoftmaxSum = 2 * 4 * sizeof(float);
   constexpr uint32_t slmSize = slmSizeOut + slmSizeSoftmaxSum;
-  __ESIMD_NS::slm_init(slmSize);
+  __ESIMD_NS::slm_init<slmSize>();
   int localLinearId = ndi.get_local_id(0);
   int globalLinearId0 = ndi.get_group(0); // [0, head dim / 16)
-  int globalLinearId1 = ndi.get_group(1); // [0, kvHead)
+  int globalLinearId1 = ndi.get_group(1); // [0, kvHead * gqaRatio/4)
   int globalLinearId2 = ndi.get_group(2); // [0, bs)
   int hh = localLinearId & 0x1;
   int vv = localLinearId >> 1;
   int batchIdx = globalLinearId2;
+  uint32_t gqaGroups = gqaRatio / 4;
+  int kvHeadIdx = globalLinearId1 / gqaGroups;
+  int qGroupIdx = globalLinearId1 % gqaGroups;
   uint32_t kvSeqLen = batchKvSeqLen[batchIdx];
   int kvSeqOutLoopCount = (kvSeqLen + 0x3f) >> 6;
   uint32_t pageTableSize = 1 << pageTableSizeLog2;
@@ -240,12 +246,13 @@ ESIMD_INLINE void sdpaDecodeGqa4Phase2(
   simd<float, 32> vvScale;
 
   uint32_t headQ = headKv * gqaRatio;
-  uint32_t outputOffset = globalLinearId1 * gqaRatio * headDim + globalLinearId0 * 16 + hh * 2 * headDim + batchIdx * headQ * headDim;
-  uint32_t offsetP = globalLinearId1 * gqaRatio * pStride + hh * 32 + batchIdx * headQ * pStride;
-  uint32_t offsetMax = globalLinearId1 * gqaRatio * maxStride + batchIdx * headQ * maxStride;
+  uint32_t qBaseIdx = kvHeadIdx * gqaRatio + qGroupIdx * 4;
+  uint32_t outputOffset = qBaseIdx * headDim + globalLinearId0 * 16 + hh * 2 * headDim + batchIdx * headQ * headDim;
+  uint32_t offsetP = qBaseIdx * pStride + hh * 32 + batchIdx * headQ * pStride;
+  uint32_t offsetMax = qBaseIdx * maxStride + batchIdx * headQ * maxStride;
   uint32_t widthV = headKv * headDim * sizeof(fp16) - 1;
   uint32_t heightV = pageTableSize - 1;
-  uint32_t vX = globalLinearId0 * 16 + headDim * globalLinearId1;
+  uint32_t vX = globalLinearId0 * 16 + headDim * kvHeadIdx;
   uint32_t vY = 32 * hh;
   uint32_t totalPages = (kvSeqLen + pageTableSize - 1) >> pageTableSizeLog2;
   uint32_t lastPageHeight = (kvSeqLen - 1) & (pageTableSize - 1);

--- a/vllm/custom-esimd-kernels-vllm/csrc/eagle/page.attn.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/eagle/page.attn.h
@@ -23,9 +23,9 @@ ESIMD_INLINE void sdpaDecodeGqa4Phase1(
   constexpr uint32_t headDim = 256;
   constexpr uint32_t maxPGroupOut = 128;
   constexpr uint32_t outputPerGroup = 64;
-  uint32_t slmSize = (4 * maxPGroupOut * 4 * sizeof(float));
   constexpr uint32_t loopCount = outputPerGroup / 16;
-  __ESIMD_NS::slm_init<4 * 128 * 4 * sizeof(float)>();
+  constexpr uint32_t slmSizePhase1 = 4 * maxPGroupOut * 4 * sizeof(float);
+  __ESIMD_NS::slm_init<slmSizePhase1>();
   int localLinearId = ndi.get_local_id(0);
   int globalLinearId0 = ndi.get_group(0); // [0, kvHead * gqaRatio/4)
   int globalLinearId1 = ndi.get_group(1); // [0, keSeqLen / 64)


### PR DESCRIPTION
Previously gqaRatio was hardcoded to 4, which only worked for TP=8 (num_q_heads=4, num_kv_heads=1). This broke TP=4 where gqaRatio=8.

Now gqaRatio is derived at runtime from query.size(1) / num_kv_heads. Each work group still processes 4 q-heads (local_size=4 unchanged), and multiple groups are launched per kv-head when gqaRatio > 4.

Verified: correctness matches PyTorch reference for gqaRatio={4,8}, performance regression < 5%.