### PR TITLE
custom-esimd-kernels-vllm: fix fp8_GEMM_pert dispatcher for M>64

### DIFF
--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/fp8_GEMM_pert.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/fp8_GEMM_pert.h
@@ -4037,6 +4037,12 @@ inline void GEMM_fp8_pert_dispatch(
             mpar_gemm_fp8_pert_host<128, 1, 16>(
                 input, weight, scale_ptr, output, M, N, K, fp8_mode, q);
         }
+    } else if (M > 64) {
+        // V7/V9 DPAS kernels cap at M_TILES=8 (M=64). For M>64 they silently
+        // only compute rows [0..63] and leave rows [64..M-1] uninitialized,
+        // which propagates NaN through subsequent layers. Fall back to WS
+        // which has a real 2D grid and per-row bounds check.
+        ws_gemm_fp8_pert_host<128, 16>(input, weight, scale_ptr, output, M, N, K, fp8_mode, q);
     } else if (K % 64 == 0 && fp8_mode == 0) {
         // V9: Transposed load + fused dequant-VNNI (E4M3 only, best for M>=2)
         dpas_v9_auto_dispatch(input, weight, scale_ptr, output, M, N, K, q);


### PR DESCRIPTION
V7 and V9 DPAS kernels use M_TILES template parameter capped at 8 (each MT handles 8 input rows via DPAS<8,8>). Their auto-dispatch tables treat any m_tiles >= 5 as MT=8, but launch only a single WG per N tile along the M axis. For M > 64 (e.g. M=76/78/80/82/86 seen with ARC prefill on Qwen3-Coder-Next), the kernel computes only rows [0..63] and leaves rows [64..M-1] uninitialized. The uninitialized fp16 output then flows through the next layer's residual-add + RMSNorm + softmax, producing NaN that cascades.

Fix by routing M > 64 cases to the WS (weight-stationary) path, which uses a real 2D grid of WGs (N x ceil(M / TILE_M)) with per- row bounds checks inside the kernel. V9 E4M3 path is likewise protected since the new branch fires before the K % 64 == 0 checks.