### PR TITLE
Omni: add nunchaku-torch + ComfyUI-nunchaku-XPU to Dockerfile

### DIFF
--- a/omni/docker/Dockerfile
+++ b/omni/docker/Dockerfile
@@ -138,14 +138,14 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     cd /llm && \
     git clone --depth 1 https://github.com/xiangyuT/nunchaku-torch.git && \
     cd nunchaku-torch && \
-    git fetch --depth 1 origin d39cf71398c5699bbed52a14a2b6c201198fc8df && \
-    git checkout d39cf71398c5699bbed52a14a2b6c201198fc8df && \
+    git fetch --depth 1 origin e09fae78f138fc0f5e86ad630be14433bd9713af && \
+    git checkout e09fae78f138fc0f5e86ad630be14433bd9713af && \
     pip install -e . --no-deps && \
     cd /llm/ComfyUI/custom_nodes && \
     git clone --depth 1 https://github.com/xiangyuT/ComfyUI-nunchaku-XPU.git && \
     cd ComfyUI-nunchaku-XPU && \
-    git fetch --depth 1 origin 2f5ec0f6c78dc4cd833fad52a37c24e4d07ad1c8 && \
-    git checkout 2f5ec0f6c78dc4cd833fad52a37c24e4d07ad1c8 && \
+    git fetch --depth 1 origin 1b78483a6af31297d5291f61965502079aed3407 && \
+    git checkout 1b78483a6af31297d5291f61965502079aed3407 && \
     pip install -r requirements.txt
 
 # ComfyUI disabled custom nodes (optional: --build-arg INSTALL_DISABLED_NODES=true)

--- a/omni/docker/Dockerfile
+++ b/omni/docker/Dockerfile
@@ -133,6 +133,21 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pip install -r requirements.txt && \
     rm -f /tmp/raylight_for_multi_arc.patch /tmp/comfyui_controlnet_aux_depth_anything_v2_xpu.patch
 
+# nunchaku-torch runtime + ComfyUI-nunchaku-XPU custom node (SVDQuant W4A4/W4A16 diffusion inference)
+RUN --mount=type=cache,target=/root/.cache/pip \
+    cd /llm && \
+    git clone --depth 1 https://github.com/xiangyuT/nunchaku-torch.git && \
+    cd nunchaku-torch && \
+    git fetch --depth 1 origin e074323ef25232c43bdd45ad7db7fd1d08cf97b5 && \
+    git checkout e074323ef25232c43bdd45ad7db7fd1d08cf97b5 && \
+    pip install -e . --no-deps && \
+    cd /llm/ComfyUI/custom_nodes && \
+    git clone --depth 1 https://github.com/xiangyuT/ComfyUI-nunchaku-XPU.git && \
+    cd ComfyUI-nunchaku-XPU && \
+    git fetch --depth 1 origin 2f5ec0f6c78dc4cd833fad52a37c24e4d07ad1c8 && \
+    git checkout 2f5ec0f6c78dc4cd833fad52a37c24e4d07ad1c8 && \
+    pip install -r requirements.txt
+
 # ComfyUI disabled custom nodes (optional: --build-arg INSTALL_DISABLED_NODES=true)
 ARG INSTALL_DISABLED_NODES=true
 COPY ./patches/comfyui_voxcpm_for_xpu.patch /tmp/

--- a/omni/docker/Dockerfile
+++ b/omni/docker/Dockerfile
@@ -138,8 +138,8 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     cd /llm && \
     git clone --depth 1 https://github.com/xiangyuT/nunchaku-torch.git && \
     cd nunchaku-torch && \
-    git fetch --depth 1 origin e074323ef25232c43bdd45ad7db7fd1d08cf97b5 && \
-    git checkout e074323ef25232c43bdd45ad7db7fd1d08cf97b5 && \
+    git fetch --depth 1 origin d39cf71398c5699bbed52a14a2b6c201198fc8df && \
+    git checkout d39cf71398c5699bbed52a14a2b6c201198fc8df && \
     pip install -e . --no-deps && \
     cd /llm/ComfyUI/custom_nodes && \
     git clone --depth 1 https://github.com/xiangyuT/ComfyUI-nunchaku-XPU.git && \


### PR DESCRIPTION
Add install step for the nunchaku SVDQuant W4A4/W4A16 diffusion runtime (nunchaku-torch) and the corresponding ComfyUI custom node (ComfyUI-nunchaku-XPU), pinned to known-good commits on the xiangyuT forks. Both were previously required to be installed manually by users after container launch.

Verified: a clean container built from the image can import nunchaku_torch and load the custom node; Z-Image, Flux.1-schnell and Qwen-Image models generate images end-to-end on Arc B580.