### PR TITLE
[ComfyUI-OmniXPU] Add XPU median/nanmedian dim-reduction workaround

### DIFF
--- a/omni/ComfyUI-OmniXPU/README.md
+++ b/omni/ComfyUI-OmniXPU/README.md
@@ -40,6 +40,8 @@ OMNIXPU_MEDIAN_FIX=0        # Disable median workaround only
 `OMNIXPU_MEDIAN_STRICT_INDICES=1` makes the median workaround reproduce
 `torch.median`'s exact tie-break indices (values are always bit-exact).
 
+> **Note:** the XPU median slowdown this works around has only been verified on Intel Arc B60/B70 with torch 2.10. It should be re-checked on other hardware or torch versions before relying on it there.
+
 ## Diagnostics
 
 Add the **OmniXPU Status** node to any workflow to see:

--- a/omni/ComfyUI-OmniXPU/README.md
+++ b/omni/ComfyUI-OmniXPU/README.md
@@ -20,6 +20,7 @@ Requires `omni_xpu_kernel` installed. Without it the node loads silently with no
 | FP8 GEMM | `fp8_linear` / `mixed_precision_ops` |
 | FP8 Negative Zero Fix | `manual_stochastic_round_to_float8` |
 | Interpolate Fix | `F.interpolate` |
+| Median Fix | `torch.median` / `torch.nanmedian` (XPU dim-reduction) |
 
 ## Environment Variables
 
@@ -33,7 +34,11 @@ OMNIXPU_NORM=0              # Disable ESIMD LayerNorm/RMSNorm only
 OMNIXPU_FP8_GEMM=0          # Disable FP8 GEMM only
 OMNIXPU_FP8_NEG_ZERO_FIX=0  # Disable FP8 negative zero fix only
 OMNIXPU_INTERPOLATE_FIX=0   # Disable interpolate workaround only
+OMNIXPU_MEDIAN_FIX=0        # Disable median workaround only
 ```
+
+`OMNIXPU_MEDIAN_STRICT_INDICES=1` makes the median workaround reproduce
+`torch.median`'s exact tie-break indices (values are always bit-exact).
 
 ## Diagnostics
 
@@ -46,6 +51,7 @@ Add the **OmniXPU Status** node to any workflow to see:
     available: sdp, norm, rotary, linear_fp8
 
   [+] interpolate_fix: applied
+  [+] median_fix: applied
   [+] fp8_neg_zero_fix: applied
   [+] norm: applied
   [+] rope: applied
@@ -60,6 +66,7 @@ When loaded successfully, ComfyUI logs:
 ```
 [OmniXPU] omni_xpu_kernel 0.1.0 — available: sdp, norm, rotary, linear_fp8
 [OmniXPU] interpolate_fix: applied
+[OmniXPU] median_fix: applied
 [OmniXPU] fp8_neg_zero_fix: applied
 [OmniXPU] norm: applied
 [OmniXPU] rope: applied

--- a/omni/ComfyUI-OmniXPU/config.py
+++ b/omni/ComfyUI-OmniXPU/config.py
@@ -12,6 +12,7 @@ class Config:
         self.fp8_gemm = master and os.environ.get("OMNIXPU_FP8_GEMM", "1") != "0"
         self.fp8_neg_zero_fix = master and os.environ.get("OMNIXPU_FP8_NEG_ZERO_FIX", "1") != "0"
         self.interpolate_fix = master and os.environ.get("OMNIXPU_INTERPOLATE_FIX", "1") != "0"
+        self.median_fix = master and os.environ.get("OMNIXPU_MEDIAN_FIX", "1") != "0"
 
 
 config = Config()

--- a/omni/ComfyUI-OmniXPU/patches/__init__.py
+++ b/omni/ComfyUI-OmniXPU/patches/__init__.py
@@ -36,6 +36,7 @@ def apply_all_patches(cfg):
         return mod.apply
 
     apply_interpolate = _load_patch("patch_interpolate")
+    apply_median = _load_patch("patch_median")
     apply_fp8_fix = _load_patch("patch_fp8_fix")
     apply_norm = _load_patch("patch_norm")
     apply_rope = _load_patch("patch_rope")
@@ -43,6 +44,7 @@ def apply_all_patches(cfg):
     apply_attention = _load_patch("patch_attention")
 
     _apply_one("interpolate_fix", cfg.interpolate_fix, apply_interpolate)
+    _apply_one("median_fix", cfg.median_fix, apply_median)
     _apply_one("fp8_neg_zero_fix", cfg.fp8_neg_zero_fix, apply_fp8_fix)
     _apply_one("norm", cfg.norm, apply_norm)
     _apply_one("rope", cfg.rope, apply_rope)

--- a/omni/ComfyUI-OmniXPU/patches/patch_median.py
+++ b/omni/ComfyUI-OmniXPU/patches/patch_median.py
@@ -1,0 +1,154 @@
+import logging
+
+import torch
+
+log = logging.getLogger("ComfyUI-OmniXPU")
+
+# Patch torch.median / torch.nanmedian on XPU.
+#
+# Why: on Intel XPU the dim-reduction median/nanmedian kernel is pathologically
+# slow -- far slower than a full sort on the same device, and well behind the
+# corresponding CUDA path -- independent of reduction length, dim, memory
+# layout, value distribution and dtype (including integer types). The global
+# median path (no dim argument) is healthy, so we only intervene on the
+# dim-reduction path and leave everything else to the original implementation.
+#
+# Strategy (all paths produce bit-exact VALUES vs torch.median):
+#   - small N  -> odd-even (Batcher) min/max compare-exchange network
+#                 (lowest overhead for small reduction lengths)
+#   - large N  -> torch.sort along dim, take the lower-median element
+#                 (on XPU sort outperforms kthvalue)
+# Indices: torch.median's index tie-break is implementation-defined; our fast
+# paths return a VALID index (a position whose value equals the median value)
+# via equality-argmax. Set OMNIXPU_MEDIAN_STRICT_INDICES=1 to force kthvalue,
+# which reproduces torch.median's exact indices.
+
+_orig_median = None
+_orig_nanmedian = None
+
+SMALL_N_MAX = 16  # measured crossover: minmax network <= sort up to ~N16
+
+# dtypes where the XPU kernel is slow and our fast paths are valid
+_FAST_DTYPES = (
+    torch.float16, torch.bfloat16, torch.float32, torch.float64,
+    torch.int16, torch.int32, torch.int64, torch.uint8, torch.int8,
+)
+
+_net_cache = {}
+
+
+def _oddeven_network(n):
+    if n in _net_cache:
+        return _net_cache[n]
+    pairs = []
+
+    def merge(lo, n2, r):
+        step = r * 2
+        if step < n2:
+            merge(lo, n2, step)
+            merge(lo + r, n2, step)
+            for i in range(lo + r, lo + n2 - r, step):
+                pairs.append((i, i + r))
+        else:
+            pairs.append((lo, lo + r))
+
+    def sort(lo, n2):
+        if n2 > 1:
+            m = n2 // 2
+            sort(lo, m)
+            sort(lo + m, m)
+            merge(lo, n2, 1)
+
+    p = 1
+    while p < n:
+        p *= 2
+    sort(0, p)
+    net = [(a, b) for a, b in pairs if a < n and b < n]
+    _net_cache[n] = net
+    return net
+
+
+def _minmax_lower_median(moved):
+    # moved: reduction dim already at position 0, shape [N, ...]
+    n = moved.shape[0]
+    cols = [moved[i] for i in range(n)]
+    for a, b in _oddeven_network(n):
+        lo = torch.minimum(cols[a], cols[b])
+        hi = torch.maximum(cols[a], cols[b])
+        cols[a], cols[b] = lo, hi
+    return cols[(n - 1) // 2]
+
+
+def _fast_dim_median(input, dim, keepdim, strict_indices):
+    moved = input.movedim(dim, 0)
+    n = moved.shape[0]
+    if strict_indices:
+        # kthvalue reproduces torch.median exactly (values + indices)
+        k = (n - 1) // 2 + 1
+        v, i = torch.kthvalue(moved, k, dim=0)
+    else:
+        if n <= SMALL_N_MAX:
+            v = _minmax_lower_median(moved)
+        else:
+            s, _ = torch.sort(moved, dim=0)
+            v = s[(n - 1) // 2]
+        # a valid median index: first position along dim holding the value
+        i = (moved == v.unsqueeze(0)).to(torch.uint8).argmax(dim=0)
+    if keepdim:
+        v = v.unsqueeze(dim)
+        i = i.unsqueeze(dim)
+    return v, i
+
+
+def _should_handle(input, dim):
+    return (
+        dim is not None
+        and isinstance(input, torch.Tensor)
+        and input.device.type == "xpu"
+        and input.dtype in _FAST_DTYPES
+        and input.dim() > 0
+    )
+
+
+def apply():
+    global _orig_median, _orig_nanmedian
+    import os
+
+    _orig_median = torch.median
+    _orig_nanmedian = torch.nanmedian
+    strict = os.environ.get("OMNIXPU_MEDIAN_STRICT_INDICES", "0") != "0"
+
+    def _patched_median(input, dim=None, keepdim=False, *, out=None):
+        if out is not None or not _should_handle(input, dim):
+            if dim is None:
+                return _orig_median(input)
+            return _orig_median(input, dim, keepdim, out=out) if out is not None \
+                else _orig_median(input, dim, keepdim)
+        # preserve NaN propagation: torch.median returns NaN if any NaN in slice
+        if input.is_floating_point() and torch.isnan(input).any():
+            return _orig_median(input, dim, keepdim)
+        try:
+            v, i = _fast_dim_median(input, dim, keepdim, strict)
+            return torch.return_types.median((v, i))
+        except Exception as e:  # never break the graph
+            log.warning("[OmniXPU] median fast path failed (%s); fallback", e)
+            return _orig_median(input, dim, keepdim)
+
+    def _patched_nanmedian(input, dim=None, keepdim=False, *, out=None):
+        if out is not None or not _should_handle(input, dim):
+            if dim is None:
+                return _orig_nanmedian(input)
+            return _orig_nanmedian(input, dim, keepdim)
+        # nanmedian ignores NaNs; if NaNs present, semantics differ -> fallback
+        if input.is_floating_point() and torch.isnan(input).any():
+            return _orig_nanmedian(input, dim, keepdim)
+        try:
+            v, i = _fast_dim_median(input, dim, keepdim, strict)
+            return torch.return_types.nanmedian((v, i))
+        except Exception as e:
+            log.warning("[OmniXPU] nanmedian fast path failed (%s); fallback", e)
+            return _orig_nanmedian(input, dim, keepdim)
+
+    torch.median = _patched_median
+    torch.nanmedian = _patched_nanmedian
+    return True, None

--- a/omni/ComfyUI-OmniXPU/patches/patch_median.py
+++ b/omni/ComfyUI-OmniXPU/patches/patch_median.py
@@ -125,9 +125,8 @@ def apply():
     def _patched_median(input, dim=None, keepdim=False, *, out=None):
         if out is not None or not _should_handle(input, dim):
             if dim is None:
-                return _orig_median(input)
-            return _orig_median(input, dim, keepdim, out=out) if out is not None \
-                else _orig_median(input, dim, keepdim)
+                return _orig_median(input, out=out) if out is not None else _orig_median(input)
+            return _orig_median(input, dim, keepdim, out=out) if out is not None else _orig_median(input, dim, keepdim)
         # preserve NaN propagation: torch.median returns NaN if any NaN in slice
         if input.is_floating_point() and torch.isnan(input).any():
             return _orig_median(input, dim, keepdim)

--- a/omni/ComfyUI-OmniXPU/patches/patch_median.py
+++ b/omni/ComfyUI-OmniXPU/patches/patch_median.py
@@ -91,13 +91,16 @@ def _fast_dim_median(input, dim, keepdim, strict_indices):
         k = (n - 1) // 2 + 1
         v, i = torch.kthvalue(moved, k, dim=0)
     else:
+        mid = (n - 1) // 2
         if n <= SMALL_N_MAX:
             v = _minmax_lower_median(moved)
+            # a valid median index: first position along dim holding the value
+            i = (moved == v.unsqueeze(0)).to(torch.uint8).argmax(dim=0)
         else:
-            s, _ = torch.sort(moved, dim=0)
-            v = s[(n - 1) // 2]
-        # a valid median index: first position along dim holding the value
-        i = (moved == v.unsqueeze(0)).to(torch.uint8).argmax(dim=0)
+            # sort already yields a valid median position; reuse its indices
+            s, sort_i = torch.sort(moved, dim=0)
+            v = s[mid]
+            i = sort_i[mid]
     if keepdim:
         v = v.unsqueeze(dim)
         i = i.unsqueeze(dim)
@@ -105,13 +108,20 @@ def _fast_dim_median(input, dim, keepdim, strict_indices):
 
 
 def _should_handle(input, dim):
-    return (
-        dim is not None
-        and isinstance(input, torch.Tensor)
-        and input.device.type == "xpu"
-        and input.dtype in _FAST_DTYPES
-        and input.dim() > 0
-    )
+    if (
+        dim is None
+        or not isinstance(input, torch.Tensor)
+        or input.device.type != "xpu"
+        or input.dtype not in _FAST_DTYPES
+        or input.dim() == 0
+    ):
+        return False
+    # reject invalid/empty reduction dims so user errors fall through to the
+    # original implementation (which raises the proper error) without a warning
+    try:
+        return input.size(dim) > 0
+    except IndexError:
+        return False
 
 
 def apply():
@@ -140,8 +150,8 @@ def apply():
     def _patched_nanmedian(input, dim=None, keepdim=False, *, out=None):
         if out is not None or not _should_handle(input, dim):
             if dim is None:
-                return _orig_nanmedian(input)
-            return _orig_nanmedian(input, dim, keepdim)
+                return _orig_nanmedian(input, out=out) if out is not None else _orig_nanmedian(input)
+            return _orig_nanmedian(input, dim, keepdim, out=out) if out is not None else _orig_nanmedian(input, dim, keepdim)
         # nanmedian ignores NaNs; if NaNs present, semantics differ -> fallback
         if input.is_floating_point() and torch.isnan(input).any():
             return _orig_nanmedian(input, dim, keepdim)

--- a/omni/ComfyUI-OmniXPU/patches/patch_median.py
+++ b/omni/ComfyUI-OmniXPU/patches/patch_median.py
@@ -13,6 +13,10 @@ log = logging.getLogger("ComfyUI-OmniXPU")
 # median path (no dim argument) is healthy, so we only intervene on the
 # dim-reduction path and leave everything else to the original implementation.
 #
+# Scope: the underlying XPU slowdown has only been verified on Intel Arc
+# B60/B70 with torch 2.10. Re-validate on other hardware / torch versions
+# before relying on this workaround there.
+#
 # Strategy (all paths produce bit-exact VALUES vs torch.median):
 #   - small N  -> odd-even (Batcher) min/max compare-exchange network
 #                 (lowest overhead for small reduction lengths)


### PR DESCRIPTION
## Summary

On Intel XPU the dim-reduction kernel for `torch.median` / `torch.nanmedian` is pathologically slow — far behind both a full sort on the same device and the corresponding CUDA path — across reduction length, dim, memory layout,
value distribution and dtype (including integer types). The global (no-dim) median path is healthy. This adds a `ComfyUI-OmniXPU` patch (`median_fix`) that only intervenes on the XPU dim-reduction path and leaves everything else untouched.

This surfaced in the HiDream workflow (`nodes_hidream_o1.py`'s median blend), where the median step dominated runtime; with the patch it is no longer a hotspot.

## What changed

- `patches/patch_median.py` (new): wraps `torch.median` / `torch.nanmedian` on XPU
  - small N → Batcher odd-even min/max compare-exchange network
  - large N → `torch.sort`, take the lower-median element
  - **Values are bit-exact** vs `torch.median`.
  - Indices return a valid median index (a position whose value equals the median) via equality-argmax. `OMNIXPU_MEDIAN_STRICT_INDICES=1` forces `kthvalue` to reproduce `torch.median`'s exact tie-break indices.
- `config.py`, `patches/__init__.py`: wire it into the dispatcher as `median_fix`.
- `README.md`: document the patch and its env vars.

## Safety / fallbacks

- Only engages for **XPU** tensors on the **dim-reduction** path over float/int dtypes.
- NaN-containing slices, `out=` calls, and any exception fall back to the original implementation, preserving `torch.median`'s NaN-propagation semantics.
- Global median (`torch.median(x)` with no dim) is left completely untouched.
- On by default; disable with `OMNIXPU_MEDIAN_FIX=0`.

## How to test

```bash
# default: patch on
# verify startup log shows: [OmniXPU] median_fix: applied
# run a HiDream workflow and confirm correct output + no median hotspot

# regression / parity check:
python -c "import torch; x=torch.randn(33,128,128,device='xpu'); v,i=torch.median(x,dim=0)；print(v.shape, i.shape)"
```
