### PR TITLE
fix(moe-int4): 支持 E=128/top_k=8 与 128/10 的 TopK V2 派发

### DIFF
--- a/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe_int4.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe_int4.sycl
@@ -324,6 +324,18 @@ std::tuple<torch::Tensor, torch::Tensor> moe_router_topk_int4(
             (fp16*)topk_weight.data_ptr(),
             topk_idx.data_ptr<int32_t>(),
             n_tokens, queue);
+    } else if (num_experts == 128 && top_k == 8) {
+        moe_topk_v2_host<128, 8>(
+            (const fp16*)s_int4_router_logits.data_ptr(),
+            (fp16*)topk_weight.data_ptr(),
+            topk_idx.data_ptr<int32_t>(),
+            n_tokens, queue);
+    } else if (num_experts == 128 && top_k == 10) {
+        moe_topk_v2_host<128, 10>(
+            (const fp16*)s_int4_router_logits.data_ptr(),
+            (fp16*)topk_weight.data_ptr(),
+            topk_idx.data_ptr<int32_t>(),
+            n_tokens, queue);
     } else {
         moe_topk_forward_kernel_impl<class MoeRouterTopKInt4>(
             (const fp16*)s_int4_router_logits.data_ptr(),
@@ -1410,6 +1422,18 @@ std::tuple<torch::Tensor, torch::Tensor> moe_topk_int4(
     sycl::queue& queue = c10::xpu::getCurrentXPUStream(logits.device().index()).queue();
     if (n_routed_experts == 256 && top_k == 8) {
         moe_topk_v2_host<256, 8>(
+            (const fp16*)logits.data_ptr(),
+            (fp16*)topk_weight.data_ptr(),
+            topk_idx.data_ptr<int32_t>(),
+            n_tokens, queue);
+    } else if (n_routed_experts == 128 && top_k == 8) {
+        moe_topk_v2_host<128, 8>(
+            (const fp16*)logits.data_ptr(),
+            (fp16*)topk_weight.data_ptr(),
+            topk_idx.data_ptr<int32_t>(),
+            n_tokens, queue);
+    } else if (n_routed_experts == 128 && top_k == 10) {
+        moe_topk_v2_host<128, 10>(
             (const fp16*)logits.data_ptr(),
             (fp16*)topk_weight.data_ptr(),
             topk_idx.data_ptr<int32_t>(),
@@ -2675,6 +2699,18 @@ torch::Tensor moe_forward_tiny_cutlass_nmajor_int4_full_fp16_shared_from_logits(
             (fp16*)s_int4_topk_weight.data_ptr(),
             s_int4_topk_idx.data_ptr<int32_t>(),
             n_tokens, queue);
+    } else if (n_routed_experts == 128 && top_k == 8) {
+        moe_topk_v2_host<128, 8>(
+            (const fp16*)logits.data_ptr(),
+            (fp16*)s_int4_topk_weight.data_ptr(),
+            s_int4_topk_idx.data_ptr<int32_t>(),
+            n_tokens, queue);
+    } else if (n_routed_experts == 128 && top_k == 10) {
+        moe_topk_v2_host<128, 10>(
+            (const fp16*)logits.data_ptr(),
+            (fp16*)s_int4_topk_weight.data_ptr(),
+            s_int4_topk_idx.data_ptr<int32_t>(),
+            n_tokens, queue);
     } else {
         moe_topk_forward_kernel_impl<class MoeTopKInt4TinyFull>(
             (const fp16*)logits.data_ptr(),
@@ -2810,6 +2846,18 @@ torch::Tensor moe_forward_full_int4(
     // ── TopK (V2 vectorized argmax when supported, fallback to heap-based) ──
     if (n_routed_experts == 256 && top_k == 8) {
         moe_topk_v2_host<256, 8>(
+            (const fp16*)logits.data_ptr(),
+            (fp16*)s_int4_topk_weight.data_ptr(),
+            s_int4_topk_idx.data_ptr<int32_t>(),
+            n_tokens, queue);
+    } else if (n_routed_experts == 128 && top_k == 8) {
+        moe_topk_v2_host<128, 8>(
+            (const fp16*)logits.data_ptr(),
+            (fp16*)s_int4_topk_weight.data_ptr(),
+            s_int4_topk_idx.data_ptr<int32_t>(),
+            n_tokens, queue);
+    } else if (n_routed_experts == 128 && top_k == 10) {
+        moe_topk_v2_host<128, 10>(
             (const fp16*)logits.data_ptr(),
             (fp16*)s_int4_topk_weight.data_ptr(),
             s_int4_topk_idx.data_ptr<int32_t>(),
@@ -3543,6 +3591,10 @@ torch::Tensor moe_forward_cutlass_nmajor_int4_full(
     auto topk_i = torch::empty({M,top_k}, torch::device(x.device()).dtype(torch::kInt));
     if(n_routed_experts==256 && top_k==8)
         moe_topk_v2_host<256,8>((const fp16*)logits.data_ptr(),(fp16*)topk_w.data_ptr(),topk_i.data_ptr<int32_t>(),M,q);
+    else if(n_routed_experts==128 && top_k==8)
+        moe_topk_v2_host<128,8>((const fp16*)logits.data_ptr(),(fp16*)topk_w.data_ptr(),topk_i.data_ptr<int32_t>(),M,q);
+    else if(n_routed_experts==128 && top_k==10)
+        moe_topk_v2_host<128,10>((const fp16*)logits.data_ptr(),(fp16*)topk_w.data_ptr(),topk_i.data_ptr<int32_t>(),M,q);
     else
         moe_topk_forward_kernel_impl<class MoeCNMFullTopK>((const fp16*)logits.data_ptr(),topk_i.data_ptr<int32_t>(),(fp16*)topk_w.data_ptr(),M,(int)n_routed_experts,top_k,true,q);
 

--- a/vllm/custom-esimd-kernels-vllm/csrc/moe_prefill/moe_prefill_int4.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/moe_prefill/moe_prefill_int4.sycl
@@ -894,6 +894,18 @@ std::vector<torch::Tensor> moe_topk_softmax(
             (fp16*)topk_weights.data_ptr(),
             topk_ids.data_ptr<int32_t>(),
             M, q);
+    } else if (num_experts == 128 && top_k == 8) {
+        moe_topk_v2_host<128, 8>(
+            (const fp16*)router_logits.data_ptr(),
+            (fp16*)topk_weights.data_ptr(),
+            topk_ids.data_ptr<int32_t>(),
+            M, q);
+    } else if (num_experts == 128 && top_k == 10) {
+        moe_topk_v2_host<128, 10>(
+            (const fp16*)router_logits.data_ptr(),
+            (fp16*)topk_weights.data_ptr(),
+            topk_ids.data_ptr<int32_t>(),
+            M, q);
     } else {
         TORCH_CHECK(false, "moe_topk_softmax: unsupported (E=", num_experts,
                     ", top_k=", top_k,
@@ -930,6 +942,18 @@ torch::Tensor moe_prefill_full_int4(
 
     if (num_experts == 256 && top_k == 8) {
         moe_topk_v2_host<256, 8>(
+            (const fp16*)router_logits.data_ptr(),
+            (fp16*)topk_values.data_ptr(),
+            topk_indices.data_ptr<int32_t>(),
+            n_tokens, queue);
+    } else if (num_experts == 128 && top_k == 8) {
+        moe_topk_v2_host<128, 8>(
+            (const fp16*)router_logits.data_ptr(),
+            (fp16*)topk_values.data_ptr(),
+            topk_indices.data_ptr<int32_t>(),
+            n_tokens, queue);
+    } else if (num_experts == 128 && top_k == 10) {
+        moe_topk_v2_host<128, 10>(
             (const fp16*)router_logits.data_ptr(),
             (fp16*)topk_values.data_ptr(),
             topk_indices.data_ptr<int32_t>(),


### PR DESCRIPTION
Qwen3-30B-A3B-Instruct-2507 的 num_experts=128、num_experts_per_tok=8， 原派发只硬编码了 (E=256, top_k=8)：
  - moe_prefill_int4.sycl 的 moe_topk_softmax / moe_prefill_full_int4 在 E=128 时走 else 分支 TORCH_CHECK(false) 直接报错（prefill 崩溃）；
  - moe_int4.sycl 的 5 处派发在 E=128 时退化到 heap fallback kernel。

底层模板 MoE_TopK_V2_Kernel<128,8>/<128,10> 本就合法
(NE%64==0 && NE<=512 && TK<=16)，且已在 esimd_kernel_topk_v2.sycl / moe.sycl 实例化使用。本次在上述 7 处补 (128,8)、(128,10) 分支。

效果：prefill 不再崩溃；decode/batch 走 V2 向量化快路径，
E=128 topk 单算子较 heap fallback 提速约 2.1x-3.0x（BMG 实测）。