### PR TITLE
Omni: replace pip config workaround with rm EXTERNALLY-MANAGED

### DIFF
--- a/omni/README.md
+++ b/omni/README.md
@@ -17,7 +17,7 @@
 
 Pull docker image from dockerhub:
 ```bash
-docker pull intel/llm-scaler-omni:0.1.0-b6
+docker pull intel/llm-scaler-omni:0.1.0-b7
 ```
 
 Or build docker image:
@@ -29,7 +29,7 @@ bash build.sh
 Run docker image:
 
 ```bash
-export DOCKER_IMAGE=intel/llm-scaler-omni:0.1.0-b6
+export DOCKER_IMAGE=intel/llm-scaler-omni:0.1.0-b7
 export CONTAINER_NAME=comfyui
 export MODEL_DIR=<your_model_dir>
 export COMFYUI_MODEL_DIR=<your_comfyui_model_dir>

--- a/omni/docker/Dockerfile
+++ b/omni/docker/Dockerfile
@@ -41,11 +41,11 @@ RUN wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRO
         libxkbcommon0 && \
     apt remove python3-blinker -y && \
     apt-get install -y intel-oneapi-dpcpp-ct=${ONEAPI_VERSION} && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    rm -f /usr/lib/python3*/EXTERNALLY-MANAGED
 
 # PyTorch
 RUN --mount=type=cache,target=/root/.cache/pip \
-    python3 -m pip config set global.break-system-packages true && \
     pip install \
         torch==${TORCH_VERSION} \
         torchvision==${TORCHVISION_VERSION} \
@@ -268,7 +268,7 @@ RUN wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRO
     apt remove python3-blinker -y && \
     apt-get install -y intel-oneapi-dpcpp-ct=${ONEAPI_VERSION} && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    python3 -m pip config set global.break-system-packages true
+    rm -f /usr/lib/python3*/EXTERNALLY-MANAGED
 
 # Copy built artifacts from builder
 COPY --from=builder /usr/local/lib/python${PYTHON_VERSION}/ /usr/local/lib/python${PYTHON_VERSION}/

--- a/omni/docs/SGLang_Diffusion_ComfyUI_Guide.md
+++ b/omni/docs/SGLang_Diffusion_ComfyUI_Guide.md
@@ -218,7 +218,7 @@ All workflow files are available in the `workflows/` directory of ComfyUI.
 1. **Start the Docker container:**
 
    ```bash
-   export DOCKER_IMAGE=intel/llm-scaler-omni:0.1.0-b6
+   export DOCKER_IMAGE=intel/llm-scaler-omni:0.1.0-b7
    export CONTAINER_NAME=comfyui
    export MODEL_DIR=<your_model_dir>
    export COMFYUI_MODEL_DIR=<your_comfyui_model_dir>

--- a/omni/patches/comfyui_controlnet_aux_depth_anything_v2_xpu.patch
+++ b/omni/patches/comfyui_controlnet_aux_depth_anything_v2_xpu.patch
@@ -1,13 +1,14 @@
 diff --git a/src/custom_controlnet_aux/depth_anything_v2/dpt.py b/src/custom_controlnet_aux/depth_anything_v2/dpt.py
-index 1234567..abcdefg 100644
+index 630ae69..14e2890 100644
 --- a/src/custom_controlnet_aux/depth_anything_v2/dpt.py
 +++ b/src/custom_controlnet_aux/depth_anything_v2/dpt.py
 @@ -214,7 +214,7 @@ class DepthAnythingV2(nn.Module):
          image = transform({'image': image})['image']
          image = torch.from_numpy(image).unsqueeze(0)
-
+         
 -        DEVICE = 'cuda' if torch.cuda.is_available() else 'mps' if torch.backends.mps.is_available() else 'cpu'
 +        DEVICE = next(self.parameters()).device
          image = image.to(DEVICE)
-
+         
          return image, (h, w)
+\ No newline at end of file


### PR DESCRIPTION
Remove the PEP 668 marker file directly instead of setting break-system-packages in pip config. This is cleaner for a Docker container context and works for all Python packaging tools (pip, uv, pipx, poetry), not just pip.