### PR TITLE
Update vllm patch from v0.14.0-b8.3

### DIFF
--- a/vllm/patches/vllm_for_multi_arc.patch
+++ b/vllm/patches/vllm_for_multi_arc.patch
@@ -13557,7 +13557,7 @@ index f2f354604..ad88271b9 100644
                  if weight_name not in name:
                      continue
 diff --git a/vllm/model_executor/models/qwen3_next.py b/vllm/model_executor/models/qwen3_next.py
-index 0f73a7746..9b7608cbb 100644
+index 0f73a7746..47998fae9 100644
 --- a/vllm/model_executor/models/qwen3_next.py
 +++ b/vllm/model_executor/models/qwen3_next.py
 @@ -2,10 +2,22 @@
@@ -13743,7 +13743,39 @@ index 0f73a7746..9b7608cbb 100644
          if self.is_sequence_parallel:
              hidden_states = sequence_parallel_chunk(hidden_states)
  
-@@ -366,6 +490,88 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
+@@ -206,7 +330,19 @@ class Qwen3NextSparseMoeBlock(nn.Module):
+             )
+ 
+         if self.shared_expert is not None:
+-            final_hidden_states = final_hidden_states[0] + final_hidden_states[1]
++            # IPEX FP8 down_proj at TP=8 leaves the last hidden channel
++            # ([..., 2047]) un-written; the buffer reuses caching-allocator
++            # stale memory which decays into NaN/Inf and cascades through
++            # the residual stream. Both shared_out and fused_out share the
++            # same buggy down_proj path, so sanitize each before the add.
++            final_hidden_states = (
++                torch.nan_to_num(final_hidden_states[0], nan=0.0, posinf=0.0, neginf=0.0)
++                + torch.nan_to_num(final_hidden_states[1], nan=0.0, posinf=0.0, neginf=0.0)
++            )
++        else:
++            final_hidden_states = torch.nan_to_num(
++                final_hidden_states, nan=0.0, posinf=0.0, neginf=0.0
++            )
+ 
+         if self.is_sequence_parallel:
+             final_hidden_states = tensor_model_parallel_all_gather(
+@@ -217,6 +353,10 @@ class Qwen3NextSparseMoeBlock(nn.Module):
+             final_hidden_states = self.experts.maybe_all_reduce_tensor_model_parallel(  # noqa E501
+                 final_hidden_states
+             )
++        # Final sanitize: defend against any residual Inf surviving allreduce.
++        final_hidden_states = torch.nan_to_num(
++            final_hidden_states, nan=0.0, posinf=0.0, neginf=0.0
++        )
+ 
+         return final_hidden_states.view(orig_shape)
+ 
+@@ -366,6 +506,88 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
          if prefix in compilation_config.static_forward_context:
              raise ValueError(f"Duplicate layer name: {prefix}")
          compilation_config.static_forward_context[prefix] = self
@@ -13832,7 +13864,7 @@ index 0f73a7746..9b7608cbb 100644
  
      def fix_query_key_value_ordering(
          self,
-@@ -441,6 +647,419 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
+@@ -441,6 +663,462 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
          self,
          hidden_states: torch.Tensor,
          output: torch.Tensor,
@@ -13853,6 +13885,27 @@ index 0f73a7746..9b7608cbb 100644
 +        2. Core attention (custom op)
 +        3. Output projection
 +        """
++        # Workaround: clone FP8 weight storage on first forward to prevent
++        # corruption by gdn_attention XE2 chunk kernel OOB writes in mixed
++        # prefill+decode batches (chunk_gated_delta_rule_xe2 writes a full
++        # 64-row tile to core_attn_out for decode rows whose
++        # current_chunk_size=1, overflowing into adjacent GPU memory which
++        # may land on FP8 weight storage). Cloning relocates the weights
++        # away from the OOB write region. See Qwen3_5GatedDeltaNet for the
++        # original PR (#91) and root-cause analysis.
++        if not getattr(self, '_weights_cloned', False):
++            self._weights_cloned = True
++            if hasattr(self.out_proj, 'weight'):
++                self.out_proj.weight.data = self.out_proj.weight.data.clone()
++            if hasattr(self.in_proj_qkvz, 'weight'):
++                self.in_proj_qkvz.weight.data = (
++                    self.in_proj_qkvz.weight.data.clone()
++                )
++            if hasattr(self.in_proj_ba, 'weight'):
++                self.in_proj_ba.weight.data = (
++                    self.in_proj_ba.weight.data.clone()
++                )
++
 +        num_tokens = hidden_states.size(0)
 +        is_decode = num_tokens == 1
 +
@@ -13924,6 +13977,17 @@ index 0f73a7746..9b7608cbb 100644
 +                device=hidden_states.device,
 +            )
 +            z = torch.empty_like(core_attn_out)
++        if attn_metadata is None:
++            # vLLM warmup/profile: attn_metadata is None, Part 2 (the GDN core
++            # kernel) does not run. core_attn_out / z (especially when routed
++            # through torch.empty_like) can land on caching-allocator memory
++            # whose bytes happen to encode fp16 NaN; the downstream
++            # RMSNormGated would then propagate NaN through out_proj. Even
++            # though warmup output is discarded, the NaN-laden output would
++            # still flow through allreduce and could corrupt cached norm /
++            # weight state in later layers. Zero the output and skip Part 3.
++            output[:num_tokens].zero_()
++            return
 +        if attn_metadata is not None:
 +            attn_metadata = attn_metadata[self.prefix]
 +
@@ -14086,6 +14150,12 @@ index 0f73a7746..9b7608cbb 100644
 +        attn_metadata: AttentionMetadata = forward_context.attn_metadata
 +        core_attn_out = self._decode_attn_out_buf
 +        z = self._decode_z_buf
++        if attn_metadata is None:
++            # Warmup/profile: skip Part 2+3 entirely. Output is discarded but
++            # routing it through stale buffers + RMSNormGated could leak NaN
++            # into allreduce-cached state. See forward_xpu for full rationale.
++            output[:1].zero_()
++            return
 +        if attn_metadata is not None:
 +            attn_metadata = attn_metadata[self.prefix]
 +            self_kv_cache = self.kv_cache[forward_context.virtual_engine]
@@ -14170,6 +14240,11 @@ index 0f73a7746..9b7608cbb 100644
 +        forward_context = get_forward_context()
 +        attn_metadata: AttentionMetadata = forward_context.attn_metadata
 +
++        # Warmup/profile: skip Part 2+3 entirely. See forward_xpu for details.
++        if attn_metadata is None:
++            output[:num_tokens].zero_()
++            return
++
 +        # Part 2: Core Attention — pre-allocated buffers, no torch.zeros
 +        if num_tokens <= self._max_bsz:
 +            core_attn_out = self._m_attn_out[:num_tokens]
@@ -14252,7 +14327,7 @@ index 0f73a7746..9b7608cbb 100644
      ):
          """
          Forward pass with three parts:
-@@ -778,42 +1397,360 @@ class Qwen3NextAttention(nn.Module):
+@@ -778,42 +1456,360 @@ class Qwen3NextAttention(nn.Module):
          self.q_norm = Qwen3NextRMSNorm(self.head_dim, eps=config.rms_norm_eps)
          self.k_norm = Qwen3NextRMSNorm(self.head_dim, eps=config.rms_norm_eps)
  
@@ -14632,7 +14707,7 @@ index 0f73a7746..9b7608cbb 100644
  
  
  class Qwen3NextDecoderLayer(nn.Module):
-@@ -900,6 +1837,116 @@ class Qwen3NextDecoderLayer(nn.Module):
+@@ -900,6 +1896,116 @@ class Qwen3NextDecoderLayer(nn.Module):
                  ),
              )
  
@@ -14749,7 +14824,7 @@ index 0f73a7746..9b7608cbb 100644
      def forward(
          self,
          hidden_states: torch.Tensor,
-@@ -907,27 +1954,161 @@ class Qwen3NextDecoderLayer(nn.Module):
+@@ -907,27 +2013,161 @@ class Qwen3NextDecoderLayer(nn.Module):
          positions: torch.Tensor = None,
          **kwargs: object,
      ):
@@ -14930,7 +15005,7 @@ index 0f73a7746..9b7608cbb 100644
  
          if self.layer_scale:
              if len(hidden_states.shape) == 2:
-@@ -939,9 +2120,139 @@ class Qwen3NextDecoderLayer(nn.Module):
+@@ -939,9 +2179,139 @@ class Qwen3NextDecoderLayer(nn.Module):
                      self.attn_layer_scale.to(hidden_states.dtype) + 1
                  )
  
@@ -15073,7 +15148,7 @@ index 0f73a7746..9b7608cbb 100644
  
          if self.layer_scale:
              if len(hidden_states.shape) == 2:
-@@ -965,7 +2276,7 @@ class Qwen3NextModel(nn.Module):
+@@ -965,7 +2335,7 @@ class Qwen3NextModel(nn.Module):
      def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
          super().__init__()
  
@@ -15082,7 +15157,7 @@ index 0f73a7746..9b7608cbb 100644
          parallel_config = vllm_config.parallel_config
  
          eplb_config = parallel_config.eplb_config
-@@ -1042,7 +2353,7 @@ class Qwen3NextModel(nn.Module):
+@@ -1042,7 +2412,7 @@ class Qwen3NextModel(nn.Module):
              ckpt_gate_proj_name="gate_proj",
              ckpt_down_proj_name="down_proj",
              ckpt_up_proj_name="up_proj",
@@ -15091,7 +15166,7 @@ index 0f73a7746..9b7608cbb 100644
              num_redundant_experts=self.num_redundant_experts,
          )
  
-@@ -1201,15 +2512,17 @@ class Qwen3NextForCausalLM(
+@@ -1201,15 +2571,17 @@ class Qwen3NextForCausalLM(
      }
  
      def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
@@ -15113,7 +15188,7 @@ index 0f73a7746..9b7608cbb 100644
          self.quant_config = vllm_config.quant_config
  
          super().__init__()
-@@ -1263,7 +2576,7 @@ class Qwen3NextForCausalLM(
+@@ -1263,7 +2635,7 @@ class Qwen3NextForCausalLM(
          cls, vllm_config: "VllmConfig"
      ) -> tuple[tuple[int, int], tuple[int, int]]:
          parallel_config = vllm_config.parallel_config
@@ -15122,7 +15197,7 @@ index 0f73a7746..9b7608cbb 100644
          tp_size = parallel_config.tensor_parallel_size
          num_spec = (
              vllm_config.speculative_config.num_speculative_tokens
-@@ -1280,6 +2593,10 @@ class Qwen3NextForCausalLM(
+@@ -1280,6 +2652,10 @@ class Qwen3NextForCausalLM(
              num_spec,
          )
  
@@ -15539,6 +15614,59 @@ index f891a88f9..256300932 100644
              ),
          )
  
+diff --git a/vllm/reasoning/qwen3_reasoning_parser.py b/vllm/reasoning/qwen3_reasoning_parser.py
+index ef7762bf0..415cb3eaa 100644
+--- a/vllm/reasoning/qwen3_reasoning_parser.py
++++ b/vllm/reasoning/qwen3_reasoning_parser.py
+@@ -32,36 +32,23 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
+     ) -> tuple[str | None, str | None]:
+         """
+         Extract reasoning content from the model output.
+-
+-        Qwen3 has stricter requirements - it needs both start and end tokens
+-        to be present, unlike other models that work with just the end token.
+-
+-        For text <think>abc</think>xyz:
+-        - 'abc' goes to reasoning
+-        - 'xyz' goes to content
+-
+-        Returns:
+-            tuple[Optional[str], Optional[str]]: reasoning content and content
++ 
++        Handles both cases:
++        - <think>abc</think>xyz (start token in output)
++        - abc</think>xyz (start token was in prompt, not in generated output)
+         """
+-
+-        # Check if the model output contains both <think> and </think> tokens.
+-        if self.start_token not in model_output or self.end_token not in model_output:
++ 
++        if self.end_token not in model_output:
++            if self.start_token in model_output:
++                _, _, after = model_output.partition(self.start_token)
++                return after or None, None
+             return None, model_output
+-
+-        # Check if the <think> is present in the model output, remove it
+-        # if it is present.
++ 
+         model_output_parts = model_output.partition(self.start_token)
+         model_output = (
+             model_output_parts[2] if model_output_parts[1] else model_output_parts[0]
+         )
+-
+-        # Check if the model output contains the </think> tokens.
+-        # If the end token is not found, return the model output as is.
+-        if self.end_token not in model_output:
+-            return None, model_output
+-
+-        # Extract reasoning content from the model output.
++ 
+         reasoning, _, content = model_output.partition(self.end_token)
+-
+-        final_content = content or None
++        final_content = content.strip() if content and content.strip() else None
+         return reasoning, final_content
 diff --git a/vllm/tokenizers/bpe_qwen.py b/vllm/tokenizers/bpe_qwen.py
 new file mode 100644
 index 000000000..170f31d96
@@ -15816,7 +15944,7 @@ index 00d5ecd25..9f0c8ec97 100644
  ]
 diff --git a/vllm/transformers_utils/configs/qwen3_asr.py b/vllm/transformers_utils/configs/qwen3_asr.py
 new file mode 100644
-index 000000000..28fa96e72
+index 000000000..a08b2b7de
 --- /dev/null
 +++ b/vllm/transformers_utils/configs/qwen3_asr.py
 @@ -0,0 +1,436 @@
@@ -16230,7 +16358,6 @@ index 000000000..28fa96e72
 +        support_languages=None,
 +        **kwargs,
 +    ):
-+        super().__init__(**kwargs)
 +        if thinker_config is None:
 +            thinker_config = {}
 +            logger.info(
@@ -16239,6 +16366,7 @@ index 000000000..28fa96e72
 +
 +        self.thinker_config = Qwen3ASRThinkerConfig(**thinker_config)
 +        self.support_languages = support_languages
++        super().__init__(**kwargs)
 +
 +    def get_text_config(self, decoder=False) -> "PretrainedConfig":
 +        """
@@ -16822,7 +16950,7 @@ index 130d85efb..e5dc2aa9b 100644
      if current_platform.is_xpu():
          return True
 diff --git a/vllm/v1/attention/backends/flash_attn.py b/vllm/v1/attention/backends/flash_attn.py
-index 6fec5001b..17bc94d7a 100755
+index 6fec5001b..734e38095 100755
 --- a/vllm/v1/attention/backends/flash_attn.py
 +++ b/vllm/v1/attention/backends/flash_attn.py
 @@ -3,6 +3,7 @@
@@ -16890,7 +17018,7 @@ index 6fec5001b..17bc94d7a 100755
  
      def forward(
          self,
-@@ -706,6 +719,53 @@ class FlashAttentionImpl(AttentionImpl):
+@@ -706,6 +719,75 @@ class FlashAttentionImpl(AttentionImpl):
                  )
                  return output
              else:
@@ -16913,6 +17041,26 @@ index 6fec5001b..17bc94d7a 100755
 +                        _gqa = _num_q // _num_kv if _num_kv > 0 else 0
 +                        _need_pad = (_gqa >= 2 and _gqa % 4 != 0)
 +
++                        # ESIMD kernel needs the [2,num_blocks,page,kv_h,hd]
++                        # tensor reinterpreted as the actual fp8 dtype the KV
++                        # cache writer used.  Bare "fp8" and "fp8_e4m3" encode
++                        # as e4m3fn on the write side (see attention layer:
++                        # assert kv_cache_dtype in {"fp8", "fp8_e4m3"}); only
++                        # "fp8_e5m2" uses e5m2.  Using a different fp8 flavour
++                        # here than the writer used garbles every dequanted byte.
++                        if self.kv_cache_dtype.startswith("fp8"):
++                            _kv_dtype = (
++                                torch.float8_e5m2
++                                if self.kv_cache_dtype == "fp8_e5m2"
++                                else torch.float8_e4m3fn)
++                            _kv_for_esimd = kv_cache.view(_kv_dtype)
++                            _k_scale = float(layer._k_scale)
++                            _v_scale = float(layer._v_scale)
++                        else:
++                            _kv_for_esimd = kv_cache
++                            _k_scale = 1.0
++                            _v_scale = 1.0
++
 +                        if _need_pad:
 +                            # Pad Q heads per KV group to next multiple of 4
 +                            _padded_gqa = ((_gqa + 3) // 4) * 4
@@ -16926,15 +17074,17 @@ index 6fec5001b..17bc94d7a 100755
 +                            _q_pad = _q_pad.reshape(_bs, _num_kv * _padded_gqa, _hd).contiguous()
 +                            _o_pad = torch.zeros_like(_q_pad)
 +                            eagle_ops.page_attn_decode(
-+                                _q_pad, kv_cache, block_table, seqused_k,
-+                                _o_pad, 1, attn_metadata.max_seq_len)
++                                _q_pad, _kv_for_esimd, block_table, seqused_k,
++                                _o_pad, 1, attn_metadata.max_seq_len,
++                                _k_scale, _v_scale)
 +                            # Unpad: reshape back and take first _gqa heads per KV group
 +                            _o_grouped = _o_pad.reshape(_bs, _num_kv, _padded_gqa, _hd)
 +                            _o.copy_(_o_grouped[:, :, :_gqa, :].reshape(_bs, _num_q, _hd))
 +                        elif _gqa >= 4:
 +                            eagle_ops.page_attn_decode(
-+                                _q, kv_cache, block_table, seqused_k,
-+                                _o, 1, attn_metadata.max_seq_len)
++                                _q, _kv_for_esimd, block_table, seqused_k,
++                                _o, 1, attn_metadata.max_seq_len,
++                                _k_scale, _v_scale)
 +                        else:
 +                            eagle_ops = None  # unsupported, fall through
 +


### PR DESCRIPTION
## Summary
- Regenerated `vllm_for_multi_arc.patch` from `intel-sandbox/llm-scaler-vllm-xpu` branch `v0.14.0-b8.3` (commit 8705a1a)
- Fix NaN/Inf propagation in Qwen3Next MoE shared expert output caused by FP8 down_proj OOB writes at TP=8
- Clone FP8 weight storage on first forward to prevent GDN attention XE2 chunk kernel corruption in mixed prefill+decode batches
- Additional GatedDeltaNet forward pass optimizations

## Test plan
- [x] Patch applies cleanly to upstream vllm v0.14.0
- [x] Docker image `v0.14.0-b8.3.1` built successfully (34.3GB)
- [ ] Run Qwen3Next inference to validate NaN fix
- [ ] Run GatedDeltaNet mixed batch test

🤖 Generated with [Claude Code](https://claude.com/claude-code)