### PR TITLE
Fix Qwen3.5/3.6 load_weights stacked-mapping name mutation (gate_gate_up_proj / qkqkv_proj)

### DIFF
--- a/vllm/patches/vllm_for_multi_arc.patch
+++ b/vllm/patches/vllm_for_multi_arc.patch
@@ -11851,16 +11851,17 @@ index 000000000..b01b55f70
 +                if "mlp.experts" in name:
 +                    continue
 +
-+                name = name.replace(weight_name, param_name)
++                name_mapped = name.replace(weight_name, param_name
 +                # Skip loading extra bias for GPTQ models.
-+                if name.endswith(".bias") and name not in params_dict:
++                if name_mapped.endswith(".bias") and name_mapped not in params_dict:
 +                    continue
 +                # Skip layers on other devices.
 +                if is_pp_missing_parameter(name, self):
 +                    continue
 +                # name = apply_attn_prefix(name, params_dict)
-+                if name not in params_dict:
++                if name_mapped not in params_dict:
 +                    continue
++                name = name_mapped
 +                param = params_dict[name]
 +
 +                # Use weight_loader_v2 for tuple shard_id (GDN projections).
@@ -12604,15 +12605,16 @@ index 000000000..547c1885a
 +                if "mlp.experts" in name:
 +                    continue
 +
-+                name = name.replace(weight_name, param_name)
++                name_mapped = name.replace(weight_name, param_name)
 +                # Skip loading extra bias for GPTQ models.
-+                if name.endswith(".bias") and name not in params_dict:
++                if name_mapped.endswith(".bias") and name_mapped not in params_dict:
 +                    continue
 +                # Skip layers on other devices.
-+                if is_pp_missing_parameter(name, self):
++                if is_pp_missing_parameter(name_mapped, self):
 +                    continue
 +                if name not in params_dict:
 +                    continue
++                name = name_mapped
 +                param = params_dict[name]
 +                weight_loader = param.weight_loader
 +                weight_loader(param, loaded_weight, shard_id)

--- a/vllm/patches/vllm_for_multi_arc.patch
+++ b/vllm/patches/vllm_for_multi_arc.patch
@@ -11851,7 +11851,7 @@ index 000000000..b01b55f70
 +                if "mlp.experts" in name:
 +                    continue
 +
-+                name_mapped = name.replace(weight_name, param_name
++                name_mapped = name.replace(weight_name, param_name)
 +                # Skip loading extra bias for GPTQ models.
 +                if name_mapped.endswith(".bias") and name_mapped not in params_dict:
 +                    continue


### PR DESCRIPTION
What

Fixes the stacked_params_mapping loop in the patched qwen3_5.py and
qwen3_5_mtp.py (vllm/patches/vllm_for_multi_arc.patch), which mutates
name in place and can produce invalid double-mapped parameter names.

Why

In load_weights():

python
```
name = name.replace(weight_name, param_name)
...
if name not in params_dict:
    continue          # name already mutated, not restored, loop continues
param = params_dict[name]
```


When a mapped name is missing, the loop continues with the already-mutated
name. A later mapping entry then re-applies .replace() to the mapped name.
Since up_proj is a substring of gate_up_proj (and q_proj/k_proj of
qkv_proj), this yields invalid names:


gate_proj      -> gate_up_proj -> gate_gate_up_proj
q_proj/k_proj  -> qkv_proj     -> qkqkv_proj


These parameters are then never loaded, and FP8 process_weights_after_loading
later fails with 'MergedColumnParallelLinear' object has no attribute 'weight'.

The expert branch in the same function already uses the safe pattern (local
name_mapped, commit only on success); this change brings the stacked-mapping
loop in line with it.

How

Use a local name_mapped candidate and only assign it back to name after a
successful params_dict lookup. Applied to both qwen3_5.py and
qwen3_5_mtp.py.

Testing

Observed on intel/llm-scaler-vllm:0.14.0-b8.3.1, Qwen/Qwen3.6-27B-FP8,
2x Intel Arc Pro B70, TP=2. After this change the gate_gate_up_proj /
qkqkv_proj "not found in params_dict" warnings disappear. (Full bring-up of
this model also required additional XPU FP8 / ESIMD fixes — see #474.)

Refs #474
