### PR TITLE
Add use_ggml_layout flag to moe_int4 kernels for transpose=False support

### DIFF
--- a/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe_int4.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe_int4.sycl
@@ -50,6 +50,7 @@ void moe_router_forward_int4_kernel(
     const fp16* scale,
     fp16* output,
     const int n_tokens, const int hidden_size, const int num_experts,
+    const bool ggml_layout,
     const torch::Device& device) {
 
     const int K_packed = hidden_size / 8;
@@ -67,11 +68,11 @@ void moe_router_forward_int4_kernel(
                 for (int k = 0; k < hidden_size; k += 64) {
                     int kp = k / 8;
                     int gi = k / 128;
-                    // scale layout: [K_groups, num_experts] — strided access
-                    fp16 s = scale[gi * num_experts + row];
+                    // IPEX: scale [K_groups, E], GGML: scale [E, K_groups]
+                    fp16 s = ggml_layout ? scale[row * n_groups + gi]
+                                         : scale[gi * num_experts + row];
 
                     simd<uint32_t, 8> packed = block_load<uint32_t, 8>(w_row + kp);
-                    // SIMD dequant: 8-wide parallel nibble extraction per int32
                     simd<fp16, 64> wv;
                     #pragma unroll
                     for (int i = 0; i < 8; i++) {
@@ -119,6 +120,7 @@ void moe_router_forward_int4_wide_kernel(
     const fp16* scale,
     fp16* output,
     const int n_tokens, const int hidden_size, const int num_experts,
+    const bool ggml_layout,
     const torch::Device& device) {
 
     const int K_packed = hidden_size / 8;
@@ -136,8 +138,8 @@ void moe_router_forward_int4_wide_kernel(
                 for (int k = 0; k < hidden_size; k += 64) {
                     int kp = k / 8;
                     int gi = k / 128;
-                    // scale layout: [K_groups, num_experts]
-                    fp16 s = scale[gi * num_experts + row];
+                    fp16 s = ggml_layout ? scale[row * n_groups + gi]
+                                         : scale[gi * num_experts + row];
 
                     simd<uint32_t, 8> packed = block_load<uint32_t, 8>(w_row + kp);
                     simd<fp16, 64> wv;
@@ -168,10 +170,11 @@ void moe_router_forward_int4_wide_kernel(
 torch::Tensor moe_router_forward_int4(
     torch::Tensor x,
     torch::Tensor weight,
-    torch::Tensor scale) {
+    torch::Tensor scale,
+    bool use_ggml_layout) {
 
     TORCH_CHECK(x.dim() == 2 && x.is_contiguous() && x.scalar_type() == torch::kHalf);
-    TORCH_CHECK(weight.scalar_type() == torch::kInt);
+    TORCH_CHECK(weight.scalar_type() == torch::kInt || weight.scalar_type() == torch::kByte);
     TORCH_CHECK(scale.scalar_type() == torch::kHalf);
 
     int n_tokens = x.size(0);
@@ -180,28 +183,42 @@ torch::Tensor moe_router_forward_int4(
 
     TORCH_CHECK(hidden_size % 128 == 0);
 
-    // IPEX OneDNN does column-major in-place repack on gate weight:
-    //   Shape stays [K_packed, E], but flat memory becomes [E, K_packed] row-major.
-    //   Fix: reshape to [E, K_packed] (no data copy, just reinterpret shape).
-    //   For square (35B: K_packed==E), reshape is no-op.
-    int num_experts = weight.numel() / K_packed;
-    weight = weight.reshape({num_experts, K_packed});
-    TORCH_CHECK(weight.size(1) == K_packed,
-        "gate weight shape mismatch: got [", weight.size(0), ", ", weight.size(1),
-        "], expected [num_experts, ", K_packed, "]");
-
-    // Scale: kernel reads as [K_groups, num_experts] with stride access.
-    // IPEX may or may not modify scale. Detect layout and adjust.
+    int num_experts;
     int K_groups = hidden_size / 128;
-    if (scale.size(0) != K_groups || scale.size(1) != num_experts) {
-        // Try reshape (column-major repack) or transpose
-        if (scale.numel() == K_groups * num_experts) {
-            scale = scale.reshape({K_groups, num_experts});
+
+    if (use_ggml_layout) {
+        // GGML layout: weight_esimd [E, K/2] uint8 → view as int32 gives [E, K/8]
+        // Or already [E, K/8] int32. scale_esimd [E, K_groups] fp16.
+        // Weight: if uint8, view as int32 first
+        if (weight.scalar_type() == torch::kByte) {
+            weight = weight.view(torch::kInt);
         }
+        num_experts = weight.size(0);
+        // weight is already [E, K_packed] contiguous
+        TORCH_CHECK(weight.size(1) == K_packed,
+            "gate weight shape mismatch: got [", weight.size(0), ", ", weight.size(1),
+            "], expected [num_experts, ", K_packed, "]");
+        // scale is [E, K_groups] — kernel reads as scale[row * n_groups + gi]
+        TORCH_CHECK(scale.size(0) == num_experts && scale.size(1) == K_groups,
+            "gate scale shape mismatch: got [", scale.size(0), ", ", scale.size(1),
+            "], expected [", num_experts, ", ", K_groups, "]");
+    } else {
+        // IPEX layout: weight may be [K_packed, E] column-major repacked
+        num_experts = weight.numel() / K_packed;
+        weight = weight.reshape({num_experts, K_packed});
+        TORCH_CHECK(weight.size(1) == K_packed,
+            "gate weight shape mismatch: got [", weight.size(0), ", ", weight.size(1),
+            "], expected [num_experts, ", K_packed, "]");
+        // Scale: [K_groups, E]
+        if (scale.size(0) != K_groups || scale.size(1) != num_experts) {
+            if (scale.numel() == K_groups * num_experts) {
+                scale = scale.reshape({K_groups, num_experts});
+            }
+        }
+        TORCH_CHECK(scale.size(0) == K_groups && scale.size(1) == num_experts,
+            "gate scale shape mismatch: got [", scale.size(0), ", ", scale.size(1),
+            "], expected [", K_groups, ", ", num_experts, "]");
     }
-    TORCH_CHECK(scale.size(0) == K_groups && scale.size(1) == num_experts,
-        "gate scale shape mismatch: got [", scale.size(0), ", ", scale.size(1),
-        "], expected [", K_groups, ", ", num_experts, "]");
 
     torch::Tensor output = torch::empty({n_tokens, num_experts},
         torch::device(x.device()).dtype(torch::kHalf));
@@ -210,12 +227,12 @@ torch::Tensor moe_router_forward_int4(
         moe_router_forward_int4_kernel(
             (const fp16*)x.data_ptr(), (const uint32_t*)weight.data_ptr(),
             (const fp16*)scale.data_ptr(), (fp16*)output.data_ptr(),
-            n_tokens, hidden_size, num_experts, x.device());
+            n_tokens, hidden_size, num_experts, use_ggml_layout, x.device());
     } else {
         moe_router_forward_int4_wide_kernel(
             (const fp16*)x.data_ptr(), (const uint32_t*)weight.data_ptr(),
             (const fp16*)scale.data_ptr(), (fp16*)output.data_ptr(),
-            n_tokens, hidden_size, num_experts, x.device());
+            n_tokens, hidden_size, num_experts, use_ggml_layout, x.device());
     }
     return output;
 }
@@ -229,12 +246,13 @@ torch::Tensor moe_router_forward_int4(
 
 void moe_up_routed_int4_kernel(
     const fp16* x,
-    const uint32_t* gate_up_qweight,  // [E, K_packed, 2*d_ff] IPEX format
-    const fp16* gate_up_scales,       // [E, K_groups, 2*d_ff] IPEX format
+    const uint32_t* gate_up_qweight,  // IPEX: [E, K_packed, 2*d_ff] or GGML: [E, 2*d_ff, K_packed]
+    const fp16* gate_up_scales,       // IPEX: [E, K_groups, 2*d_ff] or GGML: [E, 2*d_ff, K_groups]
     const int* selected_experts,
     fp16* intermediates,
     const int n_tokens, const int hidden_size, const int intermediate_size,
     const int top_k, const int rows_per_token,
+    const bool ggml_layout,
     const torch::Device& device) {
 
     const int K_packed = hidden_size / 8;
@@ -242,76 +260,118 @@ void moe_up_routed_int4_kernel(
     const int two_dff = 2 * intermediate_size;
     const int n_out_tiles = intermediate_size / 16;
 
-    auto cgf = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class MoeUpRoutedInt4>(
-            sycl::range<2>(n_tokens * top_k, n_out_tiles),
-            [=](sycl::id<2> idx) SYCL_ESIMD_KERNEL {
-                const int route_idx = (int)idx[0];
-                const int tile_idx  = (int)idx[1];
-                const int token     = route_idx / top_k;
-                const int k_idx     = route_idx % top_k;
-                const int n_start   = tile_idx * 16;
+    if (ggml_layout) {
+        // GGML N-major: weight [E, 2*d_ff, K_packed], scale [E, 2*d_ff, K_groups]
+        // Each WI computes 1 gate + 1 up output (scalar per N), vectorize along K
+        auto cgf = [&](sycl::handler& cgh) {
+            cgh.parallel_for<class MoeUpRoutedInt4GGML>(
+                sycl::range<2>(n_tokens * top_k, intermediate_size),
+                [=](sycl::id<2> idx) SYCL_ESIMD_KERNEL {
+                    const int route_idx = (int)idx[0];
+                    const int n_col     = (int)idx[1];
+                    const int token     = route_idx / top_k;
+                    const int k_idx     = route_idx % top_k;
 
-                const int eid = selected_experts[route_idx];
-                const fp16* x_row = x + (size_t)token * hidden_size;
+                    const int eid = selected_experts[route_idx];
+                    const fp16* x_row = x + (size_t)token * hidden_size;
 
-                // IPEX K-major: base at [eid, 0, 0]
-                const uint32_t* w_base = gate_up_qweight + (size_t)eid * K_packed * two_dff;
-                const fp16* s_base = gate_up_scales + (size_t)eid * K_groups * two_dff;
+                    const uint32_t* w_base = gate_up_qweight + (size_t)eid * two_dff * K_packed;
+                    const fp16* s_base = gate_up_scales + (size_t)eid * two_dff * K_groups;
 
-                const int g_offset = n_start;
-                const int u_offset = intermediate_size + n_start;
+                    const uint32_t* g_row = w_base + (size_t)n_col * K_packed;
+                    const uint32_t* u_row = w_base + (size_t)(intermediate_size + n_col) * K_packed;
+                    const fp16* g_s_row = s_base + (size_t)n_col * K_groups;
+                    const fp16* u_s_row = s_base + (size_t)(intermediate_size + n_col) * K_groups;
 
-                simd<float, 16> gate_acc(0.f), up_acc(0.f);
+                    float g_acc = 0.f, u_acc = 0.f;
+                    for (int kp = 0; kp < K_packed; kp++) {
+                        uint32_t g_packed = g_row[kp];
+                        uint32_t u_packed = u_row[kp];
+                        int gi = kp / 16;
+                        fp16 g_scale = g_s_row[gi];
+                        fp16 u_scale = u_s_row[gi];
 
-                // Marlin unshuffle: nibble position → K offset mapping
-                // IPEX shuffled nibble order: [K0, K4, K1, K5, K2, K6, K3, K7]
-                // To read K values 0..7 in order, read from positions:
-                //   K0→pos0, K1→pos2, K2→pos4, K3→pos6, K4→pos1, K5→pos3, K6→pos5, K7→pos7
-                constexpr int unshuffle[8] = {0, 2, 4, 6, 1, 3, 5, 7};
-
-                for (int kp = 0; kp < K_packed; kp++) {
-                    // block_load 16 int32 along N (contiguous in IPEX layout)
-                    simd<uint32_t, 16> g_packed = block_load<uint32_t, 16>(
-                        w_base + (size_t)kp * two_dff + g_offset);
-                    simd<uint32_t, 16> u_packed = block_load<uint32_t, 16>(
-                        w_base + (size_t)kp * two_dff + u_offset);
-
-                    // Scale: [E, K_groups, N] — changes every 16 kp
-                    int kg = kp / 16;
-                    simd<fp16, 16> g_scale = block_load<fp16, 16>(
-                        s_base + (size_t)kg * two_dff + g_offset);
-                    simd<fp16, 16> u_scale = block_load<fp16, 16>(
-                        s_base + (size_t)kg * two_dff + u_offset);
-
-                    #pragma unroll
-                    for (int b = 0; b < 8; b++) {
-                        int nib_pos = unshuffle[b];  // reverse marlin shuffle
-                        simd<uint32_t, 16> g_nib = (g_packed >> (nib_pos * 4)) & 0xFu;
-                        simd<uint32_t, 16> u_nib = (u_packed >> (nib_pos * 4)) & 0xFu;
-
-                        simd<float, 16> g_dq = (convert<float>(g_nib) - 8.f)
-                                             * convert<float>(g_scale);
-                        simd<float, 16> u_dq = (convert<float>(u_nib) - 8.f)
-                                             * convert<float>(u_scale);
-
-                        float xv = (float)x_row[kp * 8 + b];
-                        gate_acc += g_dq * xv;
-                        up_acc   += u_dq * xv;
+                        #pragma unroll
+                        for (int b = 0; b < 8; b++) {
+                            float g_val = (float(((g_packed >> (b * 4)) & 0xFu)) - 8.f) * (float)g_scale;
+                            float u_val = (float(((u_packed >> (b * 4)) & 0xFu)) - 8.f) * (float)u_scale;
+                            float xv = (float)x_row[kp * 8 + b];
+                            g_acc += g_val * xv;
+                            u_acc += u_val * xv;
+                        }
                     }
-                }
 
-                simd<float, 16> silu = gate_acc / (1.f + exp(-gate_acc));
-                simd<float, 16> result = silu * up_acc;
+                    float silu = g_acc / (1.f + sycl::exp(-g_acc));
+                    const int routed_row = token * rows_per_token + k_idx;
+                    intermediates[(size_t)routed_row * intermediate_size + n_col] = fp16(silu * u_acc);
+                });
+        };
+        submit_kernel(cgf, device, "moe up routed int4 ggml");
+    } else {
+        // IPEX K-major: weight [E, K_packed, 2*d_ff], scale [E, K_groups, 2*d_ff]
+        auto cgf = [&](sycl::handler& cgh) {
+            cgh.parallel_for<class MoeUpRoutedInt4>(
+                sycl::range<2>(n_tokens * top_k, n_out_tiles),
+                [=](sycl::id<2> idx) SYCL_ESIMD_KERNEL {
+                    const int route_idx = (int)idx[0];
+                    const int tile_idx  = (int)idx[1];
+                    const int token     = route_idx / top_k;
+                    const int k_idx     = route_idx % top_k;
+                    const int n_start   = tile_idx * 16;
 
-                const int routed_row = token * rows_per_token + k_idx;
-                block_store<fp16, 16>(
-                    intermediates + (size_t)routed_row * intermediate_size + n_start,
-                    convert<fp16>(result));
-            });
-    };
+                    const int eid = selected_experts[route_idx];
+                    const fp16* x_row = x + (size_t)token * hidden_size;
 
-    submit_kernel(cgf, device, "moe up routed int4");
+                    const uint32_t* w_base = gate_up_qweight + (size_t)eid * K_packed * two_dff;
+                    const fp16* s_base = gate_up_scales + (size_t)eid * K_groups * two_dff;
+
+                    const int g_offset = n_start;
+                    const int u_offset = intermediate_size + n_start;
+
+                    simd<float, 16> gate_acc(0.f), up_acc(0.f);
+
+                    constexpr int unshuffle[8] = {0, 2, 4, 6, 1, 3, 5, 7};
+
+                    for (int kp = 0; kp < K_packed; kp++) {
+                        simd<uint32_t, 16> g_packed = block_load<uint32_t, 16>(
+                            w_base + (size_t)kp * two_dff + g_offset);
+                        simd<uint32_t, 16> u_packed = block_load<uint32_t, 16>(
+                            w_base + (size_t)kp * two_dff + u_offset);
+
+                        int kg = kp / 16;
+                        simd<fp16, 16> g_scale = block_load<fp16, 16>(
+                            s_base + (size_t)kg * two_dff + g_offset);
+                        simd<fp16, 16> u_scale = block_load<fp16, 16>(
+                            s_base + (size_t)kg * two_dff + u_offset);
+
+                        #pragma unroll
+                        for (int b = 0; b < 8; b++) {
+                            int nib_pos = unshuffle[b];
+                            simd<uint32_t, 16> g_nib = (g_packed >> (nib_pos * 4)) & 0xFu;
+                            simd<uint32_t, 16> u_nib = (u_packed >> (nib_pos * 4)) & 0xFu;
+
+                            simd<float, 16> g_dq = (convert<float>(g_nib) - 8.f)
+                                                 * convert<float>(g_scale);
+                            simd<float, 16> u_dq = (convert<float>(u_nib) - 8.f)
+                                                 * convert<float>(u_scale);
+
+                            float xv = (float)x_row[kp * 8 + b];
+                            gate_acc += g_dq * xv;
+                            up_acc   += u_dq * xv;
+                        }
+                    }
+
+                    simd<float, 16> silu = gate_acc / (1.f + exp(-gate_acc));
+                    simd<float, 16> result = silu * up_acc;
+
+                    const int routed_row = token * rows_per_token + k_idx;
+                    block_store<fp16, 16>(
+                        intermediates + (size_t)routed_row * intermediate_size + n_start,
+                        convert<fp16>(result));
+                });
+        };
+        submit_kernel(cgf, device, "moe up routed int4");
+    }
 }
 
 // ── SLM reduction version: GS work-items cooperate on 16 outputs ────────────
@@ -326,13 +386,22 @@ void moe_up_routed_int4_slm_kernel(
     fp16* intermediates,
     const int n_tokens, const int hidden_size, const int intermediate_size,
     const int top_k, const int rows_per_token,
+    const bool ggml_layout,
     const torch::Device& device) {
+
+    // GGML layout: N-major, no block_load<16> along N possible — delegate to non-SLM path
+    if (ggml_layout) {
+        moe_up_routed_int4_kernel(x, gate_up_qweight, gate_up_scales,
+            selected_experts, intermediates, n_tokens, hidden_size,
+            intermediate_size, top_k, rows_per_token, true, device);
+        return;
+    }
 
     const int K_packed = hidden_size / 8;
     const int K_groups = hidden_size / 128;
     const int two_dff = 2 * intermediate_size;
     const int n_out_tiles = intermediate_size / 16;
-    constexpr int GS = 16;  // group size: WIs cooperating per output tile
+    constexpr int GS = 16;
 
     auto cgf = [&](sycl::handler& cgh) {
         cgh.parallel_for<class MoeUpRoutedInt4SLM>(
@@ -340,7 +409,6 @@ void moe_up_routed_int4_slm_kernel(
                 sycl::range<2>(n_tokens * top_k, n_out_tiles * GS),
                 sycl::range<2>(1, GS)),
             [=](sycl::nd_item<2> item) SYCL_ESIMD_KERNEL {
-                // SLM: GS slots × 2 (gate+up) × 16 floats = GS*128 bytes
                 slm_init<GS * 2 * 16 * sizeof(float)>();
 
                 const int route_idx = (int)item.get_global_id(0);
@@ -361,7 +429,6 @@ void moe_up_routed_int4_slm_kernel(
 
                 constexpr int unshuffle[8] = {0, 2, 4, 6, 1, 3, 5, 7};
 
-                // Each WI processes a subset of K_packed
                 simd<float, 16> gate_acc(0.f), up_acc(0.f);
                 for (int kp = tid; kp < K_packed; kp += GS) {
                     simd<uint32_t, 16> g_packed = block_load<uint32_t, 16>(
@@ -390,14 +457,12 @@ void moe_up_routed_int4_slm_kernel(
                     }
                 }
 
-                // Write partial sums to SLM
-                uint32_t slm_off = (uint32_t)(tid * 2 * 16) * 4u;  // tid * 128 bytes
+                uint32_t slm_off = (uint32_t)(tid * 2 * 16) * 4u;
                 slm_block_store<float, 16>(slm_off, gate_acc);
                 slm_block_store<float, 16>(slm_off + 64u, up_acc);
 
                 barrier();
 
-                // Thread 0 reduces all partial sums
                 if (tid == 0) {
                     simd<float, 16> g_sum(0.f), u_sum(0.f);
                     #pragma unroll
@@ -562,67 +627,105 @@ void moe_up_shared_fp16_kernel(
 
 void moe_down_routed_int4_kernel(
     const fp16* intermediates,
-    const uint32_t* down_qweight,     // [E, K_packed_inter, d_model] IPEX format
-    const fp16* down_scales,          // [E, K_groups_inter, d_model] IPEX format
+    const uint32_t* down_qweight,     // IPEX: [E, K_packed_inter, d_model] or GGML: [E, d_model, K_packed_inter]
+    const fp16* down_scales,          // IPEX: [E, K_groups_inter, d_model] or GGML: [E, d_model, K_groups_inter]
     const fp16* routing_weights,
     const int* selected_experts,
     fp16* output,
     const int n_tokens, const int hidden_size, const int intermediate_size,
     const int top_k, const int rows_per_token,
+    const bool ggml_layout,
     const torch::Device& device) {
 
     const int K_packed = intermediate_size / 8;
     const int K_groups = intermediate_size / 128;
     const int n_out_tiles = hidden_size / 16;
 
-    auto cgf = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class MoeDownRoutedInt4>(
-            sycl::range<2>(n_tokens * top_k, n_out_tiles),
-            [=](sycl::id<2> idx) SYCL_ESIMD_KERNEL {
-                const int route_idx = (int)idx[0];
-                const int tile_idx  = (int)idx[1];
-                const int token     = route_idx / top_k;
-                const int k_idx     = route_idx % top_k;
-                const int n_start   = tile_idx * 16;
+    if (ggml_layout) {
+        // GGML N-major: weight [E, d_model, K_packed_inter], scale [E, d_model, K_groups_inter]
+        auto cgf = [&](sycl::handler& cgh) {
+            cgh.parallel_for<class MoeDownRoutedInt4GGML>(
+                sycl::range<2>(n_tokens * top_k, hidden_size),
+                [=](sycl::id<2> idx) SYCL_ESIMD_KERNEL {
+                    const int route_idx = (int)idx[0];
+                    const int j         = (int)idx[1];
+                    const int token     = route_idx / top_k;
+                    const int k_idx     = route_idx % top_k;
 
-                const int eid = selected_experts[route_idx];
-                const int routed_row = token * rows_per_token + k_idx;
-                const fp16* hi = intermediates + (size_t)routed_row * intermediate_size;
+                    const int eid = selected_experts[route_idx];
+                    const int routed_row = token * rows_per_token + k_idx;
+                    const fp16* hi = intermediates + (size_t)routed_row * intermediate_size;
 
-                // IPEX K-major layout
-                const uint32_t* w_base = down_qweight + (size_t)eid * K_packed * hidden_size;
-                const fp16* s_base = down_scales + (size_t)eid * K_groups * hidden_size;
+                    const uint32_t* w_row = down_qweight + (size_t)eid * hidden_size * K_packed + (size_t)j * K_packed;
+                    const fp16* s_row = down_scales + (size_t)eid * hidden_size * K_groups + (size_t)j * K_groups;
 
-                constexpr int unshuffle[8] = {0, 2, 4, 6, 1, 3, 5, 7};
-                simd<float, 16> acc(0.f);
+                    float acc = 0.f;
+                    for (int kp = 0; kp < K_packed; kp++) {
+                        uint32_t packed = w_row[kp];
+                        int gi = kp / 16;
+                        fp16 s = s_row[gi];
 
-                for (int kp = 0; kp < K_packed; kp++) {
-                    simd<uint32_t, 16> packed = block_load<uint32_t, 16>(
-                        w_base + (size_t)kp * hidden_size + n_start);
-
-                    int kg = kp / 16;
-                    simd<fp16, 16> scale = block_load<fp16, 16>(
-                        s_base + (size_t)kg * hidden_size + n_start);
-
-                    #pragma unroll
-                    for (int b = 0; b < 8; b++) {
-                        int nib_pos = unshuffle[b];
-                        simd<uint32_t, 16> nib = (packed >> (nib_pos * 4)) & 0xFu;
-                        simd<float, 16> dq = (convert<float>(nib) - 8.f)
-                                           * convert<float>(scale);
-                        float hv = (float)hi[kp * 8 + b];
-                        acc += dq * hv;
+                        #pragma unroll
+                        for (int b = 0; b < 8; b++) {
+                            float w_val = (float(((packed >> (b * 4)) & 0xFu)) - 8.f) * (float)s;
+                            acc += w_val * (float)hi[kp * 8 + b];
+                        }
                     }
-                }
 
-                float w = (float)routing_weights[route_idx];
-                block_store<fp16, 16>(
-                    output + (size_t)routed_row * hidden_size + n_start,
-                    convert<fp16>(acc * w));
-            });
-    };
+                    float w = (float)routing_weights[route_idx];
+                    output[(size_t)routed_row * hidden_size + j] = fp16(acc * w);
+                });
+        };
+        submit_kernel(cgf, device, "moe down routed int4 ggml");
+    } else {
+        // IPEX K-major layout
+        auto cgf = [&](sycl::handler& cgh) {
+            cgh.parallel_for<class MoeDownRoutedInt4>(
+                sycl::range<2>(n_tokens * top_k, n_out_tiles),
+                [=](sycl::id<2> idx) SYCL_ESIMD_KERNEL {
+                    const int route_idx = (int)idx[0];
+                    const int tile_idx  = (int)idx[1];
+                    const int token     = route_idx / top_k;
+                    const int k_idx     = route_idx % top_k;
+                    const int n_start   = tile_idx * 16;
 
-    submit_kernel(cgf, device, "moe down routed int4");
+                    const int eid = selected_experts[route_idx];
+                    const int routed_row = token * rows_per_token + k_idx;
+                    const fp16* hi = intermediates + (size_t)routed_row * intermediate_size;
+
+                    const uint32_t* w_base = down_qweight + (size_t)eid * K_packed * hidden_size;
+                    const fp16* s_base = down_scales + (size_t)eid * K_groups * hidden_size;
+
+                    constexpr int unshuffle[8] = {0, 2, 4, 6, 1, 3, 5, 7};
+                    simd<float, 16> acc(0.f);
+
+                    for (int kp = 0; kp < K_packed; kp++) {
+                        simd<uint32_t, 16> packed = block_load<uint32_t, 16>(
+                            w_base + (size_t)kp * hidden_size + n_start);
+
+                        int kg = kp / 16;
+                        simd<fp16, 16> scale = block_load<fp16, 16>(
+                            s_base + (size_t)kg * hidden_size + n_start);
+
+                        #pragma unroll
+                        for (int b = 0; b < 8; b++) {
+                            int nib_pos = unshuffle[b];
+                            simd<uint32_t, 16> nib = (packed >> (nib_pos * 4)) & 0xFu;
+                            simd<float, 16> dq = (convert<float>(nib) - 8.f)
+                                               * convert<float>(scale);
+                            float hv = (float)hi[kp * 8 + b];
+                            acc += dq * hv;
+                        }
+                    }
+
+                    float w = (float)routing_weights[route_idx];
+                    block_store<fp16, 16>(
+                        output + (size_t)routed_row * hidden_size + n_start,
+                        convert<fp16>(acc * w));
+                });
+        };
+        submit_kernel(cgf, device, "moe down routed int4");
+    }
 }
 
 // ── SLM reduction version for down routed ────────────────────────────────────
@@ -636,7 +739,15 @@ void moe_down_routed_int4_slm_kernel(
     fp16* output,
     const int n_tokens, const int hidden_size, const int intermediate_size,
     const int top_k, const int rows_per_token,
+    const bool ggml_layout,
     const torch::Device& device) {
+
+    if (ggml_layout) {
+        moe_down_routed_int4_kernel(intermediates, down_qweight, down_scales,
+            routing_weights, selected_experts, output, n_tokens, hidden_size,
+            intermediate_size, top_k, rows_per_token, true, device);
+        return;
+    }
 
     const int K_packed = intermediate_size / 8;
     const int K_groups = intermediate_size / 128;
@@ -1093,7 +1204,8 @@ torch::Tensor moe_forward_full_int4(
     torch::Tensor shared_down_weight, torch::Tensor shared_down_scale,
     // Shared expert gate — FP16 (always unquantized)
     torch::Tensor shared_expert_gate_weight,
-    int64_t top_k, int64_t num_shared_experts, int64_t n_routed_experts) {
+    int64_t top_k, int64_t num_shared_experts, int64_t n_routed_experts,
+    bool use_ggml_layout) {
 
     TORCH_CHECK(x.scalar_type() == torch::kHalf);
     TORCH_CHECK(gate_up_qweight.scalar_type() == torch::kInt);
@@ -1102,8 +1214,9 @@ torch::Tensor moe_forward_full_int4(
     TORCH_CHECK(down_scales.scalar_type() == torch::kHalf);
 
     int n_tokens = x.size(0), hidden_size = x.size(1);
-    // IPEX K-major layout: gate_up_qweight [E, K_packed, 2*d_ff]
-    int two_dff = gate_up_qweight.size(2);
+    // IPEX K-major: gate_up_qweight [E, K_packed, 2*d_ff]
+    // GGML N-major: gate_up_qweight [E, 2*d_ff, K_packed]
+    int two_dff = use_ggml_layout ? gate_up_qweight.size(1) : gate_up_qweight.size(2);
     int intermediate_size = two_dff / 2;
     int rows_per_token = top_k + num_shared_experts;
 
@@ -1157,7 +1270,7 @@ torch::Tensor moe_forward_full_int4(
             s_int4_topk_idx.data_ptr<int>(),
             (fp16*)s_int4_intermediates.data_ptr(),
             n_tokens, hidden_size, intermediate_size,
-            top_k, rows_per_token, x.device());
+            top_k, rows_per_token, use_ggml_layout, x.device());
     } else {
         moe_up_routed_int4_kernel(
             (const fp16*)x.data_ptr(),
@@ -1166,7 +1279,7 @@ torch::Tensor moe_forward_full_int4(
             s_int4_topk_idx.data_ptr<int>(),
             (fp16*)s_int4_intermediates.data_ptr(),
             n_tokens, hidden_size, intermediate_size,
-            top_k, rows_per_token, x.device());
+            top_k, rows_per_token, use_ggml_layout, x.device());
     }
 
     // ── Up: shared — dispatch INT4 or FP16 based on weight dtype ──
@@ -1208,7 +1321,7 @@ torch::Tensor moe_forward_full_int4(
             s_int4_topk_idx.data_ptr<int>(),
             (fp16*)s_int4_routed_output.data_ptr(),
             n_tokens, hidden_size, intermediate_size,
-            top_k, rows_per_token, x.device());
+            top_k, rows_per_token, use_ggml_layout, x.device());
     } else {
         moe_down_routed_int4_kernel(
             (const fp16*)s_int4_intermediates.data_ptr(),
@@ -1218,7 +1331,7 @@ torch::Tensor moe_forward_full_int4(
             s_int4_topk_idx.data_ptr<int>(),
             (fp16*)s_int4_routed_output.data_ptr(),
             n_tokens, hidden_size, intermediate_size,
-            top_k, rows_per_token, x.device());
+            top_k, rows_per_token, use_ggml_layout, x.device());
     }
 
     // ── Down Finalize: shared + accumulate ──
@@ -1304,14 +1417,15 @@ torch::Tensor moe_forward_full_int4(
 // ═══════════════════════════════════════════════════════════════════════════════
 
 TORCH_LIBRARY_FRAGMENT(moe_int4_ops, m) {
-    m.def("moe_router_forward_int4(Tensor x, Tensor weight, Tensor scale) -> Tensor");
+    m.def("moe_router_forward_int4(Tensor x, Tensor weight, Tensor scale, bool use_ggml_layout) -> Tensor");
     m.def("moe_forward_full_int4(Tensor x, Tensor logits, "
           "Tensor gate_up_qweight, Tensor gate_up_scales, "
           "Tensor shared_gate_up_weight, Tensor shared_gate_up_scale, "
           "Tensor down_qweight, Tensor down_scales, "
           "Tensor shared_down_weight, Tensor shared_down_scale, "
           "Tensor shared_expert_gate_weight, "
-          "int top_k, int num_shared_experts, int n_routed_experts) -> Tensor");
+          "int top_k, int num_shared_experts, int n_routed_experts, "
+          "bool use_ggml_layout) -> Tensor");
 }
 
 TORCH_LIBRARY_IMPL(moe_int4_ops, XPU, m) {

--- a/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/ops.py
+++ b/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/ops.py
@@ -780,15 +780,21 @@ def moe_router_forward_int4(
     x: torch.Tensor,
     weight: torch.Tensor,
     scale: torch.Tensor,
+    use_ggml_layout: bool = False,
 ) -> torch.Tensor:
     """INT4 router GEMV: x @ dequant(weight).T → logits.
 
     x:      [n_tokens, hidden_size] fp16
-    weight: [num_experts, hidden_size//8] int32 (IPEX physically transposed to [E, K_packed])
-    scale:  [hidden_size//128, num_experts] fp16 (original layout, kernel handles stride)
+    weight: [num_experts, hidden_size//8] int32 (or uint8 viewed as int32)
+    scale:  fp16
+
+    use_ggml_layout=False (IPEX): weight [E, K_packed] after IPEX repack,
+        scale [K_groups, E] (kernel reads with stride).
+    use_ggml_layout=True (GGML): weight_esimd [E, K/2] uint8 → [E, K/8] int32,
+        scale_esimd [E, K_groups] contiguous (kernel reads row-major).
     Returns: [n_tokens, num_experts] fp16
     """
-    return _moe_int4.moe_router_forward_int4(x, weight, scale)
+    return _moe_int4.moe_router_forward_int4(x, weight, scale, use_ggml_layout)
 
 
 def moe_forward_full_int4(
@@ -806,12 +812,17 @@ def moe_forward_full_int4(
     top_k: int,
     num_shared_experts: int,
     n_routed_experts: int,
+    use_ggml_layout: bool = False,
 ) -> torch.Tensor:
     """INT4 MoE full forward: topk + up + down + finalize in one C++ call.
 
     Supports both INT4 and FP16 shared expert weights (auto-detected by dtype).
     When shared expert is INT4: shared_gate_up_scale/shared_down_scale are used.
     When shared expert is FP16: pass dummy tensors for scales (ignored).
+
+    use_ggml_layout: if True, routed expert weights are in GGML N-major layout
+        [E, N, K_packed] with natural nibble order (transpose=False from ggml_quantize_tensor).
+        If False (default), expects IPEX K-major layout [E, K_packed, N] with marlin shuffled nibbles.
     """
     return _moe_int4.moe_forward_full_int4(
         x, logits,
@@ -820,4 +831,5 @@ def moe_forward_full_int4(
         down_qweight, down_scales,
         shared_down_weight, shared_down_scale,
         shared_expert_gate_weight,
-        top_k, num_shared_experts, n_routed_experts)
+        top_k, num_shared_experts, n_routed_experts,
+        use_ggml_layout)

--- a/vllm/custom-esimd-kernels-vllm/tests/test_moe_int4_kernel.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/test_moe_int4_kernel.py
@@ -179,7 +179,7 @@ def test_router_forward():
                 sc = scales.t().contiguous().to(DEVICE)
 
                 kernel_out = moe_int4_ops.moe_router_forward_int4(
-                    x.to(DEVICE), qw, sc).cpu()
+                    x.to(DEVICE), qw, sc, False).cpu()
 
                 cos = cosine_similarity(ref_out, kernel_out)
                 mae = (ref_out.float() - kernel_out.float()).abs().max().item()
@@ -311,7 +311,7 @@ def test_forward_full():
                 w2_ipex.to(DEVICE), s2_ipex.to(DEVICE),
                 shared_down.to(DEVICE), _dummy_scale,
                 shared_gate_w.to(DEVICE),
-                TK, NUM_SHARED_EXPERTS, E).cpu()
+                TK, NUM_SHARED_EXPERTS, E, False).cpu()
 
             cos = cosine_similarity(ref_out, kernel_out)
             mae = (ref_out.float() - kernel_out.float()).abs().max().item()
@@ -421,7 +421,7 @@ def test_forward_full_int4_shared():
                 w2_ipex.to(DEVICE), s2_ipex.to(DEVICE),
                 shared_dw_ipex.int().to(DEVICE), shared_dw_sc_ipex.to(DEVICE),
                 shared_gate_w.to(DEVICE),
-                TK, NUM_SHARED_EXPERTS, E).cpu()
+                TK, NUM_SHARED_EXPERTS, E, False).cpu()
 
             cos = cosine_similarity(ref_out, kernel_out)
             mae = (ref_out.float() - kernel_out.float()).abs().max().item()
@@ -452,7 +452,7 @@ def test_edge_cases():
     gate_fp16 = (torch.randn(E, H) * 0.02).half()
     qw, sc = quantize_int4(gate_fp16, GROUP_SIZE)
     out = moe_int4_ops.moe_router_forward_int4(
-        x_zero, qw.to(DEVICE), sc.t().contiguous().to(DEVICE))
+        x_zero, qw.to(DEVICE), sc.t().contiguous().to(DEVICE), False)
     all_zero = (out.cpu().abs().max().item() < 1e-3)
     print(f"  Zero input → near-zero output: {'PASS' if all_zero else 'FAIL'}")
 


### PR DESCRIPTION
Add bool use_ggml_layout parameter to moe_router_forward_int4 and moe_forward_full_int4 to support both IPEX K-major (marlin shuffled) and GGML N-major (natural nibble order) weight layouts.

moe_int4.sycl:
  - moe_router_forward_int4_kernel/wide: add ggml_layout flag. GGML: scale read as [E, K_groups] row-major. IPEX: scale read as [K_groups, E] (unchanged). Weight layout [E, K_packed] is the same for both.
  - moe_up_routed_int4_kernel: add ggml_layout flag. GGML: weight [E, 2*d_ff, K_packed], 1 WI per N output, scalar. IPEX: weight [E, K_packed, 2*d_ff], block_load<16> (unchanged).
  - moe_up_routed_int4_slm_kernel: delegate to non-SLM for GGML.
  - moe_down_routed_int4_kernel: same pattern as up.
  - moe_down_routed_int4_slm_kernel: delegate to non-SLM for GGML.
  - moe_forward_full_int4: add use_ggml_layout, auto-detect dims.
  - TORCH_LIBRARY/PYBIND signatures updated.

ops.py:
  - moe_router_forward_int4: add use_ggml_layout param (default False).
  - moe_forward_full_int4: add use_ggml_layout param (default False).

tests/test_moe_int4_kernel.py:
  - Pass explicit False for use_ggml_layout in existing IPEX tests.