### PR TITLE
patches: add cutlass scale prefetch alignment fix to vllm_xpu_kernels

### DIFF
--- a/vllm/patches/vllm_xpu_kernels.patch
+++ b/vllm/patches/vllm_xpu_kernels.patch
@@ -226,3 +226,46 @@ index 10d7a1b..66b104c 100644
        reinterpret_cast<int*>(query_start_loc.data_ptr()),          \
        reinterpret_cast<int*>(cache_indices.data_ptr()),            \
        has_initial_state.has_value()                                \
+diff --git a/csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp b/csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp
+index 0f78d83..726bd4e 100644
+--- a/csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp
++++ b/csrc/xpu/grouped_gemm/xe_2/gemm_xe2.hpp
+@@ -349,6 +349,19 @@ CUTE_DEVICE void xe_gemm_4bits(
+   int group_num = get<1>(A.shape()) / group_size;
+   int x_idx = sg_local_id / channel_num;
+ 
++  // FIX (2026-06-01): block_2d_prefetch on the scales tensor uses
++  // group_num * sizeof(ElementS) as the row pitch. Xe2 block_2d_load
++  // requires pitch >= 64B and 16B-aligned. When K is not a power-of-two
++  // multiple of group_size (e.g. Qwen3.5-35B W2: K=1408, group_num=11,
++  // pitch=22B), the prefetch over-reads adjacent memory and can hit
++  // unrelated live tensors -> bogus scales -> DEVICE_LOST.
++  // Skip the scale prefetch in that case; the actual scale load below
++  // (regular indexing, lines further down) still works correctly. The
++  // prefetch is a perf hint, dropping it costs ~1-3% on this path only.
++  const bool can_prefetch_scales =
++      (group_num * static_cast<int>(sizeof(ElementS))) >= 64 &&
++      ((group_num * static_cast<int>(sizeof(ElementS))) % 16) == 0;
++
+   using scaleStoreType = conditional_t<is_same_v<TA, half_t>, half_t, float>;
+   scaleStoreType scales[thr_N * channel_num];
+ 
+@@ -364,7 +377,7 @@ CUTE_DEVICE void xe_gemm_4bits(
+     prefetch(prefetch_a, pAgA(_, _, _, k_tile_prefetch));
+     prefetch(prefetch_b, pBgB(_, _, _, k_tile_prefetch));
+ 
+-    if (k_tile_prefetch * group_size < shape<1>(A)) {
++    if (can_prefetch_scales && k_tile_prefetch * group_size < shape<1>(A)) {
+       auto next_scales_tensor = make_tensor(
+           make_gmem_ptr(
+               reinterpret_cast<const ElementS*>(
+@@ -416,7 +429,8 @@ CUTE_DEVICE void xe_gemm_4bits(
+         }
+       }
+ 
+-      if ((group_idx + prefetch_dist) * group_size < shape<1>(A)) {
++      if (can_prefetch_scales &&
++          (group_idx + prefetch_dist) * group_size < shape<1>(A)) {
+         auto next_scales_tensor = make_tensor(
+             make_gmem_ptr(
+                 reinterpret_cast<const ElementS*>(


### PR DESCRIPTION
Adds the gemm_xe2.hpp can_prefetch_scales guard from upstream vllm-xpu-kernels to vllm_xpu_kernels.patch.

The INT4 grouped GEMM (W4A16) loads its scale tensor with block_2d_prefetch on a per-sub-group [SG_N, 1] tile whose row pitch equals group_num * sizeof(ElementS). On Xe2, block_2d_load/prefetch requires the row pitch to be >= 64 bytes and 16-byte aligned; violating this silently over-reads adjacent device memory.

For Qwen3.5-35B-A3B W2 (K=intermediate_size=1408, group_size=128, group_num=11), the pitch is 22B -- below the requirement and not 16B aligned. Under VLLM_OFFLOAD_WEIGHTS_BEFORE_QUANT=0 streaming load the scale tensors physical neighbors are other live tensors, often int4 weight bytes; the prefetch over-read parses those bytes as fp16, producing huge/NaN scales which explode the cutlass accumulator and cause DEVICE_LOST. Under non-streaming load the trailing memory is allocator padding so the same kernel bug stays latent.

The patched kernel adds a runtime check that the pitch satisfies both constraints; when it does not, the scale prefetch is skipped. The actual scale load further down the kernel uses regular indexed loads and is unaffected, so correctness is fully preserved.

Verified on Qwen3.5-35B-A3B INT4 with VLLM_OFFLOAD_WEIGHTS_BEFORE_QUANT=0: input_len=129/256/1024 prefill no longer crashes, gsm8k 100q passes.

Performance: paths that meet the alignment continue to prefetch (0% impact); paths that do not (only the unusual non-power-of-two K case) lose only the prefetch hint, costing roughly 1-3% on those shapes.

Upstream commit (vllm-xpu-kernels): 2004ffe