### PR TITLE
vLLM: add PA split-K and fused paged attention kernels

### DIFF
--- a/vllm/custom-esimd-kernels-vllm/csrc/eagle/page.attn.fused.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/eagle/page.attn.fused.h
@@ -1,0 +1,294 @@
+// page.attn.fused.h — Fused single-kernel paged attention decode
+// GQA ratio = 4, head_dim = 256, fp16.
+//
+// Grid:  (kvHead, batches)      ← 2D, not 3D
+// WG:    4 threads
+//
+// Register peak: 91 / 128 GRF (K phase), 67 / 128 GRF (V phase)
+
+#define FUSED_FP32_MIN (-1e+38f)
+
+ESIMD_INLINE void sdpaDecodeGqa4Fused(
+  uint8_t* qState,
+  uint8_t* kvCache,
+  uint8_t* out,
+  uint32_t* pageTable,
+  uint32_t* batchKvSeqLen,
+  uint32_t batchSize,
+  uint32_t kvCacheBatchStride0,
+  uint32_t kvCacheBatchStride1,
+  uint32_t pageTableBatchStride,
+  uint32_t pageTableSizeLog2,
+  uint32_t headKv,
+  sycl::nd_item<2>& ndi) {
+
+  constexpr uint32_t baseOffsetInc16[16] = {0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15};
+  constexpr float scaleCoeff = 0.0625f;
+  constexpr uint32_t gqaRatio = 4;
+  constexpr uint32_t headDim = 256;
+
+  // SLM: 4 threads × 4 heads × 16 scores = 1024 bytes
+  constexpr uint32_t slmSize = 4 * gqaRatio * 16 * sizeof(float);
+  __ESIMD_NS::slm_init(slmSize);
+
+  int hh         = ndi.get_local_id(0);  // [0..3]
+  int kvHeadIdx  = ndi.get_group(0);
+  int batchIdx   = ndi.get_group(1);
+
+  uint32_t headQ         = headKv * gqaRatio;
+  uint32_t pageTableSize = 1u << pageTableSizeLog2;
+  uint32_t pageMask      = pageTableSize - 1;
+  uint32_t kvSeqLen      = batchKvSeqLen[batchIdx];
+  uint32_t pageTableBase = pageTableBatchStride * batchIdx;
+
+  if (kvSeqLen == 0) return;
+
+  simd<uint32_t, 16> baseInc16(baseOffsetInc16);
+  uint32_t qHeadIdx = kvHeadIdx * gqaRatio;
+
+  // ══════ Load Q (identical to Phase 1) ══════
+  // Each thread: 4 heads × 64 dims (two 32-dim chunks: hh*32 and 128+hh*32)
+  simd<fp16, 64 * 4> qqFp16;
+  simd<float, 64 * 4> qqFp32;  // 16 GRF — constant
+
+  uint32_t offsetQ = (qHeadIdx * headDim + hh * 32) * sizeof(fp16)
+                   + batchIdx * headQ * headDim * sizeof(fp16);
+
+#pragma unroll
+  for (int qn = 0; qn < 4; qn++) {
+#pragma unroll
+    for (int qk = 0; qk < 2; qk++) {
+      qqFp16.template bit_cast_view<uint8_t>().select<64, 1>(128 * qn + 64 * qk) =
+        __ESIMD_ENS::lsc_block_load<uint8_t, 64,
+          __ESIMD_ENS::lsc_data_size::default_size,
+          __ESIMD_ENS::cache_hint::cached,
+          __ESIMD_ENS::cache_hint::cached>(
+            (uint8_t*)qState + offsetQ
+            + qn * headDim * sizeof(fp16)
+            + qk * 4 * 32 * sizeof(fp16));
+    }
+  }
+  qqFp32 = qqFp16;
+
+  // ══════ Output accumulator — constant across loop ══════
+  simd<float, 4 * 64> outputAccum = 0.0f;  // 16 GRF
+  simd<float, 4> runningMax;                // 1 GRF
+  runningMax = FUSED_FP32_MIN;
+  simd<float, 4> softmaxSum = 0.0f;        // 1 GRF
+  // Total constant: 34 GRF
+
+
+  // ══════ K offset base (same as Phase 1) ══════
+  uint32_t offsetBaseK = hh * 32 * sizeof(fp16) + headDim * kvHeadIdx * sizeof(fp16);
+
+  // ══════ V cache ══════
+  uint32_t vWidthBytes = headKv * headDim * sizeof(fp16) - 1;
+  fp16* vPtrBase = (fp16*)kvCache + kvCacheBatchStride0;
+  uint32_t totalPages = (kvSeqLen + pageTableSize - 1) >> pageTableSizeLog2;
+  uint32_t lastPageH  = (kvSeqLen - 1) & pageMask;
+
+  // ══════ Main loop: 16 tokens per chunk ══════
+  uint32_t numChunks = (kvSeqLen + 15) / 16;
+
+  for (uint32_t chunkIdx = 0; chunkIdx < numChunks; chunkIdx++) {
+    uint32_t kvSeqOffset = chunkIdx * 16;
+
+    // Page table lookup
+    uint32_t ptIdx    = kvSeqOffset >> pageTableSizeLog2;
+    uint32_t ptOffset = kvSeqOffset & pageMask;
+    uint32_t pageIdx  = pageTable[pageTableBase + ptIdx];
+
+    // Validity mask
+    simd<uint16_t, 16> validMask   = (baseInc16 + kvSeqOffset) < kvSeqLen;
+    simd<uint16_t, 16> invalidMask = (baseInc16 + kvSeqOffset) >= kvSeqLen;
+
+    // ─── QK^T: copied from Phase 1, kkCacheHalf per kk ───
+    simd<float, 4 * 16> partialScores = 0.0f;  // 4 GRF
+
+    simd<uint32_t, 16> simdOffsetsK = baseInc16;
+    simdOffsetsK =
+      simdOffsetsK * headKv * headDim * sizeof(fp16)
+      + offsetBaseK
+      + pageIdx * kvCacheBatchStride1 * sizeof(fp16)
+      + ptOffset * headKv * headDim * sizeof(fp16);
+
+#pragma unroll
+    for (int kk = 0; kk < 2; kk++) {
+      // 16 GRF: 512 fp16 = 16 tokens × 32 dims (one kk half)
+      simd<fp16, 16 * 32> kkCacheHalf;
+      // 32 GRF: 512 float (deinterleaved)
+      simd<float, 16 * 32> kkFp32;
+
+      // 4 gathers: 16 lanes × 4 uint32 = 16 tokens × 8 fp16 each
+#pragma unroll
+      for (int kkk = 0; kkk < 4; kkk++) {
+        kkCacheHalf.template bit_cast_view<uint32_t>().select<64, 1>(64 * kkk) =
+          __ESIMD_ENS::lsc_gather<uint32_t, 4,
+            __ESIMD_ENS::lsc_data_size::u32,
+            __ESIMD_ENS::cache_hint::cached,
+            __ESIMD_ENS::cache_hint::cached,
+            16, uint32_t>(
+              (uint32_t*)kvCache, simdOffsetsK, validMask);
+        simdOffsetsK = simdOffsetsK + 8 * sizeof(fp16);
+      }
+
+      // Skip to next 32-dim block (other 3 threads' slices)
+      simdOffsetsK = simdOffsetsK + 3 * 32 * sizeof(fp16);
+
+      // Deinterleave fp16 pairs within uint32 → fp32
+      // Same pattern as original but with offset 0 instead of 512*kk
+#pragma unroll
+      for (int kkk = 0; kkk < 16; kkk++) {
+        kkFp32.select<16, 1>(32 * kkk + 16 * 0) = kkCacheHalf.select<16, 2>(32 * kkk + 0);
+        kkFp32.select<16, 1>(32 * kkk + 16 * 1) = kkCacheHalf.select<16, 2>(32 * kkk + 1);
+      }
+
+      // MAD: partialScores[head, token] += K[dim, token] * Q[head, dim]
+#pragma unroll
+      for (int kkk = 0; kkk < 32; kkk++) {
+#pragma unroll
+        for (int pn = 0; pn < 4; pn++) {
+          partialScores.select<16, 1>(16 * pn) =
+            partialScores.select<16, 1>(16 * pn)
+            + kkFp32.select<16, 1>(16 * kkk) * qqFp32[64 * pn + 32 * kk + kkk];
+        }
+      }
+    } // kk
+    // After this scope: kkCacheHalf(16) + kkFp32(32) = 48 GRF freed
+
+    // Mask invalid tokens
+#pragma unroll
+    for (int pn = 0; pn < 4; pn++) {
+      partialScores.select<16, 1>(16 * pn).merge(FUSED_FP32_MIN, invalidMask);
+    }
+
+    // ─── SLM reduce: 4 threads → full 4×16 scores ───
+    // Each thread writes its partial scores for all 4 heads
+#pragma unroll
+    for (int pn = 0; pn < 4; pn++) {
+      slm_block_store<float, 16>(
+        hh * gqaRatio * 16 * sizeof(float) + pn * 16 * sizeof(float),
+        partialScores.select<16, 1>(16 * pn));
+    }
+    barrier();
+
+    // Each thread reads and sums across 4 threads
+    simd<float, 4 * 16> fullScores;  // 4 GRF (reuses partialScores reg space)
+#pragma unroll
+    for (int pn = 0; pn < 4; pn++) {
+      simd<float, 16> s =
+        slm_block_load<float, 16>(0 * gqaRatio * 16 * sizeof(float) + pn * 16 * sizeof(float));
+      s = s + slm_block_load<float, 16>(1 * gqaRatio * 16 * sizeof(float) + pn * 16 * sizeof(float));
+      s = s + slm_block_load<float, 16>(2 * gqaRatio * 16 * sizeof(float) + pn * 16 * sizeof(float));
+      s = s + slm_block_load<float, 16>(3 * gqaRatio * 16 * sizeof(float) + pn * 16 * sizeof(float));
+      fullScores.select<16, 1>(16 * pn) = s;
+    }
+    barrier();  // protect SLM for next iteration
+
+    // ─── Online softmax ───
+    fullScores = fullScores * scaleCoeff;
+
+    simd<float, 4> chunkMax;
+#pragma unroll
+    for (int pn = 0; pn < 4; pn++) {
+      simd<float, 16> s = fullScores.select<16, 1>(16 * pn);
+      simd<float, 8> m8 = __ESIMD_NS::max<float, 8, float>(s.select<8,1>(0), s.select<8,1>(8));
+      simd<float, 4> m4 = __ESIMD_NS::max<float, 4, float>(m8.select<4,1>(0), m8.select<4,1>(4));
+      simd<float, 2> m2 = __ESIMD_NS::max<float, 2, float>(m4.select<2,1>(0), m4.select<2,1>(2));
+      chunkMax[pn] = __ESIMD_NS::max<float>(m2[0], m2[1]);
+    }
+
+    simd<float, 4> newMax = __ESIMD_NS::max<float, 4, float>(chunkMax, runningMax);
+    simd<float, 4> compOld = exp(runningMax - newMax);
+    simd<float, 4> compNew = exp(chunkMax - newMax);
+
+    // Rescale accumulators
+#pragma unroll
+    for (int pn = 0; pn < 4; pn++) {
+      outputAccum.select<64, 1>(64 * pn) = outputAccum.select<64, 1>(64 * pn) * compOld[pn];
+      softmaxSum[pn] = softmaxSum[pn] * compOld[pn];
+    }
+
+    // exp(score - newMax) and accumulate softmax sum
+    simd<float, 4 * 16> expScores;  // 4 GRF
+#pragma unroll
+    for (int pn = 0; pn < 4; pn++) {
+      expScores.select<16, 1>(16 * pn) = exp(fullScores.select<16, 1>(16 * pn) - newMax[pn]);
+      softmaxSum[pn] = softmaxSum[pn]
+        + __ESIMD_DNS::sum<float, float, 16>(expScores.select<16, 1>(16 * pn));
+    }
+
+    runningMax = newMax;
+
+    // ─── V accumulation ───
+    // This thread owns 64 output dims (two 32-dim chunks).
+    // Process in 4 sub-passes of 16 dims: lsc_load_2d(16 tokens × 16 dims)
+    //
+    // V sub-pass dim offsets within headDim=256:
+    //   pass 0: hh*32 + 0
+    //   pass 1: hh*32 + 16
+    //   pass 2: 128 + hh*32 + 0
+    //   pass 3: 128 + hh*32 + 16
+
+    uint32_t pageOffset = pageIdx * kvCacheBatchStride1;
+    fp16* currPtrV = vPtrBase + pageOffset;
+    uint32_t heightV = (ptIdx + 1 < totalPages) ? (pageTableSize - 1) : lastPageH;
+
+    uint32_t vDimBase[4];
+    vDimBase[0] = kvHeadIdx * headDim + hh * 32;
+    vDimBase[1] = kvHeadIdx * headDim + hh * 32 + 16;
+    vDimBase[2] = kvHeadIdx * headDim + 128 + hh * 32;
+    vDimBase[3] = kvHeadIdx * headDim + 128 + hh * 32 + 16;
+
+#pragma unroll
+    for (int vpass = 0; vpass < 4; vpass++) {
+      simd<fp16, 16 * 16> vvCache;  // 8 GRF
+      vvCache =
+        __ESIMD_ENS::lsc_load_2d<fp16, 16, 16, 1, false, false,
+          __ESIMD_ENS::cache_hint::cached,
+          __ESIMD_ENS::cache_hint::cached>(
+            currPtrV, vWidthBytes, heightV, vWidthBytes,
+            vDimBase[vpass],  // x = dim offset
+            ptOffset);        // y = token offset within page
+
+      simd<float, 16 * 16> vvFp32;  // 16 GRF
+      vvFp32 = vvCache;
+
+      // output[head, vpass*16 + 0..15] += sum_t( expScore[head, t] * V[t, 0..15] )
+      uint32_t dimOff = vpass * 16;
+#pragma unroll
+      for (int pn = 0; pn < 4; pn++) {
+#pragma unroll
+        for (int t = 0; t < 16; t++) {
+          outputAccum.select<16, 1>(64 * pn + dimOff) =
+            outputAccum.select<16, 1>(64 * pn + dimOff)
+            + vvFp32.select<16, 1>(16 * t) * expScores[16 * pn + t];
+        }
+      }
+    }
+  } // end main loop
+
+  // ══════ Finalize: normalize and store ══════
+  uint32_t outBase = (batchIdx * headQ + qHeadIdx) * headDim;
+
+#pragma unroll
+  for (int pn = 0; pn < 4; pn++) {
+    float ss = softmaxSum[pn];
+    float invSum = (ss > 0.0f) ? (1.0f / ss) : 0.0f;
+    outputAccum.select<64, 1>(64 * pn) = outputAccum.select<64, 1>(64 * pn) * invSum;
+  }
+
+  // Store: 4 heads × 2 chunks of 32 fp16
+#pragma unroll
+  for (int pn = 0; pn < 4; pn++) {
+    simd<fp16, 64> outFp16 = outputAccum.select<64, 1>(64 * pn);
+    // First 32 dims: offset hh*32
+    block_store<fp16, 32>(
+      (fp16*)out + outBase + pn * headDim + hh * 32,
+      outFp16.select<32, 1>(0));
+    // Second 32 dims: offset 128+hh*32
+    block_store<fp16, 32>(
+      (fp16*)out + outBase + pn * headDim + 128 + hh * 32,
+      outFp16.select<32, 1>(32));
+  }
+}

--- a/vllm/custom-esimd-kernels-vllm/csrc/eagle/page.attn.splitk.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/eagle/page.attn.splitk.h
@@ -1,0 +1,328 @@
+// page.attn.splitk.h — Split-K paged attention decode for GQA4 / headDim=256
+//
+// Reuses Phase 1 (sdpaDecodeGqa4Phase1) from page.attn.h unchanged.
+// Phase 2 is split along the KV-sequence dimension.
+// numPartitions is FIXED at launch time (e.g. 8). Each WG computes its
+// own token range from the per-batch seq_lens[batchIdx] on device, so
+// the grid size and buffer size are independent of max_model_len.
+
+// ────────────────────────────────────────────────────────────────────────
+// Phase 2 with split-K.
+//
+// Grid:  (headDim/16 * 2,  kvHead,  batches * numPartitions)
+// Local: (2, 1, 1)
+//
+// Each WG computes:
+//   kvSeqLen = batchKvSeqLen[batchIdx]
+//   totalChunks = ceil(kvSeqLen / 64)
+//   myStartChunk = partitionIdx * ceil(totalChunks / numPartitions)
+//   myEndChunk   = min((partitionIdx+1) * ceil(totalChunks / numPartitions), totalChunks)
+//
+// This means the partition boundaries adapt to actual sequence length,
+// not max_model_len.
+// ────────────────────────────────────────────────────────────────────────
+ESIMD_INLINE void sdpaDecodeGqa4Phase2SplitK(
+  uint8_t* pState,
+  float* pMax,
+  uint8_t* vState,
+  uint8_t* tmpOut,
+  float* expSums,
+  float* maxLogitsOut,
+  uint32_t* pageTable,
+  uint32_t* batchKvSeqLen,
+  uint32_t batchSize,
+  uint32_t kvCacheBatchStride0,
+  uint32_t kvCacheBatchStride1,
+  uint32_t pageTableBatchStride,
+  uint32_t pageTableSizeLog2,
+  uint32_t pStride,
+  uint32_t maxStride,
+  uint32_t headKv,
+  uint32_t numPartitions,
+  sycl::nd_item<3>& ndi) {
+
+  constexpr uint32_t gqaRatio = 4;
+  constexpr uint32_t headDim = 256;
+  constexpr uint32_t outputPerGroup = 64;
+  constexpr float matMulQuantCoeff = 0.0625f;
+  constexpr uint32_t slmSizeOut = 2 * gqaRatio * 16 * sizeof(float);
+  constexpr uint32_t slmSizeSoftmaxSum = 2 * gqaRatio * sizeof(float);
+  constexpr uint32_t slmSize = slmSizeOut + slmSizeSoftmaxSum;
+  __ESIMD_NS::slm_init(slmSize);
+
+  int localLinearId = ndi.get_local_id(0);
+  int globalLinearId0 = ndi.get_group(0); // [0, headDim / 16)
+  int globalLinearId1 = ndi.get_group(1); // [0, kvHead)
+  int globalLinearId2 = ndi.get_group(2); // [0, batches * numPartitions)
+  int hh = localLinearId & 0x1;
+
+  int batchIdx = globalLinearId2 / numPartitions;
+  int partitionIdx = globalLinearId2 % numPartitions;
+
+  uint32_t kvSeqLen = batchKvSeqLen[batchIdx];
+  uint32_t headQ = headKv * gqaRatio;
+
+  // ── Compute this partition's chunk range from actual kvSeqLen ──
+  uint32_t totalChunks = (kvSeqLen + outputPerGroup - 1) / outputPerGroup;
+  uint32_t chunksPerPart = (totalChunks + numPartitions - 1) / numPartitions;
+  uint32_t partStartChunk = partitionIdx * chunksPerPart;
+  uint32_t partEndChunk = partStartChunk + chunksPerPart;
+  if (partEndChunk > totalChunks) partEndChunk = totalChunks;
+
+  // Early exit: no work for this partition
+  if (partStartChunk >= totalChunks) {
+    if (localLinearId == 0 && globalLinearId0 == 0) {
+      uint32_t metaBase = (batchIdx * numPartitions + partitionIdx) * headQ;
+      for (uint32_t h = 0; h < headQ; h++) {
+        expSums[metaBase + h]   = 0.0f;
+        maxLogitsOut[metaBase + h] = FP32_MIN * matMulQuantCoeff;
+      }
+    }
+    return;
+  }
+
+  int kvSeqOutLoopCount = (int)(partEndChunk - partStartChunk);
+
+  uint32_t pageTableSize     = 1 << pageTableSizeLog2;
+  uint32_t pageTableLoopMask = pageTableSize - 1;
+  uint32_t pageTableBase     = pageTableBatchStride * batchIdx;
+
+  simd<uint32_t, 32> simdOffsetsVs;
+  simd<float, 4 * 32> ppFp32;
+  simd<float, 4> historicMax;
+  simd<fp16, 32 * 16> vvCache;
+  simd<float, 16 * 16> vvFp32;
+  simd<float, 4 * 16> softmaxSum;
+  simd<float, 4 * 16> outputFp32;
+
+  // tmpOut layout:  [batches, numPartitions, headQ, headDim]  fp16
+  uint32_t tmpOutOffset =
+      ((batchIdx * numPartitions + partitionIdx) * headQ
+        + globalLinearId1 * gqaRatio) * headDim
+      + globalLinearId0 * 16
+      + hh * 2 * headDim;
+
+  // pState / pMax pointers — offset to this partition's first chunk
+  uint32_t offsetP = globalLinearId1 * gqaRatio * pStride
+                   + hh * 32
+                   + batchIdx * headQ * pStride
+                   + partStartChunk * outputPerGroup;
+
+  uint32_t offsetMax = globalLinearId1 * gqaRatio * maxStride
+                     + batchIdx * headQ * maxStride
+                     + partStartChunk;
+
+  // V cache 2D-load parameters
+  uint32_t widthV  = headKv * headDim * sizeof(fp16) - 1;
+  uint32_t heightV = pageTableSize - 1;
+  uint32_t vX      = globalLinearId0 * 16 + headDim * globalLinearId1;
+  uint32_t vY;
+  uint32_t totalPages    = (kvSeqLen + pageTableSize - 1) >> pageTableSizeLog2;
+  uint32_t lastPageHeight = (kvSeqLen > 0) ? ((kvSeqLen - 1) & (pageTableSize - 1)) : 0;
+  fp16* vPtrBase = (fp16*)vState + kvCacheBatchStride0;
+
+  historicMax = FP32_MIN * matMulQuantCoeff;
+  softmaxSum  = 0;
+  outputFp32  = 0;
+
+  // ── Main loop ──
+  for (int loopIdx = 0; loopIdx < kvSeqOutLoopCount; loopIdx++) {
+    simd<float, 4> loopMax;
+    simd<float, 4> currMax;
+    simd<float, 4> compensationP;
+    simd<float, 4> compensationO;
+    uint32_t kvSeqOffset    = (partStartChunk + loopIdx) * outputPerGroup;
+    uint32_t pageTableIdx   = kvSeqOffset >> pageTableSizeLog2;
+    uint32_t pageTableOffset = kvSeqOffset & pageTableLoopMask;
+    uint32_t pageIdx  = pageTable[pageTableBase + pageTableIdx];
+    uint32_t pageOff  = pageIdx * kvCacheBatchStride1;
+    fp16* currPtrV = vPtrBase + pageOff;
+
+    heightV = (pageTableIdx + 1 < totalPages) ? (pageTableSize - 1) : lastPageHeight;
+    vY = pageTableOffset + 32 * hh;
+
+#pragma unroll
+    for (int pn = 0; pn < 4; pn++) {
+      ppFp32.select<32, 1>(32 * pn) =
+        block_load<float, 32>((float*)pState + offsetP + pStride * pn);
+      currMax[pn] = pMax[offsetMax + maxStride * pn];
+    }
+
+    vvCache.select<256, 1>(0) =
+      __ESIMD_ENS::lsc_load_2d<fp16, 16, 16, 1, false, false,
+        __ESIMD_ENS::cache_hint::cached,
+        __ESIMD_ENS::cache_hint::cached>(currPtrV, widthV, heightV, widthV, vX, vY);
+    vY += 16;
+    vvCache.select<256, 1>(256) =
+      __ESIMD_ENS::lsc_load_2d<fp16, 16, 16, 1, false, false,
+        __ESIMD_ENS::cache_hint::cached,
+        __ESIMD_ENS::cache_hint::cached>(currPtrV, widthV, heightV, widthV, vX, vY);
+
+    loopMax = __ESIMD_NS::max<float, 4, float>(currMax, historicMax);
+    compensationO = historicMax - loopMax;
+    compensationP = currMax - loopMax;
+    compensationO = exp(compensationO);
+    compensationP = exp(compensationP);
+
+#pragma unroll
+    for (int oc = 0; oc < 4; oc++)
+      ppFp32.select<32, 1>(32 * oc) = ppFp32.select<32, 1>(32 * oc) * compensationP[oc];
+
+#pragma unroll
+    for (int oc = 0; oc < 4; oc++) {
+      outputFp32.select<16, 1>(16 * oc) = outputFp32.select<16, 1>(16 * oc) * compensationO[oc];
+      softmaxSum.select<16, 1>(16 * oc) = softmaxSum.select<16, 1>(16 * oc) * compensationO[oc];
+    }
+
+#pragma unroll
+    for (int oc = 0; oc < 4; oc++) {
+#pragma unroll
+      for (int pk = 0; pk < 2; pk++)
+        softmaxSum.select<16, 1>(16 * oc) += ppFp32.select<16, 1>(32 * oc + 16 * pk);
+    }
+
+#pragma unroll
+    for (int vk = 0; vk < 2; vk++) {
+      vvFp32 = vvCache.select<256, 1>(256 * vk);
+#pragma unroll
+      for (int oc = 0; oc < 4; oc++) {
+#pragma unroll
+        for (int pk = 0; pk < 16; pk++)
+          outputFp32.select<16, 1>(16 * oc) += vvFp32.select<16, 1>(16 * pk) * ppFp32[32 * oc + 16 * vk + pk];
+      }
+    }
+
+    historicMax = loopMax;
+    offsetP   += outputPerGroup;
+    offsetMax += 1;
+  }
+
+  // ── SLM reduction across 2 threads ──
+
+#pragma unroll
+  for (int32_t kk = 0; kk < 4; kk++)
+    slm_block_store<float, 16>(hh * 16 * sizeof(float) + 32 * kk * sizeof(float),
+                               outputFp32.select<16, 1>(16 * kk));
+
+#pragma unroll
+  for (int32_t kk = 0; kk < 4; kk++) {
+    float s = __ESIMD_DNS::sum<float, float, 16>(softmaxSum.select<16, 1>(16 * kk));
+    slm_block_store<float, 1>(slmSizeOut + hh * sizeof(float) + 2 * kk * sizeof(float), s);
+  }
+
+  barrier();
+
+  {
+    simd<float, 4> dividor;
+    simd<float, 64> outputTempFp32;
+
+    dividor = slm_block_load<float, 4>(slmSizeOut + hh * 4 * sizeof(float));
+    dividor.select<2, 2>(0) = dividor.select<2, 2>(0) + dividor.select<2, 2>(1);
+
+    float expSum0 = dividor[0];
+    float expSum1 = dividor[2];
+
+    dividor = 1.0f / dividor;
+
+    outputTempFp32 = slm_block_load<float, 64>(hh * 4 * 16 * sizeof(float));
+
+#pragma unroll
+    for (int oc = 0; oc < 2; oc++) {
+      outputFp32.select<16, 1>(16 * oc) =
+        outputTempFp32.select<16, 1>(32 * oc) + outputTempFp32.select<16, 1>(32 * oc + 16);
+      outputFp32.select<16, 1>(16 * oc) = outputFp32.select<16, 1>(16 * oc) * dividor[2 * oc];
+    }
+
+    simd<fp16, 32> outputTemp = outputFp32.select<32, 1>(0);
+#pragma unroll
+    for (int oc = 0; oc < 2; oc++)
+      block_store<fp16, 16>((fp16*)tmpOut + tmpOutOffset + oc * headDim,
+                            outputTemp.select<16, 1>(16 * oc));
+
+    if (globalLinearId0 == 0) {
+      uint32_t metaBase = (batchIdx * numPartitions + partitionIdx) * headQ
+                        + globalLinearId1 * gqaRatio
+                        + hh * 2;
+      expSums[metaBase + 0]   = expSum0;
+      expSums[metaBase + 1]   = expSum1;
+      maxLogitsOut[metaBase + 0] = historicMax[hh * 2 + 0];
+      maxLogitsOut[metaBase + 1] = historicMax[hh * 2 + 1];
+    }
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Reduce kernel.
+//
+// Grid:  (headDim / 16,  headQ,  batches)
+// Local: (1, 1, 1)
+// ────────────────────────────────────────────────────────────────────────
+ESIMD_INLINE void sdpaDecodeGqa4Reduce(
+  uint8_t* tmpOut,
+  float*   expSums,
+  float*   maxLogitsArr,
+  uint8_t* out,
+  uint32_t* batchKvSeqLen,
+  uint32_t numPartitions,
+  uint32_t headQ,
+  sycl::nd_item<3>& ndi) {
+
+  constexpr uint32_t headDim = 256;
+  constexpr float matMulQuantCoeff = 0.0625f;
+
+  int dimChunk  = ndi.get_group(0);
+  int headIdx   = ndi.get_group(1);
+  int batchIdx  = ndi.get_group(2);
+
+  // Find how many partitions actually did work for this batch.
+  // A partition with expSum==0 and maxLogit==sentinel had no tokens.
+  float sentinel = FP32_MIN * matMulQuantCoeff;
+
+  // Fast path: single partition — just copy.
+  if (numPartitions == 1) {
+    uint32_t srcOff = (batchIdx * numPartitions * headQ + headIdx) * headDim + dimChunk * 16;
+    uint32_t dstOff = (batchIdx * headQ + headIdx) * headDim + dimChunk * 16;
+    simd<fp16, 16> v = block_load<fp16, 16>((fp16*)tmpOut + srcOff);
+    block_store<fp16, 16>((fp16*)out + dstOff, v);
+    return;
+  }
+
+  // 1. Find global max across active partitions
+  float globalMax = sentinel;
+  for (uint32_t p = 0; p < numPartitions; p++) {
+    uint32_t idx = (batchIdx * numPartitions + p) * headQ + headIdx;
+    float m = maxLogitsArr[idx];
+    if (m > globalMax) globalMax = m;
+  }
+
+  // 2. Accumulate rescaled partial outputs.
+  simd<float, 16> accum = 0.0f;
+  float globalExpSum = 0.0f;
+
+  for (uint32_t p = 0; p < numPartitions; p++) {
+    uint32_t metaIdx = (batchIdx * numPartitions + p) * headQ + headIdx;
+    float localMax    = maxLogitsArr[metaIdx];
+    float localExpSum = expSums[metaIdx];
+
+    // Skip empty partitions
+    if (localExpSum == 0.0f) continue;
+
+    float rescale     = exp(localMax - globalMax);
+    float rescaledExp = localExpSum * rescale;
+    globalExpSum += rescaledExp;
+
+    uint32_t srcOff = ((batchIdx * numPartitions + p) * headQ + headIdx) * headDim
+                    + dimChunk * 16;
+    simd<fp16, 16> partialFp16 = block_load<fp16, 16>((fp16*)tmpOut + srcOff);
+    simd<float, 16> partialFp32 = partialFp16;
+    accum = accum + partialFp32 * rescaledExp;
+  }
+
+  // 3. Normalise and store.
+  float invSum = (globalExpSum > 0.0f) ? (1.0f / globalExpSum) : 0.0f;
+  accum = accum * invSum;
+
+  uint32_t dstOff = (batchIdx * headQ + headIdx) * headDim + dimChunk * 16;
+  simd<fp16, 16> result = accum;
+  block_store<fp16, 16>((fp16*)out + dstOff, result);
+}

--- a/vllm/custom-esimd-kernels-vllm/csrc/eagle/page_attn_fused.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/eagle/page_attn_fused.sycl
@@ -1,0 +1,106 @@
+// page_attn_fused.sycl — fused single-kernel paged attention decode
+//
+// Single kernel, single launch. No intermediate global-memory buffer.
+
+#include <torch/extension.h>
+#include <c10/xpu/XPUStream.h>
+#include <sycl/ext/intel/esimd.hpp>
+#include <sycl/ext/intel/experimental/esimd/memory.hpp>
+using fp16 = sycl::half;
+using namespace sycl::ext::intel::esimd;
+namespace xesimd = sycl::ext::intel::experimental::esimd;
+
+static inline sycl::event submit_kernel_fused(
+    std::function<void(sycl::handler&)> kernel,
+    const torch::Device& device,
+    const char* desc) {
+  sycl::queue& queue = c10::xpu::getCurrentXPUStream(device.index()).queue();
+  return queue.submit(kernel);
+}
+
+static inline uint32_t getHighestBitFused(uint32_t in) {
+  uint32_t ret = 0;
+  uint32_t temp = in - 1;
+  while (temp != 0) { temp >>= 1; ret++; }
+  return ret;
+}
+
+#include "page.attn.fused.h"
+
+// ── torch op entry point ──────────────────────────────────────────────
+
+void page_attn_decode_fused(
+  torch::Tensor query,
+  torch::Tensor kv_cache,
+  torch::Tensor block_table,
+  torch::Tensor seq_lens,
+  torch::Tensor& out,
+  int64_t max_query_len,
+  int64_t max_seq_len
+) {
+  TORCH_CHECK(block_table.dim() == 2);
+  TORCH_CHECK(seq_lens.dim() == 1);
+  TORCH_CHECK(kv_cache.dim() == 5);
+  TORCH_CHECK(query.scalar_type() == torch::kHalf);
+  TORCH_CHECK(kv_cache.scalar_type() == torch::kHalf);
+  TORCH_CHECK(out.scalar_type() == torch::kHalf);
+  TORCH_CHECK(max_query_len == 1);
+
+  uint32_t kvCacheStride0 = kv_cache.stride(0);
+  uint32_t kvCacheStride1 = kv_cache.stride(1);
+  uint32_t totalDimsKv    = kv_cache.dim();
+  uint32_t headDim  = kv_cache.size(totalDimsKv - 1);
+  uint32_t headV    = kv_cache.size(totalDimsKv - 2);
+  uint32_t pageSize = kv_cache.size(totalDimsKv - 3);
+  uint32_t batches  = seq_lens.size(0);
+  uint32_t headQk   = headV << 2;
+  uint32_t pageTableSizeLog2    = getHighestBitFused(pageSize);
+  uint32_t pageTableBatchStride = block_table.stride(0);
+
+  TORCH_CHECK(headDim == 256);
+
+  // Extract raw pointers before lambda capture (torch::Tensor is not device-copyable)
+  uint8_t*  qPtr  = (uint8_t*)query.data_ptr();
+  uint8_t*  kvPtr = (uint8_t*)kv_cache.data_ptr();
+  uint8_t*  oPtr  = (uint8_t*)out.data_ptr();
+  uint32_t* btPtr = (uint32_t*)block_table.data_ptr();
+  uint32_t* slPtr = (uint32_t*)seq_lens.data_ptr();
+
+  // Single kernel launch — no intermediate buffers needed
+  uint32_t groupH = headV;     // kvHead
+  uint32_t groupD = batches;
+  sycl::range<2> global(groupH * 4, groupD);
+  sycl::range<2> local(4, 1);
+  sycl::nd_range<2> range(global, local);
+
+  auto kernel = [&](sycl::handler& cgh) {
+    cgh.parallel_for<class paFusedForward>(
+      range, [=](sycl::nd_item<2> idx) SYCL_ESIMD_KERNEL {
+        sdpaDecodeGqa4Fused(
+          qPtr, kvPtr, oPtr, btPtr, slPtr,
+          batches,
+          kvCacheStride0, kvCacheStride1,
+          pageTableBatchStride, pageTableSizeLog2,
+          headV, idx);
+      });
+  };
+  submit_kernel_fused(kernel, kv_cache.device(), "page_attn_fused");
+}
+
+// ── torch library + pybind registration ───────────────────────────────
+
+TORCH_LIBRARY_FRAGMENT(page_attn_fused_ops, m) {
+  m.def("page_attn_decode_fused("
+        "Tensor query, Tensor kv_cache, Tensor block_table, Tensor seq_lens, "
+        "Tensor! out, int max_query_len, int max_seq_len"
+        ") -> ()");
+}
+
+TORCH_LIBRARY_IMPL(page_attn_fused_ops, XPU, m) {
+  m.impl("page_attn_decode_fused", &page_attn_decode_fused);
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("page_attn_decode_fused", &page_attn_decode_fused,
+        "Fused paged attention decode");
+}

--- a/vllm/custom-esimd-kernels-vllm/csrc/eagle/page_attn_splitk.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/eagle/page_attn_splitk.sycl
@@ -1,0 +1,260 @@
+// page_attn_splitk.sycl — split-K paged attention decode
+//
+// Interface change: partition_tokens → num_partitions.
+// The grid size and buffer size are now O(num_partitions), completely
+// independent of max_model_len.  Each WG computes its token range
+// from the actual per-batch seq_lens on device.
+
+#include <torch/extension.h>
+#include <c10/xpu/XPUStream.h>
+#include <sycl/ext/intel/esimd.hpp>
+#include <sycl/ext/intel/experimental/esimd/memory.hpp>
+#include <unordered_map>
+#include <mutex>
+using fp16 = sycl::half;
+using namespace sycl::ext::intel::esimd;
+namespace xesimd = sycl::ext::intel::experimental::esimd;
+
+static inline sycl::event submit_kernel_splitk(
+    std::function<void(sycl::handler&)> kernel,
+    const torch::Device& device,
+    const char* desc) {
+  sycl::queue& queue = c10::xpu::getCurrentXPUStream(device.index()).queue();
+  return queue.submit(kernel);
+}
+
+static inline uint32_t getHighestBitSplitK(uint32_t in) {
+  uint32_t ret = 0;
+  uint32_t temp = in - 1;
+  while (temp != 0) { temp >>= 1; ret++; }
+  return ret;
+}
+
+// ── per-device workspace cache ────────────────────────────────────────
+
+struct Workspace {
+  torch::Tensor buf;
+  size_t capacity{0};
+  std::mutex mu;
+};
+
+static std::unordered_map<int, Workspace> g_ws;
+static std::mutex g_ws_mu;
+
+static Workspace& get_workspace(int device_index) {
+  std::lock_guard<std::mutex> lk(g_ws_mu);
+  return g_ws[device_index];
+}
+
+// ── include kernel headers ────────────────────────────────────────────
+
+#include "page.attn.h"
+#include "page.attn.splitk.h"
+
+// ── host launcher ─────────────────────────────────────────────────────
+
+static void page_attention_splitk_forward(
+  uint8_t* qState,
+  uint8_t* kvCache,
+  uint32_t* pageTable,
+  uint32_t* kvSeqLens,
+  uint8_t* out,
+  float* pState,
+  float* pMax,
+  uint8_t* tmpOut,
+  float* expSums,
+  float* maxLogits,
+  uint32_t batches,
+  uint32_t headQk,
+  uint32_t headV,
+  uint32_t headDim,
+  uint32_t kvCacheStride0,
+  uint32_t kvCacheStride1,
+  uint32_t pageTableBatchStride,
+  uint32_t pageTableSizeLog2,
+  uint32_t pStride,
+  uint32_t maxStride,
+  uint32_t maxKvSeqLen,
+  uint32_t numPartitions,
+  const torch::Device& device) {
+
+  // ── Phase 1: unchanged ──
+  {
+    uint32_t groupH = headV;
+    uint32_t groupV = (maxKvSeqLen + 63) / 64;
+    uint32_t groupD = batches;
+    sycl::range<3> global(groupH * 4, groupV, groupD);
+    sycl::range<3> local(4, 1, 1);
+    sycl::nd_range<3> range(global, local);
+
+    auto kernel = [&](sycl::handler& cgh) {
+      cgh.parallel_for<class paPhase1SplitK>(
+        range, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL {
+          sdpaDecodeGqa4Phase1(
+            qState, kvCache, (uint8_t*)pState, pMax,
+            pageTable, kvSeqLens, batches,
+            kvCacheStride0, kvCacheStride1,
+            pageTableBatchStride, pageTableSizeLog2,
+            pStride, maxStride, headV, idx);
+        });
+    };
+    submit_kernel_splitk(kernel, device, "page_attn_splitk_ph1");
+  }
+
+  // ── Phase 2: split-K ──
+  {
+    uint32_t groupH = (headDim / 16) * 2;
+    uint32_t groupV = headV;
+    uint32_t groupD = batches * numPartitions;
+    sycl::range<3> global(groupH, groupV, groupD);
+    sycl::range<3> local(2, 1, 1);
+    sycl::nd_range<3> range(global, local);
+
+    auto kernel = [&](sycl::handler& cgh) {
+      cgh.parallel_for<class paPhase2SplitK>(
+        range, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL {
+          sdpaDecodeGqa4Phase2SplitK(
+            (uint8_t*)pState, pMax, kvCache,
+            tmpOut, expSums, maxLogits,
+            pageTable, kvSeqLens, batches,
+            kvCacheStride0, kvCacheStride1,
+            pageTableBatchStride, pageTableSizeLog2,
+            pStride, maxStride, headV,
+            numPartitions, idx);
+        });
+    };
+    submit_kernel_splitk(kernel, device, "page_attn_splitk_ph2");
+  }
+
+  // ── Reduce ──
+  {
+    uint32_t groupH = headDim / 16;
+    uint32_t groupV = headQk;
+    uint32_t groupD = batches;
+    sycl::range<3> global(groupH, groupV, groupD);
+    sycl::range<3> local(1, 1, 1);
+    sycl::nd_range<3> range(global, local);
+
+    auto kernel = [&](sycl::handler& cgh) {
+      cgh.parallel_for<class paReduceSplitK>(
+        range, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL {
+          sdpaDecodeGqa4Reduce(
+            tmpOut, expSums, maxLogits, out,
+            kvSeqLens, numPartitions,
+            headQk, idx);
+        });
+    };
+    submit_kernel_splitk(kernel, device, "page_attn_splitk_reduce");
+  }
+}
+
+// ── torch op entry point ──────────────────────────────────────────────
+
+void page_attn_decode_splitk(
+  torch::Tensor query,
+  torch::Tensor kv_cache,
+  torch::Tensor block_table,
+  torch::Tensor seq_lens,
+  torch::Tensor& out,
+  int64_t max_query_len,
+  int64_t max_seq_len,
+  int64_t num_partitions
+) {
+  TORCH_CHECK(block_table.dim() == 2);
+  TORCH_CHECK(seq_lens.dim() == 1);
+  TORCH_CHECK(kv_cache.dim() == 5);
+  TORCH_CHECK(query.scalar_type() == torch::kHalf);
+  TORCH_CHECK(kv_cache.scalar_type() == torch::kHalf);
+  TORCH_CHECK(out.scalar_type() == torch::kHalf);
+  TORCH_CHECK(num_partitions >= 1 && num_partitions <= 64,
+    "num_partitions must be in [1, 64]");
+
+  uint32_t kvCacheStride0 = kv_cache.stride(0);
+  uint32_t kvCacheStride1 = kv_cache.stride(1);
+  uint32_t totalDimsKv = kv_cache.dim();
+
+  uint32_t headDim  = kv_cache.size(totalDimsKv - 1);
+  uint32_t headV    = kv_cache.size(totalDimsKv - 2);
+  uint32_t pageSize = kv_cache.size(totalDimsKv - 3);
+  uint32_t batches  = seq_lens.size(0);
+  uint32_t headQk   = headV << 2;
+  uint32_t maxSeqLen = (uint32_t)max_seq_len;
+  uint32_t hiddenDimP    = ((maxSeqLen + 63) / 64) * 64;
+  uint32_t hiddenDimPMax = ((maxSeqLen + 63) / 64);
+  uint32_t pageTableSizeLog2     = getHighestBitSplitK(pageSize);
+  uint32_t pageTableBatchStride  = block_table.stride(0);
+  uint32_t numParts = (uint32_t)num_partitions;
+
+  TORCH_CHECK(headDim == 256);
+  TORCH_CHECK(max_query_len == 1);
+
+  // ── Workspace sizes (independent of max_model_len for split-K buffers) ──
+  // Region 0: temp_p (Phase 1) — still depends on max_seq_len (same as original)
+  size_t temp_p_bytes = (size_t)batches * headQk * (hiddenDimP + hiddenDimPMax) * sizeof(float);
+
+  // Region 1: tmp_out [batches, numParts, headQk, headDim] fp16
+  size_t tmp_out_bytes = (size_t)batches * numParts * headQk * headDim * sizeof(fp16);
+
+  // Region 2+3: exp_sums + max_logits [batches, numParts, headQk] fp32 each
+  size_t meta_bytes = (size_t)batches * numParts * headQk * sizeof(float);
+
+  auto align256 = [](size_t x) -> size_t { return (x + 255) & ~(size_t)255; };
+  size_t off_tmp_out    = align256(temp_p_bytes);
+  size_t off_exp_sums   = off_tmp_out + align256(tmp_out_bytes);
+  size_t off_max_logits = off_exp_sums + align256(meta_bytes);
+  size_t total_bytes    = off_max_logits + align256(meta_bytes);
+
+  // ── Get or grow workspace ──
+  int dev_idx = kv_cache.device().index();
+  Workspace& ws = get_workspace(dev_idx);
+  {
+    std::lock_guard<std::mutex> lk(ws.mu);
+    if (ws.capacity < total_bytes) {
+      size_t alloc_bytes = total_bytes + total_bytes / 2;
+      ws.buf = torch::empty({(int64_t)alloc_bytes},
+                  torch::device(kv_cache.device()).dtype(torch::kUInt8));
+      ws.capacity = alloc_bytes;
+    }
+  }
+
+  uint8_t* base = (uint8_t*)ws.buf.data_ptr();
+  float*   pState     = (float*)(base);
+  float*   pMax       = (float*)(base + (size_t)batches * headQk * hiddenDimP * sizeof(float));
+  uint8_t* tmpOut     = base + off_tmp_out;
+  float*   expSums    = (float*)(base + off_exp_sums);
+  float*   maxLogitsP = (float*)(base + off_max_logits);
+
+  page_attention_splitk_forward(
+    (uint8_t*)query.data_ptr(),
+    (uint8_t*)kv_cache.data_ptr(),
+    (uint32_t*)block_table.data_ptr(),
+    (uint32_t*)seq_lens.data_ptr(),
+    (uint8_t*)out.data_ptr(),
+    pState, pMax,
+    tmpOut, expSums, maxLogitsP,
+    batches, headQk, headV, headDim,
+    kvCacheStride0, kvCacheStride1,
+    pageTableBatchStride, pageTableSizeLog2,
+    hiddenDimP, hiddenDimPMax, maxSeqLen,
+    numParts,
+    kv_cache.device()
+  );
+}
+
+// ── torch library registration ────────────────────────────────────────
+
+TORCH_LIBRARY_FRAGMENT(page_attn_splitk_ops, m) {
+  m.def("page_attn_decode_splitk("
+        "Tensor query, Tensor kv_cache, Tensor block_table, Tensor seq_lens, "
+        "Tensor! out, int max_query_len, int max_seq_len, int num_partitions"
+        ") -> ()");
+}
+
+TORCH_LIBRARY_IMPL(page_attn_splitk_ops, XPU, m) {
+  m.impl("page_attn_decode_splitk", &page_attn_decode_splitk);
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("page_attn_decode_splitk", &page_attn_decode_splitk,
+        "Split-K paged attention decode");
+}

--- a/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/__init__.py
+++ b/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/__init__.py
@@ -9,6 +9,15 @@ from custom_esimd_kernels_vllm import custom_esimd_kernels_gemm
 # Eagle kernels — registers torch.ops.eagle_ops.*
 from custom_esimd_kernels_vllm import eagle_ops
 
+# Split-K paged attention — registers torch.ops.page_attn_splitk_ops.*
+from custom_esimd_kernels_vllm import page_attn_splitk_ops
+
+# Fused paged attention — registers torch.ops.page_attn_fused_ops.*
+try:
+    from custom_esimd_kernels_vllm import page_attn_fused_ops
+except ImportError:
+    pass
+
 # MoE Batch kernels — registers torch.ops.moe_ops.*
 from custom_esimd_kernels_vllm import moe_ops
 
@@ -39,6 +48,10 @@ from custom_esimd_kernels_vllm.ops import (
     # Eagle ops
     eagle_gdn,
     eagle_page_attn_decode,
+    # Split-K paged attention
+    eagle_page_attn_decode_splitk,
+    # Fused paged attention
+    eagle_page_attn_decode_fused,
     # MoE Batch ops
     moe_router_forward,
     moe_batch_topk,

--- a/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/ops.py
+++ b/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/ops.py
@@ -561,6 +561,63 @@ def eagle_page_attn_decode(
         max_query_len, max_seq_len)
 
 
+# ---- Split-K Paged Attention ----
+
+_splitk_ops = torch.ops.page_attn_splitk_ops
+
+
+def eagle_page_attn_decode_splitk(
+    query: torch.Tensor,
+    kv_cache: torch.Tensor,
+    block_table: torch.Tensor,
+    seq_lens: torch.Tensor,
+    out: torch.Tensor,
+    max_query_len: int,
+    max_seq_len: int,
+    num_partitions: int = 8,
+) -> None:
+    """Split-K paged attention decode.
+
+    Same interface as eagle_page_attn_decode with an extra num_partitions
+    parameter that controls how many partitions to split Phase-2 into.
+    Each WG computes its token range from actual seq_lens on device.
+
+    query:          [batches, num_heads, head_dim] fp16
+    kv_cache:       paged KV cache tensor
+    block_table:    [batches, max_blocks] int32
+    seq_lens:       [batches] int32
+    out:            [batches, num_heads, head_dim] fp16 (output)
+    num_partitions: number of Phase-2 partitions (default 8)
+    """
+    return _splitk_ops.page_attn_decode_splitk(
+        query, kv_cache, block_table, seq_lens, out,
+        max_query_len, max_seq_len, num_partitions)
+
+
+# ---- Fused Paged Attention ----
+
+_fused_ops = torch.ops.page_attn_fused_ops
+
+
+def eagle_page_attn_decode_fused(
+    query: torch.Tensor,
+    kv_cache: torch.Tensor,
+    block_table: torch.Tensor,
+    seq_lens: torch.Tensor,
+    out: torch.Tensor,
+    max_query_len: int,
+    max_seq_len: int,
+) -> None:
+    """Fused single-kernel paged attention decode.
+
+    Same interface as eagle_page_attn_decode. Single kernel launch,
+    no intermediate global-memory buffer.
+    """
+    return _fused_ops.page_attn_decode_fused(
+        query, kv_cache, block_table, seq_lens, out,
+        max_query_len, max_seq_len)
+
+
 # ---- MoE Batch Ops (Router, TopK, Up/Down, Accumulate) ----
 
 _moe_batch = torch.ops.moe_ops

--- a/vllm/custom-esimd-kernels-vllm/setup.py
+++ b/vllm/custom-esimd-kernels-vllm/setup.py
@@ -146,6 +146,27 @@ ext_modules.append(
 )
 ### Eagle kernels
 
+### Split-K paged attention (standalone, does not touch eagle_ops)
+ext_modules.append(
+    SyclExtension(
+        name="custom_esimd_kernels_vllm.page_attn_splitk_ops",
+        sources=[
+            "csrc/eagle/page_attn_splitk.sycl",
+        ],
+        include_dirs=[
+            root / "csrc" / "eagle",
+        ],
+        extra_compile_args={
+            "cxx": ["-O3", "-std=c++20"],
+            "sycl": ["-ffast-math", "-fsycl-device-code-split=per_kernel",
+                     f"-I{torch_include}"],
+        },
+        extra_link_args=["-Wl,-rpath,$ORIGIN/../../torch/lib"],
+        py_limited_api=False,
+    )
+)
+### Split-K paged attention
+
 ### MoE Batch kernels (Router, TopK, Up/Down, Accumulate) — from custom-esimd-kernels-vllm-moe-batch-test
 ext_modules.append(
     SyclExtension(

--- a/vllm/custom-esimd-kernels-vllm/setup_fused.py
+++ b/vllm/custom-esimd-kernels-vllm/setup_fused.py
@@ -1,0 +1,32 @@
+"""Build only the fused paged attention module."""
+from pathlib import Path
+from setuptools import setup
+from torch.utils.cpp_extension import SyclExtension
+from esimd_build_extention import BuildExtension
+import torch
+
+root = Path(__file__).parent.resolve()
+torch_include = str(Path(torch.__file__).parent / "include")
+
+ext_modules = [
+    SyclExtension(
+        name="custom_esimd_kernels_vllm.page_attn_fused_ops",
+        sources=["csrc/eagle/page_attn_fused.sycl"],
+        include_dirs=[root / "csrc" / "eagle"],
+        extra_compile_args={
+            "cxx": ["-O3", "-std=c++20"],
+            "sycl": ["-ffast-math", "-fsycl-device-code-split=per_kernel",
+                     f"-I{torch_include}"],
+        },
+        extra_link_args=["-Wl,-rpath,$ORIGIN/../../torch/lib"],
+        py_limited_api=False,
+    )
+]
+
+setup(
+    name="custom-esimd-kernels-vllm-fused",
+    version="0.1.0",
+    packages=[],
+    ext_modules=ext_modules,
+    cmdclass={"build_ext": BuildExtension.with_options(use_ninja=True)},
+)

--- a/vllm/custom-esimd-kernels-vllm/setup_splitk.py
+++ b/vllm/custom-esimd-kernels-vllm/setup_splitk.py
@@ -1,0 +1,39 @@
+"""Build only the split-K paged attention module."""
+import sys
+from pathlib import Path
+
+from setuptools import find_packages, setup
+from torch.utils.cpp_extension import SyclExtension
+from esimd_build_extention import BuildExtension
+
+root = Path(__file__).parent.resolve()
+
+import torch
+torch_include = str(Path(torch.__file__).parent / "include")
+
+ext_modules = [
+    SyclExtension(
+        name="custom_esimd_kernels_vllm.page_attn_splitk_ops",
+        sources=[
+            "csrc/eagle/page_attn_splitk.sycl",
+        ],
+        include_dirs=[
+            root / "csrc" / "eagle",
+        ],
+        extra_compile_args={
+            "cxx": ["-O3", "-std=c++20"],
+            "sycl": ["-ffast-math", "-fsycl-device-code-split=per_kernel",
+                     f"-I{torch_include}"],
+        },
+        extra_link_args=["-Wl,-rpath,$ORIGIN/../../torch/lib"],
+        py_limited_api=False,
+    )
+]
+
+setup(
+    name="custom-esimd-kernels-vllm-splitk",
+    version="0.1.0",
+    packages=[],
+    ext_modules=ext_modules,
+    cmdclass={"build_ext": BuildExtension.with_options(use_ninja=True)},
+)


### PR DESCRIPTION
Split-K PA (ESIMD_PA_SPLITK=8):
- Phase2 (P·V) split into 8 parallel partitions + reduce
- 3 kernel launches per FA layer (ph1 + ph2_splitk + reduce)

Fused PA (experimental):
- Single-kernel paged attention decode
- No intermediate global-memory buffer