### PR TITLE
Optimize IPEX INT4 MoE kernels: 2x32 tiles + preload

### DIFF
--- a/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe_int4.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe_int4.sycl
@@ -309,15 +309,17 @@ void moe_up_routed_int4_kernel(
         submit_kernel(cgf, device, "moe up routed int4 ggml");
     } else {
         // IPEX K-major: weight [E, K_packed, 2*d_ff], scale [E, K_groups, 2*d_ff]
+        // Optimized: 64-wide tiles (2×32), preload x with block_load<fp16,8>
+        const int n_out_tiles_ipex = intermediate_size / 64;
         auto cgf = [&](sycl::handler& cgh) {
             cgh.parallel_for<class MoeUpRoutedInt4>(
-                sycl::range<2>(n_tokens * top_k, n_out_tiles),
+                sycl::range<2>(n_tokens * top_k, n_out_tiles_ipex),
                 [=](sycl::id<2> idx) SYCL_ESIMD_KERNEL {
                     const int route_idx = (int)idx[0];
                     const int tile_idx  = (int)idx[1];
                     const int token     = route_idx / top_k;
                     const int k_idx     = route_idx % top_k;
-                    const int n_start   = tile_idx * 16;
+                    const int n_start   = tile_idx * 64;
 
                     const int eid = selected_experts[route_idx];
                     const fp16* x_row = x + (size_t)token * hidden_size;
@@ -325,49 +327,43 @@ void moe_up_routed_int4_kernel(
                     const uint32_t* w_base = gate_up_qweight + (size_t)eid * K_packed * two_dff;
                     const fp16* s_base = gate_up_scales + (size_t)eid * K_groups * two_dff;
 
-                    const int g_offset = n_start;
-                    const int u_offset = intermediate_size + n_start;
+                    const int g0 = n_start, g1 = n_start + 32;
+                    const int u0 = intermediate_size + n_start, u1 = u0 + 32;
 
-                    simd<float, 16> gate_acc(0.f), up_acc(0.f);
+                    simd<float, 32> ga0(0.f), ga1(0.f), ua0(0.f), ua1(0.f);
 
                     constexpr int unshuffle[8] = {0, 2, 4, 6, 1, 3, 5, 7};
 
                     for (int kp = 0; kp < K_packed; kp++) {
-                        simd<uint32_t, 16> g_packed = block_load<uint32_t, 16>(
-                            w_base + (size_t)kp * two_dff + g_offset);
-                        simd<uint32_t, 16> u_packed = block_load<uint32_t, 16>(
-                            w_base + (size_t)kp * two_dff + u_offset);
+                        simd<fp16, 8> x_chunk = block_load<fp16, 8>(x_row + kp * 8);
+
+                        simd<uint32_t, 32> gp0 = block_load<uint32_t, 32>(w_base + (size_t)kp * two_dff + g0);
+                        simd<uint32_t, 32> gp1 = block_load<uint32_t, 32>(w_base + (size_t)kp * two_dff + g1);
+                        simd<uint32_t, 32> up0 = block_load<uint32_t, 32>(w_base + (size_t)kp * two_dff + u0);
+                        simd<uint32_t, 32> up1 = block_load<uint32_t, 32>(w_base + (size_t)kp * two_dff + u1);
 
                         int kg = kp / 16;
-                        simd<fp16, 16> g_scale = block_load<fp16, 16>(
-                            s_base + (size_t)kg * two_dff + g_offset);
-                        simd<fp16, 16> u_scale = block_load<fp16, 16>(
-                            s_base + (size_t)kg * two_dff + u_offset);
+                        simd<fp16, 32> gs0 = block_load<fp16, 32>(s_base + (size_t)kg * two_dff + g0);
+                        simd<fp16, 32> gs1 = block_load<fp16, 32>(s_base + (size_t)kg * two_dff + g1);
+                        simd<fp16, 32> us0 = block_load<fp16, 32>(s_base + (size_t)kg * two_dff + u0);
+                        simd<fp16, 32> us1 = block_load<fp16, 32>(s_base + (size_t)kg * two_dff + u1);
 
                         #pragma unroll
                         for (int b = 0; b < 8; b++) {
-                            int nib_pos = unshuffle[b];
-                            simd<uint32_t, 16> g_nib = (g_packed >> (nib_pos * 4)) & 0xFu;
-                            simd<uint32_t, 16> u_nib = (u_packed >> (nib_pos * 4)) & 0xFu;
+                            int shift = unshuffle[b] * 4;
+                            float xv = (float)(fp16)x_chunk[b];
 
-                            simd<float, 16> g_dq = (convert<float>(g_nib) - 8.f)
-                                                 * convert<float>(g_scale);
-                            simd<float, 16> u_dq = (convert<float>(u_nib) - 8.f)
-                                                 * convert<float>(u_scale);
-
-                            float xv = (float)x_row[kp * 8 + b];
-                            gate_acc += g_dq * xv;
-                            up_acc   += u_dq * xv;
+                            ga0 += (convert<float>((gp0 >> shift) & 0xFu) - 8.f) * convert<float>(gs0) * xv;
+                            ga1 += (convert<float>((gp1 >> shift) & 0xFu) - 8.f) * convert<float>(gs1) * xv;
+                            ua0 += (convert<float>((up0 >> shift) & 0xFu) - 8.f) * convert<float>(us0) * xv;
+                            ua1 += (convert<float>((up1 >> shift) & 0xFu) - 8.f) * convert<float>(us1) * xv;
                         }
                     }
 
-                    simd<float, 16> silu = gate_acc / (1.f + exp(-gate_acc));
-                    simd<float, 16> result = silu * up_acc;
-
                     const int routed_row = token * rows_per_token + k_idx;
-                    block_store<fp16, 16>(
-                        intermediates + (size_t)routed_row * intermediate_size + n_start,
-                        convert<fp16>(result));
+                    fp16* out = intermediates + (size_t)routed_row * intermediate_size + n_start;
+                    block_store<fp16, 32>(out,      convert<fp16>(ga0 / (1.f + exp(-ga0)) * ua0));
+                    block_store<fp16, 32>(out + 32, convert<fp16>(ga1 / (1.f + exp(-ga1)) * ua1));
                 });
         };
         submit_kernel(cgf, device, "moe up routed int4");
@@ -431,6 +427,7 @@ void moe_up_routed_int4_slm_kernel(
 
                 simd<float, 16> gate_acc(0.f), up_acc(0.f);
                 for (int kp = tid; kp < K_packed; kp += GS) {
+                    simd<fp16, 8> x_chunk = block_load<fp16, 8>(x_row + kp * 8);
                     simd<uint32_t, 16> g_packed = block_load<uint32_t, 16>(
                         w_base + (size_t)kp * two_dff + g_offset);
                     simd<uint32_t, 16> u_packed = block_load<uint32_t, 16>(
@@ -451,7 +448,7 @@ void moe_up_routed_int4_slm_kernel(
                         simd<float, 16> g_dq = (convert<float>(g_nib) - 8.f) * convert<float>(g_scale);
                         simd<float, 16> u_dq = (convert<float>(u_nib) - 8.f) * convert<float>(u_scale);
 
-                        float xv = (float)x_row[kp * 8 + b];
+                        float xv = (float)(fp16)x_chunk[b];
                         gate_acc += g_dq * xv;
                         up_acc   += u_dq * xv;
                     }
@@ -532,20 +529,18 @@ void moe_up_shared_int4_kernel(
 
                 float g_acc = 0.f, u_acc = 0.f;
                 for (int kp = 0; kp < K_packed_shared; kp++) {
-                    // qweight: [2*inter, K_packed] layout (column-major repacked)
+                    simd<fp16, 8> x_chunk = block_load<fp16, 8>(x_row + kp * 8);
                     uint32_t g_packed = gw_base[(size_t)row * K_packed_shared + kp];
                     uint32_t u_packed = gw_base[(size_t)(shared_inter_size + row) * K_packed_shared + kp];
-                    // scales: [K_groups, 2*inter] layout (NOT repacked)
-                    int gi = kp / 16;  // 128 / 8 = 16 kp per group
+                    int gi = kp / 16;
                     fp16 g_scale = gs_base[(size_t)gi * two_inter + row];
                     fp16 u_scale = gs_base[(size_t)gi * two_inter + shared_inter_size + row];
 
-                    // Dequant 8 nibbles (no marlin shuffle for shared expert)
                     #pragma unroll
                     for (int b = 0; b < 8; b++) {
                         float g_val = (float(((g_packed >> (b * 4)) & 0xFu)) - 8.f) * (float)g_scale;
                         float u_val = (float(((u_packed >> (b * 4)) & 0xFu)) - 8.f) * (float)u_scale;
-                        float xv = (float)x_row[kp * 8 + b];
+                        float xv = (float)(fp16)x_chunk[b];
                         g_acc += g_val * xv;
                         u_acc += u_val * xv;
                     }
@@ -678,16 +673,17 @@ void moe_down_routed_int4_kernel(
         };
         submit_kernel(cgf, device, "moe down routed int4 ggml");
     } else {
-        // IPEX K-major layout
+        // IPEX K-major layout — optimized: 64-wide tiles (2×32), preload hi
+        const int n_out_tiles_ipex = hidden_size / 64;
         auto cgf = [&](sycl::handler& cgh) {
             cgh.parallel_for<class MoeDownRoutedInt4>(
-                sycl::range<2>(n_tokens * top_k, n_out_tiles),
+                sycl::range<2>(n_tokens * top_k, n_out_tiles_ipex),
                 [=](sycl::id<2> idx) SYCL_ESIMD_KERNEL {
                     const int route_idx = (int)idx[0];
                     const int tile_idx  = (int)idx[1];
                     const int token     = route_idx / top_k;
                     const int k_idx     = route_idx % top_k;
-                    const int n_start   = tile_idx * 16;
+                    const int n_start   = tile_idx * 64;
 
                     const int eid = selected_experts[route_idx];
                     const int routed_row = token * rows_per_token + k_idx;
@@ -697,31 +693,31 @@ void moe_down_routed_int4_kernel(
                     const fp16* s_base = down_scales + (size_t)eid * K_groups * hidden_size;
 
                     constexpr int unshuffle[8] = {0, 2, 4, 6, 1, 3, 5, 7};
-                    simd<float, 16> acc(0.f);
+                    simd<float, 32> acc0(0.f), acc1(0.f);
 
                     for (int kp = 0; kp < K_packed; kp++) {
-                        simd<uint32_t, 16> packed = block_load<uint32_t, 16>(
-                            w_base + (size_t)kp * hidden_size + n_start);
+                        simd<fp16, 8> hi_chunk = block_load<fp16, 8>(hi + kp * 8);
+
+                        simd<uint32_t, 32> pk0 = block_load<uint32_t, 32>(w_base + (size_t)kp * hidden_size + n_start);
+                        simd<uint32_t, 32> pk1 = block_load<uint32_t, 32>(w_base + (size_t)kp * hidden_size + n_start + 32);
 
                         int kg = kp / 16;
-                        simd<fp16, 16> scale = block_load<fp16, 16>(
-                            s_base + (size_t)kg * hidden_size + n_start);
+                        simd<fp16, 32> sc0 = block_load<fp16, 32>(s_base + (size_t)kg * hidden_size + n_start);
+                        simd<fp16, 32> sc1 = block_load<fp16, 32>(s_base + (size_t)kg * hidden_size + n_start + 32);
 
                         #pragma unroll
                         for (int b = 0; b < 8; b++) {
-                            int nib_pos = unshuffle[b];
-                            simd<uint32_t, 16> nib = (packed >> (nib_pos * 4)) & 0xFu;
-                            simd<float, 16> dq = (convert<float>(nib) - 8.f)
-                                               * convert<float>(scale);
-                            float hv = (float)hi[kp * 8 + b];
-                            acc += dq * hv;
+                            int shift = unshuffle[b] * 4;
+                            float hv = (float)(fp16)hi_chunk[b];
+                            acc0 += (convert<float>((pk0 >> shift) & 0xFu) - 8.f) * convert<float>(sc0) * hv;
+                            acc1 += (convert<float>((pk1 >> shift) & 0xFu) - 8.f) * convert<float>(sc1) * hv;
                         }
                     }
 
                     float w = (float)routing_weights[route_idx];
-                    block_store<fp16, 16>(
-                        output + (size_t)routed_row * hidden_size + n_start,
-                        convert<fp16>(acc * w));
+                    fp16* out = output + (size_t)routed_row * hidden_size + n_start;
+                    block_store<fp16, 32>(out,      convert<fp16>(acc0 * w));
+                    block_store<fp16, 32>(out + 32, convert<fp16>(acc1 * w));
                 });
         };
         submit_kernel(cgf, device, "moe down routed int4");
@@ -780,6 +776,7 @@ void moe_down_routed_int4_slm_kernel(
                 simd<float, 16> acc(0.f);
 
                 for (int kp = tid; kp < K_packed; kp += GS) {
+                    simd<fp16, 8> hi_chunk = block_load<fp16, 8>(hi + kp * 8);
                     simd<uint32_t, 16> packed = block_load<uint32_t, 16>(
                         w_base + (size_t)kp * hidden_size + n_start);
 
@@ -792,7 +789,7 @@ void moe_down_routed_int4_slm_kernel(
                         int nib_pos = unshuffle[b];
                         simd<uint32_t, 16> nib = (packed >> (nib_pos * 4)) & 0xFu;
                         simd<float, 16> dq = (convert<float>(nib) - 8.f) * convert<float>(scale);
-                        float hv = (float)hi[kp * 8 + b];
+                        float hv = (float)(fp16)hi_chunk[b];
                         acc += dq * hv;
                     }
                 }
@@ -894,6 +891,7 @@ void moe_down_shared_int4_standalone_kernel(
 
                 float acc = 0.f;
                 for (int kp = 0; kp < K_packed_down; kp++) {
+                    simd<fp16, 8> hi_chunk = block_load<fp16, 8>(hi + kp * 8);
                     uint32_t packed = dw_base[(size_t)j * K_packed_down + kp];
                     int gi = kp / 16;
                     fp16 s = ds_base[(size_t)gi * hidden_size + j];
@@ -901,7 +899,7 @@ void moe_down_shared_int4_standalone_kernel(
                     #pragma unroll
                     for (int b = 0; b < 8; b++) {
                         float w_val = (float(((packed >> (b * 4)) & 0xFu)) - 8.f) * (float)s;
-                        acc += w_val * (float)hi[kp * 8 + b];
+                        acc += w_val * (float)(fp16)hi_chunk[b];
                     }
                 }
 
@@ -1138,6 +1136,7 @@ void moe_down_finalize_int4_kernel(
 
                     float acc = 0.f;
                     for (int kp = 0; kp < K_packed_down; kp++) {
+                        simd<fp16, 8> hi_chunk = block_load<fp16, 8>(hi + kp * 8);
                         uint32_t packed = dw_base[(size_t)j * K_packed_down + kp];
                         int gi = kp / 16;
                         fp16 s = ds_base[(size_t)gi * hidden_size + j];
@@ -1145,7 +1144,7 @@ void moe_down_finalize_int4_kernel(
                         #pragma unroll
                         for (int b = 0; b < 8; b++) {
                             float w_val = (float(((packed >> (b * 4)) & 0xFu)) - 8.f) * (float)s;
-                            acc += w_val * (float)hi[kp * 8 + b];
+                            acc += w_val * (float)(fp16)hi_chunk[b];
                         }
                     }
                     sum += acc * gate_w;


### PR DESCRIPTION
Apply three optimizations to IPEX path (use_ggml_layout=false):

1. Preload x/hi with block_load<fp16,8> in all routed/shared kernels
2. Widen Up/Down Routed tiles from 16 to 64 outputs per WI
3. Widen SIMD from 4x16 to 2x32 — halves block_load count

GGML path (use_ggml_layout=true) unchanged.

Performance (122B-TP4): BS=1 7%, BS=4 18%, BS=32 39% faster.