### PR TITLE
Omni: replace ComfyUI core patch with ComfyUI-OmniXPU custom node

### DIFF
--- a/omni/ComfyUI-OmniXPU/README.md
+++ b/omni/ComfyUI-OmniXPU/README.md
@@ -1,0 +1,85 @@
+# ComfyUI-OmniXPU
+
+Intel XPU acceleration for upstream ComfyUI via [omni_xpu_kernel](https://github.com/intel/llm-scaler/tree/main/omni/omni_xpu_kernel).
+
+All optimizations are applied transparently at startup — no workflow changes needed.
+
+## Install
+
+Bundled with the `llm-scaler-omni` Docker image. No manual installation needed.
+
+Requires `omni_xpu_kernel` installed. Without it the node loads silently with no patches applied.
+
+## What it does
+
+| Patch | Target |
+|-------|--------|
+| ESIMD Flash Attention | `optimized_attention` |
+| ESIMD RoPE | `_apply_rope1` / `apply_rope1` |
+| ESIMD LayerNorm/RMSNorm | `LayerNorm.forward` / `RMSNorm.forward` / `rms_norm()` |
+| FP8 GEMM | `fp8_linear` / `mixed_precision_ops` |
+| FP8 Negative Zero Fix | `manual_stochastic_round_to_float8` |
+| Interpolate Fix | `F.interpolate` |
+
+## Environment Variables
+
+All patches enabled by default. Disable with `=0`:
+
+```bash
+OMNIXPU_ENABLE=0            # Master switch — disable everything
+OMNIXPU_ATTENTION=0         # Disable ESIMD Flash Attention only
+OMNIXPU_ROPE=0              # Disable ESIMD RoPE only
+OMNIXPU_NORM=0              # Disable ESIMD LayerNorm/RMSNorm only
+OMNIXPU_FP8_GEMM=0          # Disable FP8 GEMM only
+OMNIXPU_FP8_NEG_ZERO_FIX=0  # Disable FP8 negative zero fix only
+OMNIXPU_INTERPOLATE_FIX=0   # Disable interpolate workaround only
+```
+
+## Diagnostics
+
+Add the **OmniXPU Status** node to any workflow to see:
+
+```
+=== ComfyUI-OmniXPU Status ===
+  GPU: Intel(R) Arc(TM) B580 Graphics (11605 MB)
+  omni_xpu_kernel: 0.1.0
+    available: sdp, norm, rotary, linear_fp8
+
+  [+] interpolate_fix: applied
+  [+] fp8_neg_zero_fix: applied
+  [+] norm: applied
+  [+] rope: applied
+  [+] fp8_gemm: applied
+  [+] attention: applied
+```
+
+## Startup Log
+
+When loaded successfully, ComfyUI logs:
+
+```
+[OmniXPU] omni_xpu_kernel 0.1.0 — available: sdp, norm, rotary, linear_fp8
+[OmniXPU] interpolate_fix: applied
+[OmniXPU] fp8_neg_zero_fix: applied
+[OmniXPU] norm: applied
+[OmniXPU] rope: applied
+[OmniXPU] fp8_gemm: applied
+[OmniXPU] attention: applied
+```
+
+## How it works
+
+The node monkey-patches ComfyUI internals at import time. Each patch:
+
+1. Checks if the corresponding `omni_xpu_kernel` submodule is available (via centralized probe)
+2. Verifies the target function/class exists in the current ComfyUI version
+3. Wraps the original with an XPU-accelerated version that falls back to the original for non-XPU tensors or unsupported shapes
+4. Records status for the diagnostics node
+
+No ComfyUI core files are modified. Works with unmodified upstream ComfyUI.
+
+## Compatibility
+
+- ComfyUI >= 0.18.x
+- PyTorch >= 2.7 with XPU support
+- `omni_xpu_kernel` >= 0.1.0

--- a/omni/ComfyUI-OmniXPU/__init__.py
+++ b/omni/ComfyUI-OmniXPU/__init__.py
@@ -1,0 +1,57 @@
+import logging
+import importlib.util
+import os
+import sys
+
+log = logging.getLogger("ComfyUI-OmniXPU")
+
+NODE_CLASS_MAPPINGS = {}
+NODE_DISPLAY_NAME_MAPPINGS = {}
+
+# Resolve package directory (works regardless of how we're loaded)
+_DIR = os.path.dirname(os.path.abspath(__file__))
+_PKG = "ComfyUI-OmniXPU"
+
+
+def _load(rel_path, mod_name):
+    """Load a .py file as a named module."""
+    fpath = os.path.join(_DIR, *rel_path.split("/"))
+    if os.path.isdir(fpath):
+        fpath = os.path.join(fpath, "__init__.py")
+    elif not fpath.endswith(".py"):
+        fpath += ".py"
+    search = [os.path.dirname(fpath)] if os.path.basename(fpath) == "__init__.py" else None
+    spec = importlib.util.spec_from_file_location(mod_name, fpath, submodule_search_locations=search)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+try:
+    import torch
+    if not (hasattr(torch, "xpu") and torch.xpu.is_available()):
+        log.info("[OmniXPU] No Intel XPU detected, skipping all patches")
+    else:
+        # Load probe and run capability check
+        probe = _load("probe.py", f"{_PKG}.probe")
+        probe.probe()
+
+        # Load config and patches
+        _load("config.py", f"{_PKG}.config")
+        patches = _load("patches", f"{_PKG}.patches")
+
+        config_mod = sys.modules[f"{_PKG}.config"]
+        patches.apply_all_patches(config_mod.config)
+
+        # Load diagnostics node
+        _load("nodes/__init__.py", f"{_PKG}.nodes")
+        diag = _load("nodes/diagnostics.py", f"{_PKG}.nodes.diagnostics")
+        NODE_CLASS_MAPPINGS["OmniXPUStatus"] = diag.OmniXPUStatus
+        NODE_DISPLAY_NAME_MAPPINGS["OmniXPUStatus"] = "OmniXPU Status"
+
+except Exception as e:
+    import traceback
+    log.error("[OmniXPU] Initialization failed: %s\n%s", e, traceback.format_exc())
+
+__all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS"]

--- a/omni/ComfyUI-OmniXPU/config.py
+++ b/omni/ComfyUI-OmniXPU/config.py
@@ -1,0 +1,17 @@
+import os
+
+
+class Config:
+    """Feature flags controlled via environment variables."""
+
+    def __init__(self):
+        master = os.environ.get("OMNIXPU_ENABLE", "1") != "0"
+        self.attention = master and os.environ.get("OMNIXPU_ATTENTION", "1") != "0"
+        self.rope = master and os.environ.get("OMNIXPU_ROPE", "1") != "0"
+        self.norm = master and os.environ.get("OMNIXPU_NORM", "1") != "0"
+        self.fp8_gemm = master and os.environ.get("OMNIXPU_FP8_GEMM", "1") != "0"
+        self.fp8_neg_zero_fix = master and os.environ.get("OMNIXPU_FP8_NEG_ZERO_FIX", "1") != "0"
+        self.interpolate_fix = master and os.environ.get("OMNIXPU_INTERPOLATE_FIX", "1") != "0"
+
+
+config = Config()

--- a/omni/ComfyUI-OmniXPU/nodes/diagnostics.py
+++ b/omni/ComfyUI-OmniXPU/nodes/diagnostics.py
@@ -1,0 +1,72 @@
+import sys
+
+_PKG = "ComfyUI-OmniXPU"
+
+
+class OmniXPUStatus:
+    CATEGORY = "OmniXPU"
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("status",)
+    FUNCTION = "get_status"
+    OUTPUT_NODE = True
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {}}
+
+    def get_status(self):
+        lines = ["=== ComfyUI-OmniXPU Status ==="]
+
+        # GPU info
+        try:
+            import torch
+            if torch.xpu.is_available():
+                name = torch.xpu.get_device_name(0)
+                mem = torch.xpu.get_device_properties(0).total_memory // (1024 * 1024)
+                lines.append(f"  GPU: {name} ({mem} MB)")
+        except Exception:
+            pass
+
+        # omni_xpu_kernel probe
+        probe = sys.modules.get(f"{_PKG}.probe")
+        if probe:
+            try:
+                s = probe.summary()
+                lines.append(f"  omni_xpu_kernel: {s['version'] or 'not installed'}")
+                caps = [k for k in ("sdp", "norm", "rotary", "linear_fp8") if s.get(k)]
+                missing = [k for k in ("sdp", "norm", "rotary", "linear_fp8") if not s.get(k)]
+                if caps:
+                    lines.append(f"    available: {', '.join(caps)}")
+                if missing:
+                    lines.append(f"    missing:   {', '.join(missing)}")
+            except Exception:
+                pass
+
+        # Patch status
+        lines.append("")
+        patches = sys.modules.get(f"{_PKG}.patches")
+        if patches:
+            for entry in patches.get_status():
+                name = entry["name"]
+                status = entry["status"]
+                reason = entry.get("reason", "")
+                mark = {"applied": "+", "skipped": "-", "failed": "!!"}.get(status, "?")
+                line = f"  [{mark}] {name}: {status}"
+                if reason:
+                    line += f" ({reason})"
+                lines.append(line)
+
+        # Attention stats
+        attn = sys.modules.get(f"{_PKG}.patches.patch_attention")
+        if attn and hasattr(attn, "get_stats"):
+            try:
+                stats = attn.get_stats()
+                if stats["esimd"] or stats["fallback"]:
+                    lines.append("")
+                    lines.append(f"  Attention calls: esimd={stats['esimd']} fallback={stats['fallback']}")
+                    for r, c in sorted(stats["reasons"].items(), key=lambda x: -x[1]):
+                        lines.append(f"    {r}: {c}")
+            except Exception:
+                pass
+
+        return ("\n".join(lines),)

--- a/omni/ComfyUI-OmniXPU/patches/__init__.py
+++ b/omni/ComfyUI-OmniXPU/patches/__init__.py
@@ -1,0 +1,64 @@
+import logging
+
+log = logging.getLogger("ComfyUI-OmniXPU")
+
+# Patch registry: ordered list of (name, status, reason)
+_registry = []
+
+
+def _record(name, status, reason=""):
+    _registry.append({"name": name, "status": status, "reason": reason})
+    if status == "applied":
+        log.info("[OmniXPU] %s: applied", name)
+    elif status == "skipped":
+        log.info("[OmniXPU] %s: skipped (%s)", name, reason)
+    elif status == "failed":
+        log.warning("[OmniXPU] %s: FAILED (%s)", name, reason)
+
+
+def get_status():
+    return list(_registry)
+
+
+def apply_all_patches(cfg):
+    import importlib, os, sys
+
+    _patches_dir = os.path.dirname(os.path.abspath(__file__))
+    _pkg_name = os.path.basename(os.path.dirname(_patches_dir))
+
+    def _load_patch(name):
+        fpath = os.path.join(_patches_dir, name + ".py")
+        mod_name = f"{_pkg_name}.patches.{name}"
+        spec = importlib.util.spec_from_file_location(mod_name, fpath)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[mod_name] = mod
+        spec.loader.exec_module(mod)
+        return mod.apply
+
+    apply_interpolate = _load_patch("patch_interpolate")
+    apply_fp8_fix = _load_patch("patch_fp8_fix")
+    apply_norm = _load_patch("patch_norm")
+    apply_rope = _load_patch("patch_rope")
+    apply_fp8_gemm = _load_patch("patch_fp8_gemm")
+    apply_attention = _load_patch("patch_attention")
+
+    _apply_one("interpolate_fix", cfg.interpolate_fix, apply_interpolate)
+    _apply_one("fp8_neg_zero_fix", cfg.fp8_neg_zero_fix, apply_fp8_fix)
+    _apply_one("norm", cfg.norm, apply_norm)
+    _apply_one("rope", cfg.rope, apply_rope)
+    _apply_one("fp8_gemm", cfg.fp8_gemm, apply_fp8_gemm)
+    _apply_one("attention", cfg.attention, apply_attention)
+
+
+def _apply_one(name, enabled, apply_fn):
+    if not enabled:
+        _record(name, "skipped", "disabled by env")
+        return
+    try:
+        ok, reason = apply_fn()
+        if ok:
+            _record(name, "applied")
+        else:
+            _record(name, "skipped", reason)
+    except Exception as e:
+        _record(name, "failed", str(e))

--- a/omni/ComfyUI-OmniXPU/patches/patch_attention.py
+++ b/omni/ComfyUI-OmniXPU/patches/patch_attention.py
@@ -1,0 +1,141 @@
+import logging
+
+import torch
+
+log = logging.getLogger("ComfyUI-OmniXPU")
+
+_esimd_sdp = None
+_esimd_call_count = 0
+_esimd_fallback_count = 0
+_esimd_fallback_reasons = {}
+
+
+def get_stats():
+    return {
+        "esimd": _esimd_call_count,
+        "fallback": _esimd_fallback_count,
+        "reasons": dict(_esimd_fallback_reasons),
+    }
+
+
+def apply():
+    global _esimd_sdp
+    import sys
+    probe = sys.modules.get("ComfyUI-OmniXPU.probe")
+    if probe.sdp is None:
+        return False, "omni_xpu_kernel sdp not available"
+    _esimd_sdp = probe.sdp
+
+    import comfy.ldm.modules.attention as attn_mod
+
+    if not hasattr(attn_mod, "attention_pytorch"):
+        return False, "attention_pytorch not found"
+
+    _pytorch_fallback = attn_mod.attention_pytorch
+    wrap_attn = attn_mod.wrap_attn
+
+    @wrap_attn
+    def attention_esimd(q, k, v, heads, mask=None, attn_precision=None,
+                        skip_reshape=False, skip_output_reshape=False, **kwargs):
+        global _esimd_call_count, _esimd_fallback_count
+
+        if skip_reshape:
+            b, _, _, dim_head = q.shape
+        else:
+            b, _, dim_head = q.shape
+            dim_head //= heads
+
+        # Constraint check
+        reasons = []
+        if b != 1:
+            reasons.append(f"batch={b}")
+        if mask is not None:
+            reasons.append(f"mask={mask.shape}")
+        if dim_head not in (64, 128):
+            reasons.append(f"dim_head={dim_head}")
+        if q.device.type != "xpu":
+            reasons.append(f"device={q.device.type}")
+        if q.dtype not in (torch.float16, torch.bfloat16):
+            reasons.append(f"dtype={q.dtype}")
+
+        if reasons:
+            _esimd_fallback_count += 1
+            key = ",".join(reasons)
+            _esimd_fallback_reasons[key] = _esimd_fallback_reasons.get(key, 0) + 1
+            if _esimd_fallback_count <= 5:
+                seq = q.shape[1] if not skip_reshape else q.shape[2]
+                log.info("[OmniXPU] attention fallback: %s (seq=%d)", key, seq)
+            return _pytorch_fallback(q, k, v, heads, mask=mask, attn_precision=attn_precision,
+                                     skip_reshape=skip_reshape, skip_output_reshape=skip_output_reshape, **kwargs)
+
+        _esimd_call_count += 1
+        if _esimd_call_count <= 3:
+            seq = q.shape[1] if not skip_reshape else q.shape[2]
+            log.info("[OmniXPU] attention ESIMD #%d: heads=%d seq=%d dtype=%s", _esimd_call_count, heads, seq, q.dtype)
+
+        if skip_reshape:
+            q_blhd = q.permute(0, 2, 1, 3).contiguous()
+            k_blhd = k.permute(0, 2, 1, 3).contiguous()
+            v_blhd = v.permute(0, 2, 1, 3).contiguous()
+        else:
+            q_blhd = q.view(b, -1, heads, dim_head).contiguous()
+            k_blhd = k.view(b, -1, heads, dim_head).contiguous()
+            v_blhd = v.view(b, -1, heads, dim_head).contiguous()
+
+        out = _esimd_sdp.sdp(q_blhd, k_blhd, v_blhd)
+
+        # FP16 NaN safety
+        if q.dtype == torch.float16 and (out != out).any():
+            _esimd_fallback_count += 1
+            _esimd_fallback_reasons["output_non_finite"] = _esimd_fallback_reasons.get("output_non_finite", 0) + 1
+            if _esimd_fallback_reasons["output_non_finite"] <= 3:
+                log.warning("[OmniXPU] FP16 overflow in ESIMD, falling back to SDPA")
+            return _pytorch_fallback(q, k, v, heads, mask=mask, attn_precision=attn_precision,
+                                     skip_reshape=skip_reshape, skip_output_reshape=skip_output_reshape, **kwargs)
+
+        if skip_output_reshape:
+            return out.permute(0, 2, 1, 3)
+        return out.reshape(b, -1, heads * dim_head)
+
+    # Capture the originals BEFORE rebinding so we can detect by-value imports
+    # in already-loaded modules.
+    _originals = {
+        attn_mod.attention_basic,
+        attn_mod.attention_pytorch,
+        attn_mod.optimized_attention,
+        attn_mod.optimized_attention_masked,
+    }
+
+    # Patch module-level variables
+    attn_mod.optimized_attention = attention_esimd
+    attn_mod.optimized_attention_masked = attention_esimd
+
+    # ── Rebind by-value imports in already-loaded modules ────────────────────
+    # Many comfy.ldm.* and custom_nodes do `from comfy.ldm.modules.attention
+    # import optimized_attention[_masked]` at module top-level. Those bindings
+    # are frozen to attention_basic/attention_pytorch by the time this patch
+    # runs (after `import nodes` has already pulled in model_base → all
+    # ldm.*.model files). We must walk sys.modules and rebind each one.
+    NAMES = ("optimized_attention", "optimized_attention_masked")
+    rebound = 0
+    for mod_name, mod in list(sys.modules.items()):
+        if mod is None or mod is attn_mod:
+            continue
+        for name in NAMES:
+            try:
+                cur = getattr(mod, name, None)
+            except Exception:
+                continue
+            if cur is not None and cur in _originals:
+                try:
+                    setattr(mod, name, attention_esimd)
+                    rebound += 1
+                except Exception:
+                    pass
+    log.info("[OmniXPU] attention: rebound %d by-value imports across sys.modules", rebound)
+
+    # Also register via the official API
+    if hasattr(attn_mod, "register_attention_function"):
+        attn_mod.register_attention_function("esimd", attention_esimd)
+
+    return True, None

--- a/omni/ComfyUI-OmniXPU/patches/patch_fp8_fix.py
+++ b/omni/ComfyUI-OmniXPU/patches/patch_fp8_fix.py
@@ -1,0 +1,32 @@
+import logging
+
+import torch
+
+log = logging.getLogger("ComfyUI-OmniXPU")
+
+_original_fn = None
+
+
+def apply():
+    global _original_fn
+    try:
+        import comfy.float as comfy_float
+    except ImportError:
+        return False, "comfy.float not found"
+
+    if not hasattr(comfy_float, "manual_stochastic_round_to_float8"):
+        return False, "manual_stochastic_round_to_float8 not found"
+
+    _original_fn = comfy_float.manual_stochastic_round_to_float8
+
+    def _patched(x, dtype, generator=None):
+        result = _original_fn(x, dtype, generator=generator)
+        # Fix: on XPU, -0.0 → float8 produces NaN
+        if result.device.type == "xpu":
+            is_neg_zero = (result == 0) & torch.signbit(result)
+            if is_neg_zero.any():
+                result = torch.where(is_neg_zero, torch.zeros_like(result), result)
+        return result
+
+    comfy_float.manual_stochastic_round_to_float8 = _patched
+    return True, None

--- a/omni/ComfyUI-OmniXPU/patches/patch_fp8_gemm.py
+++ b/omni/ComfyUI-OmniXPU/patches/patch_fp8_gemm.py
@@ -1,0 +1,149 @@
+"""Patch comfy.ops fp8_linear and mixed_precision_ops to use
+omni_xpu_kernel's oneDNN W8A16 FP8 GEMM when running on XPU.
+
+Exactly mirrors the logic from comfyui_for_multi_arc.patch.
+"""
+
+import logging
+
+import torch
+import comfy.model_management
+
+log = logging.getLogger("ComfyUI-OmniXPU")
+
+_omni_fp8_linear = None
+_logged_first_use = False
+
+
+def _log_first(msg):
+    global _logged_first_use
+    if not _logged_first_use:
+        _logged_first_use = True
+        log.info("[OmniXPU] fp8_gemm first use: %s", msg)
+
+
+def apply():
+    global _omni_fp8_linear
+    import sys
+    probe = sys.modules.get("ComfyUI-OmniXPU.probe")
+    if probe.linear_fp8 is None:
+        return False, "omni_xpu_kernel linear_fp8 not available"
+    _omni_fp8_linear = probe.linear_fp8
+
+    import comfy.ops as comfy_ops
+
+    # --- Patch fp8_linear module-level function ---
+    if hasattr(comfy_ops, "fp8_linear"):
+        _orig_fp8_linear = comfy_ops.fp8_linear
+
+        def _patched_fp8_linear(self, input):
+            dtype = self.weight.dtype
+            if dtype not in (torch.float8_e4m3fn, torch.float8_e5m2):
+                return None
+
+            input_dtype = input.dtype
+            input_shape = input.shape
+            tensor_3d = input.ndim == 3
+            if tensor_3d:
+                input = input.reshape(-1, input_shape[2])
+            if input.ndim != 2:
+                return None
+
+            lora_compute_dtype = comfy.model_management.lora_compute_dtype(input.device)
+            w, bias, offload_stream = comfy_ops.cast_bias_weight(
+                self, input, dtype=dtype, bias_dtype=input_dtype,
+                offloadable=True, compute_dtype=lora_compute_dtype, want_requant=True,
+            )
+
+            # --- omni_xpu_kernel oneDNN FP8 GEMM (fast path for XPU) ---
+            if _omni_fp8_linear is not None and input.is_xpu:
+                _log_first(f"input={list(input.shape)} weight={list(w.shape)} dtype={dtype}")
+                scale_weight = self.scale_weight if hasattr(self, 'scale_weight') and self.scale_weight is not None else torch.ones((), device=input.device, dtype=torch.float32)
+                try:
+                    o = _omni_fp8_linear(input, w, scale_weight, bias)
+                    comfy_ops.uncast_bias_weight(self, w, bias, offload_stream)
+                    if tensor_3d:
+                        o = o.reshape((input_shape[0], input_shape[1], w.shape[0]))
+                    return o
+                except Exception as e:
+                    _log_first(f"failed, falling back: {e}")
+
+            # --- Original path: QuantizedTensor dispatch ---
+            comfy_ops.uncast_bias_weight(self, w, bias, offload_stream)
+            return _orig_fp8_linear(self, input)
+
+        comfy_ops.fp8_linear = _patched_fp8_linear
+
+    # --- Patch mixed_precision_ops Linear ---
+    if hasattr(comfy_ops, "mixed_precision_ops"):
+        _orig_mixed = comfy_ops.mixed_precision_ops
+        QuantizedTensor = getattr(comfy_ops, "QuantizedTensor", None)
+
+        def _patched_mixed(*args, **kwargs):
+            klass = _orig_mixed(*args, **kwargs)
+
+            _orig_fwd = klass.Linear.forward
+            _orig_inner_fwd = klass.Linear._forward
+
+            # -- Intercept 1: _forward(input, weight, bias) --
+            # Called from forward_comfy_cast_weights after cast_bias_weight.
+            def _mp_inner_forward(self, input, weight, bias):
+                if (_omni_fp8_linear is not None and input.is_xpu and input.ndim == 2 and
+                        hasattr(weight, 'dtype') and weight.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)):
+                    _log_first(f"input={list(input.shape)} weight={list(weight.shape)} dtype={weight.dtype}")
+                    try:
+                        scale_w = getattr(self, 'scale_weight', None)
+                        if scale_w is None:
+                            p = getattr(self.weight, 'params', None) or getattr(self.weight, '_layout_params', None)
+                            scale_w = getattr(p, 'scale', None) if p else None
+                        if scale_w is None:
+                            scale_w = torch.ones((), device=input.device, dtype=torch.float32)
+                        return _omni_fp8_linear(input, weight, scale_w, bias)
+                    except Exception as e:
+                        _log_first(f"_forward failed, falling back: {e}")
+                return _orig_inner_fwd(self, input, weight, bias)
+
+            # -- Intercept 2: forward() --
+            # Intercepts before comfy_kitchen QuantizedTensor dispatch.
+            def _mp_forward(self, input, *fwd_args, **fwd_kwargs):
+                if (_omni_fp8_linear is not None and input.is_xpu and
+                        getattr(self, 'quant_format', None) in ('float8_e4m3fn', 'float8_e5m2') and
+                        len(self.weight_function) == 0 and len(self.bias_function) == 0):
+                    input_shape = input.shape
+                    input_2d = input.reshape(-1, input_shape[-1]) if input.ndim == 3 else input
+                    if input_2d.ndim == 2:
+                        try:
+                            w = self.weight
+                            fp8_dtype = torch.float8_e4m3fn if self.quant_format == 'float8_e4m3fn' else torch.float8_e5m2
+                            if QuantizedTensor is not None and isinstance(w, QuantizedTensor):
+                                w_fp8 = w._qdata
+                                scale_w = getattr(w.params, 'scale', None)
+                            else:
+                                w_fp8 = w if w.dtype == fp8_dtype else w.view(fp8_dtype)
+                                scale_w = getattr(self, 'scale_weight', None)
+                            if scale_w is None:
+                                scale_w = torch.ones((), device=input.device, dtype=torch.float32)
+                            scale_w = comfy.model_management.cast_to_device(scale_w, input.device, torch.float32)
+                            w_fp8 = comfy.model_management.cast_to_device(w_fp8, input.device, None)
+                            bias = (comfy.model_management.cast_to_device(self.bias, input.device, input.dtype)
+                                    if self.bias is not None else None)
+
+                            _log_first(f"input={list(input_2d.shape)} weight={list(w_fp8.shape)} "
+                                       f"dtype={w_fp8.dtype} format={self.quant_format}")
+
+                            o = _omni_fp8_linear(input_2d, w_fp8, scale_w, bias)
+                            if input.ndim == 3:
+                                o = o.reshape(input_shape[0], input_shape[1], -1)
+                            return o
+                        except Exception as e:
+                            _log_first(f"forward failed, falling back: {e}")
+
+                return _orig_fwd(self, input, *fwd_args, **fwd_kwargs)
+
+            klass.Linear.forward = _mp_forward
+            klass.Linear._forward = _mp_inner_forward
+            return klass
+
+        comfy_ops.mixed_precision_ops = _patched_mixed
+
+    return True, None

--- a/omni/ComfyUI-OmniXPU/patches/patch_interpolate.py
+++ b/omni/ComfyUI-OmniXPU/patches/patch_interpolate.py
@@ -1,0 +1,25 @@
+import functools
+import logging
+
+import torch
+import torch.nn.functional as F
+
+log = logging.getLogger("ComfyUI-OmniXPU")
+
+_original_interpolate = None
+
+
+def apply():
+    global _original_interpolate
+    _original_interpolate = F.interpolate
+
+    @functools.wraps(_original_interpolate)
+    def _xpu_interpolate(input_tensor, *args, **kwargs):
+        if input_tensor.device.type == "xpu":
+            dev = input_tensor.device
+            result = _original_interpolate(input_tensor.to("cpu"), *args, **kwargs)
+            return result.to(dev)
+        return _original_interpolate(input_tensor, *args, **kwargs)
+
+    F.interpolate = _xpu_interpolate
+    return True, None

--- a/omni/ComfyUI-OmniXPU/patches/patch_norm.py
+++ b/omni/ComfyUI-OmniXPU/patches/patch_norm.py
@@ -22,6 +22,8 @@ _logged_first_use = False
 def _can_use_omni(x):
     if _omni_norm is None or not x.is_xpu:
         return False
+    if not x.is_contiguous():
+        return False
     if x.ndim < 2:
         return False
     h = x.shape[-1]

--- a/omni/ComfyUI-OmniXPU/patches/patch_norm.py
+++ b/omni/ComfyUI-OmniXPU/patches/patch_norm.py
@@ -1,0 +1,175 @@
+"""Patch comfy.ops LayerNorm / RMSNorm and comfy.rmsnorm.rms_norm to use
+omni_xpu_kernel accelerated norms on XPU.
+
+Mirrors the omni_b7 branch (analytics-zoo/ComfyUI @ 4aa7b1c):
+- forward_comfy_cast_weights: cast weights via cast_bias_weight(..., offloadable=True),
+  use omni kernel when eligible, then uncast. Preserves offload_stream lifecycle.
+- forward: only takes the omni fast path when NOT in comfy-cast-weights mode and
+  when weight_function / bias_function hooks are empty.
+"""
+
+import logging
+
+import torch
+import comfy.model_management
+
+log = logging.getLogger("ComfyUI-OmniXPU")
+
+_omni_norm = None
+_logged_first_use = False
+
+
+def _can_use_omni(x):
+    if _omni_norm is None or not x.is_xpu:
+        return False
+    if x.ndim < 2:
+        return False
+    h = x.shape[-1]
+    return h <= 8192 and h % 32 == 0
+
+
+def _log_first(op, shape):
+    global _logged_first_use
+    if not _logged_first_use:
+        _logged_first_use = True
+        log.info("[OmniXPU] norm first use: %s shape=%s", op, shape)
+
+
+def apply():
+    global _omni_norm
+    import sys
+    probe = sys.modules.get("ComfyUI-OmniXPU.probe")
+    if probe.norm is None:
+        return False, "omni_xpu_kernel norm not available"
+    _omni_norm = probe.norm
+
+    import comfy.ops as comfy_ops
+
+    # cast_bias_weight / uncast_bias_weight must exist for us to preserve
+    # the offload_stream lifecycle correctly.
+    if not (hasattr(comfy_ops, "cast_bias_weight") and hasattr(comfy_ops, "uncast_bias_weight")):
+        return False, "comfy.ops cast_bias_weight helpers not available"
+
+    # --- LayerNorm ---
+    LN = comfy_ops.disable_weight_init.LayerNorm
+    _orig_ln_cast = LN.forward_comfy_cast_weights
+    _orig_ln_fwd = LN.forward
+
+    def _ln_cast(self, input):
+        if self.weight is not None:
+            weight, bias, offload_stream = comfy_ops.cast_bias_weight(self, input, offloadable=True)
+        else:
+            weight = None
+            bias = None
+            offload_stream = None
+        if (_can_use_omni(input) and len(self.normalized_shape) == 1
+                and (weight is None or weight.shape[0] == input.shape[-1])):
+            _log_first("LayerNorm", input.shape)
+            orig = input.shape
+            x_2d = input.reshape(-1, orig[-1])
+            x = _omni_norm.layer_norm(x_2d, weight, bias, self.eps).reshape(orig)
+        else:
+            x = torch.nn.functional.layer_norm(input, self.normalized_shape, weight, bias, self.eps)
+        comfy_ops.uncast_bias_weight(self, weight, bias, offload_stream)
+        return x
+
+    def _ln_fwd(self, *args, **kwargs):
+        # run_every_op() is called by the original forward; skip here to avoid
+        # double-counting. Only use omni fast path when NOT in cast-weights mode.
+        if self.comfy_cast_weights or len(self.weight_function) > 0 or len(self.bias_function) > 0:
+            return _ln_cast(self, *args, **kwargs)
+        input = args[0] if args else kwargs.get("input")
+        if (input is not None and _can_use_omni(input) and len(self.normalized_shape) == 1
+                and (self.weight is None or self.weight.shape[0] == input.shape[-1])):
+            _log_first("LayerNorm", input.shape)
+            orig = input.shape
+            x_2d = input.reshape(-1, orig[-1])
+            return _omni_norm.layer_norm(x_2d, self.weight, self.bias, self.eps).reshape(orig)
+        return _orig_ln_fwd(self, *args, **kwargs)
+
+    LN.forward_comfy_cast_weights = _ln_cast
+    LN.forward = _ln_fwd
+
+    # --- RMSNorm ---
+    RN = comfy_ops.disable_weight_init.RMSNorm
+    _orig_rn_cast = RN.forward_comfy_cast_weights
+    _orig_rn_fwd = RN.forward
+
+    def _rn_cast(self, input):
+        if self.weight is not None:
+            weight, bias, offload_stream = comfy_ops.cast_bias_weight(self, input, offloadable=True)
+        else:
+            weight = None
+            bias = None
+            offload_stream = None
+        if _can_use_omni(input) and weight is not None and weight.shape[0] == input.shape[-1]:
+            _log_first("RMSNorm", input.shape)
+            orig = input.shape
+            x_2d = input.reshape(-1, orig[-1])
+            eps = self.eps if self.eps is not None else 1e-6
+            x = _omni_norm.rms_norm(weight, x_2d, eps).reshape(orig)
+        else:
+            x = torch.nn.functional.rms_norm(input, self.normalized_shape, weight, self.eps)
+        comfy_ops.uncast_bias_weight(self, weight, bias, offload_stream)
+        return x
+
+    def _rn_fwd(self, *args, **kwargs):
+        if self.comfy_cast_weights or len(self.weight_function) > 0 or len(self.bias_function) > 0:
+            return _rn_cast(self, *args, **kwargs)
+        input = args[0] if args else kwargs.get("input")
+        if (input is not None and _can_use_omni(input)
+                and self.weight is not None and self.weight.shape[0] == input.shape[-1]):
+            _log_first("RMSNorm", input.shape)
+            orig = input.shape
+            x_2d = input.reshape(-1, orig[-1])
+            eps = self.eps if self.eps is not None else 1e-6
+            return _omni_norm.rms_norm(self.weight, x_2d, eps).reshape(orig)
+        return _orig_rn_fwd(self, *args, **kwargs)
+
+    RN.forward_comfy_cast_weights = _rn_cast
+    RN.forward = _rn_fwd
+
+    # --- functional rms_norm ---
+    try:
+        import comfy.rmsnorm as comfy_rmsnorm
+        _orig_rms_fn = comfy_rmsnorm.rms_norm
+
+        def _patched_rms_norm(x, weight=None, eps=1e-6):
+            if _can_use_omni(x):
+                _log_first("rms_norm_fn", x.shape)
+                orig = x.shape
+                x_2d = x.reshape(-1, orig[-1])
+                if weight is not None:
+                    w = comfy.model_management.cast_to(weight, dtype=x.dtype, device=x.device)
+                else:
+                    w = torch.ones(orig[-1], dtype=x.dtype, device=x.device)
+                return _omni_norm.rms_norm(w, x_2d, eps).reshape(orig)
+            return _orig_rms_fn(x, weight=weight, eps=eps)
+
+        comfy_rmsnorm.rms_norm = _patched_rms_norm
+
+        # ── Rebind by-value imports of rms_norm ──────────────────────────────
+        # comfy.ldm.common_dit.py does `rms_norm = comfy.rmsnorm.rms_norm` at
+        # import time, and many diffusion models (lightricks/LTX, genmo,
+        # mmdit, llama text encoder) call `comfy.ldm.common_dit.rms_norm`.
+        # Without this rebind, those call sites still hit the original
+        # PyTorch implementation.
+        rebound = 0
+        for mod_name, mod in list(sys.modules.items()):
+            if mod is None or mod is comfy_rmsnorm:
+                continue
+            try:
+                cur = getattr(mod, "rms_norm", None)
+            except Exception:
+                continue
+            if cur is _orig_rms_fn:
+                try:
+                    setattr(mod, "rms_norm", _patched_rms_norm)
+                    rebound += 1
+                except Exception:
+                    pass
+        log.info("[OmniXPU] norm: rebound %d by-value imports of rms_norm", rebound)
+    except (ImportError, AttributeError):
+        pass  # comfy.rmsnorm may not exist in all versions
+
+    return True, None

--- a/omni/ComfyUI-OmniXPU/patches/patch_rope.py
+++ b/omni/ComfyUI-OmniXPU/patches/patch_rope.py
@@ -1,0 +1,98 @@
+import logging
+
+import torch
+from torch import Tensor
+
+log = logging.getLogger("ComfyUI-OmniXPU")
+
+_omni_rotary = None
+_logged_first = False
+
+
+def _can_use(x):
+    if _omni_rotary is None or not x.is_xpu:
+        return False
+    return x.shape[-1] in (64, 128)
+
+
+def _omni_apply_rope1(x: Tensor, freqs_cis: Tensor):
+    global _logged_first
+    B, H, S, D = x.shape
+    S_freq = freqs_cis.shape[2]
+
+    # Fallback if freq seq_len < x seq_len
+    if S_freq < S:
+        x_ = x.to(dtype=freqs_cis.dtype).reshape(*x.shape[:-1], -1, 1, 2)
+        if x_.shape[2] != 1 and freqs_cis.shape[2] != 1 and x_.shape[2] != freqs_cis.shape[2]:
+            freqs_cis = freqs_cis[:, :, :x_.shape[2]]
+        x_out = freqs_cis[..., 0] * x_[..., 0]
+        x_out.addcmul_(freqs_cis[..., 1], x_[..., 1])
+        return x_out.reshape(*x.shape).type_as(x)
+
+    if not _logged_first:
+        _logged_first = True
+        log.info("[OmniXPU] rope first use: ESIMD rotary_emb shape=%s", x.shape)
+
+    cos_cache = freqs_cis[0, 0, :S, :, 0, 0].to(dtype=torch.float32).contiguous()
+    sin_cache = freqs_cis[0, 0, :S, :, 1, 0].to(dtype=torch.float32).contiguous()
+    x_flat = x.permute(0, 2, 1, 3).contiguous().reshape(B * S * H, D)
+    out = _omni_rotary.rotary_emb(x_flat, cos_cache, sin_cache, S, H)
+    return out.reshape(B, S, H, D).permute(0, 2, 1, 3).contiguous()
+
+
+def apply():
+    global _omni_rotary
+    import sys
+    probe = sys.modules.get("ComfyUI-OmniXPU.probe")
+    if probe.rotary is None:
+        return False, "omni_xpu_kernel rotary not available"
+    _omni_rotary = probe.rotary
+
+    import comfy.ldm.flux.math as flux_math
+
+    # Save originals
+    _orig_apply_rope1 = flux_math._apply_rope1
+
+    def _patched_apply_rope1(x: Tensor, freqs_cis: Tensor):
+        if _can_use(x) and x.ndim == 4 and freqs_cis.ndim == 6:
+            return _omni_apply_rope1(x, freqs_cis)
+        return _orig_apply_rope1(x, freqs_cis)
+
+    flux_math._apply_rope1 = _patched_apply_rope1
+
+    # Patch apply_rope1 (the compiled/quant_ops version if present)
+    _new_apply_rope1 = None
+    if hasattr(flux_math, "apply_rope1"):
+        _orig_compiled = flux_math.apply_rope1
+
+        def _patched_compiled(x, freqs_cis):
+            if _can_use(x) and x.ndim == 4 and freqs_cis.ndim == 6:
+                return _omni_apply_rope1(x, freqs_cis)
+            return _orig_compiled(x, freqs_cis)
+
+        flux_math.apply_rope1 = _patched_compiled
+        _new_apply_rope1 = _patched_compiled
+
+    # ── Rebind by-value imports of apply_rope1 in already-loaded modules ─────
+    # Several diffusion model files (wan, qwen_image, kandinsky5, sam3, ...)
+    # do `from comfy.ldm.flux.math import apply_rope1` at module top-level.
+    # Those bindings are frozen to the unpatched apply_rope1 by the time this
+    # patch runs (after `import nodes`). Walk sys.modules and rebind.
+    if _new_apply_rope1 is not None:
+        rebound = 0
+        for mod_name, mod in list(sys.modules.items()):
+            if mod is None or mod is flux_math:
+                continue
+            try:
+                cur = getattr(mod, "apply_rope1", None)
+            except Exception:
+                continue
+            if cur is _orig_compiled:
+                try:
+                    setattr(mod, "apply_rope1", _new_apply_rope1)
+                    rebound += 1
+                except Exception:
+                    pass
+        log.info("[OmniXPU] rope: rebound %d by-value imports of apply_rope1", rebound)
+
+    return True, None

--- a/omni/ComfyUI-OmniXPU/probe.py
+++ b/omni/ComfyUI-OmniXPU/probe.py
@@ -1,0 +1,71 @@
+"""Centralized omni_xpu_kernel capability probe."""
+
+import logging
+
+log = logging.getLogger("ComfyUI-OmniXPU")
+
+version = None
+sdp = None
+norm = None
+rotary = None
+linear_fp8 = None
+
+
+def probe():
+    """Probe omni_xpu_kernel and populate available submodules."""
+    global version, sdp, norm, rotary, linear_fp8
+
+    try:
+        import omni_xpu_kernel as pkg
+        version = getattr(pkg, "__version__", "unknown")
+    except ImportError:
+        log.info("[OmniXPU] omni_xpu_kernel not installed")
+        return
+
+    modules = {}
+
+    try:
+        from omni_xpu_kernel._C import sdp as _sdp
+        sdp = _sdp
+        modules["sdp"] = True
+    except ImportError:
+        modules["sdp"] = False
+
+    try:
+        from omni_xpu_kernel import norm as _norm
+        norm = _norm
+        modules["norm"] = True
+    except ImportError:
+        modules["norm"] = False
+
+    try:
+        from omni_xpu_kernel import rotary as _rotary
+        rotary = _rotary
+        modules["rotary"] = True
+    except ImportError:
+        modules["rotary"] = False
+
+    try:
+        from omni_xpu_kernel import linear as _linear
+        linear_fp8 = _linear.onednn_w8a16_fp8
+        modules["linear_fp8"] = True
+    except (ImportError, AttributeError):
+        modules["linear_fp8"] = False
+
+    available = [k for k, v in modules.items() if v]
+    missing = [k for k, v in modules.items() if not v]
+
+    log.info("[OmniXPU] omni_xpu_kernel %s — available: %s%s",
+             version, ", ".join(available) if available else "none",
+             f" | missing: {', '.join(missing)}" if missing else "")
+
+
+def summary():
+    """Return a dict for diagnostics."""
+    return {
+        "version": version,
+        "sdp": sdp is not None,
+        "norm": norm is not None,
+        "rotary": rotary is not None,
+        "linear_fp8": linear_fp8 is not None,
+    }

--- a/omni/docker/Dockerfile
+++ b/omni/docker/Dockerfile
@@ -82,18 +82,22 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pip install -e . && \
     rm -f /tmp/yunchang_for_multi_arc.patch /tmp/xdit_for_multi_arc.patch
 
-# ComfyUI core
-COPY ./patches/comfyui_for_multi_arc.patch /tmp/
-
+# ComfyUI core (upstream, no patches)
 RUN --mount=type=cache,target=/root/.cache/pip \
     cd /llm && \
     git clone --depth 1 https://github.com/comfyanonymous/ComfyUI.git && \
     cd ComfyUI && \
     git fetch --depth 1 origin 64b8457f55cd7fb54ca7a956d9c73b505e903e0c && \
     git checkout 64b8457f55cd7fb54ca7a956d9c73b505e903e0c && \
-    git apply /tmp/comfyui_for_multi_arc.patch && \
-    pip install -r requirements.txt && \
-    rm -f /tmp/comfyui_for_multi_arc.patch
+    pip install -r requirements.txt
+
+# ComfyUI-OmniXPU: Intel XPU acceleration via custom node (replaces core patch)
+COPY ./ComfyUI-OmniXPU /llm/ComfyUI/custom_nodes/ComfyUI-OmniXPU
+ARG IMAGE_TAG="0.1.0-dev"
+RUN cd /llm/ComfyUI/custom_nodes/ComfyUI-OmniXPU && \
+    git init && git add -A && \
+    git -c user.name="llm-scaler" -c user.email="noreply@intel.com" \
+        commit --allow-empty -m "ComfyUI-OmniXPU ${IMAGE_TAG}"
 
 # ComfyUI custom nodes (active)
 COPY ./patches/raylight_for_multi_arc.patch /tmp/
@@ -297,6 +301,7 @@ RUN cp /opt/intel/oneapi/compiler/2025.3/lib/libsycl-native-*.spv /usr/local/lib
 ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib/python${PYTHON_VERSION}/dist-packages/torch/lib:${LD_LIBRARY_PATH}"
 ENV CCL_SYCL_ALLTOALL_ARC_LL=1
 ENV CCL_SYCL_CCL_BARRIER=1
-ENV _LLM_SCALER_DISABLE_INTERPOLATE_FIX=1
+ENV OMNIXPU_INTERPOLATE_FIX=0
+ENV OMNIXPU_ATTENTION=0
 
 WORKDIR /llm/entrypoints


### PR DESCRIPTION
Convert the build-time `comfyui_for_multi_arc.patch` into a custom node so upstream ComfyUI is not modified. Same kernel coverage (LayerNorm/RMSNorm, RoPE, Flash Attention, FP8 W8A16 GEMM, FP8 negative-zero fix) plus runtime sys.modules walk that rebinds by-value imports of `optimized_attention`, `apply_rope1`, and `rms_norm` in already-loaded diffusion model files — without it, those bindings stay frozen to the unpatched callables since ComfyUI imports model_base before custom_node init.

Env knobs (default values mirror b7 behavior):
  OMNIXPU_ENABLE / _ATTENTION / _ROPE / _NORM / _FP8_GEMM /
  _FP8_NEG_ZERO_FIX / _INTERPOLATE_FIX

Dockerfile drops `git apply comfyui_for_multi_arc.patch` and copies the node into custom_nodes/ instead, with a tag-stamped git init so ComfyUI Manager can recognise the directory.