### PR TITLE
[XPU] Fix ESIMD gelu_tanh NaN on large activations (DiffusionGemma TP=1)

### DIFF
--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/moe_ops.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/moe_ops.h
@@ -707,8 +707,17 @@ struct MoE_GeluTanh_Mul_Kernel {
             // GELU_tanh(x) = 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
             simd<float, 64> x3 = x * x * x;
             simd<float, 64> inner = sqrt_2_over_pi * (x + coeff * x3);
-            // tanh(z) = (exp(2z) - 1) / (exp(2z) + 1)
-            simd<float, 64> exp2z = esimd_math::exp<float, 64>(2.0f * inner);
+            // tanh(z) = (exp(2z) - 1) / (exp(2z) + 1) overflows fp32 exp() for a
+            // gate value x>~11 (DiffusionGemma's unsharded TP=1 dense MLP has
+            // gate absmax ~40): exp(2z) -> inf -> inf/inf = NaN. tanh saturates
+            // to +/-1 by |z|>~15, so first SATURATE 2z into a safe range via an
+            // explicit mask-merge (robust to -ffast-math: no reliance on
+            // finite-math or on min/max intrinsics that the optimizer may treat
+            // as dead once it assumes finiteness), then take exp().
+            simd<float, 64> two_z = 2.0f * inner;
+            two_z.merge(simd<float, 64>(30.0f), two_z > 30.0f);
+            two_z.merge(simd<float, 64>(-30.0f), two_z < -30.0f);
+            simd<float, 64> exp2z = esimd_math::exp<float, 64>(two_z);
             simd<float, 64> tanh_val = (exp2z - 1.0f) / (exp2z + 1.0f);
             simd<float, 64> gelu = 0.5f * x * (1.0f + tanh_val);
             simd<float, 64> result = gelu * up;


### PR DESCRIPTION
## Problem

DiffusionGemma sym_int4 at **TP=1** produced empty output (GSM8K 0%, `finish_reason=length`, `content=''`), while TP=2 worked. Root-caused to the ESIMD `gelu_tanh` activation kernel producing **NaN logits**.

The `MoE_GeluTanh_Mul_Kernel` computed `tanh(z) = (exp(2z)-1)/(exp(2z)+1)`. For a gate value `x>~11`, the argument `2z = 2·sqrt(2/pi)·(x + 0.044715·x³)` exceeds fp32 `exp()`'s input range (~88) → `exp(2z)` overflows to `+inf` → `inf/inf = NaN`.

**Why only TP=1:** dense MLP intermediate = 2112, so the gelu half-width is `d=2112`. The unsharded TP=1 path drives gate activations up to ~40, overflowing the tanh. TP=2 shards `d` to 1056 and happened to stay under the threshold, masking the bug. The int4 GEMM output itself is correct (gate absmax ~40); the NaN is purely in this activation kernel. Once logits are NaN, `argmax()=0` commits 256 token-id-0 → blank content.

## Fix

Saturate `2z` into `[-30, 30]` before `exp()`. `tanh` is ±1 well within fp16 precision by `|z|>15`, so this is exact for the fp16 output and never overflows. Single-file change in `moe_ops.h`.

## Testing

- **Microbench vs `torch.nn.functional.gelu(..., approximate='tanh')`**: NaN gone for gate amplitudes 8/11/15/40 (max abs diff < 0.09, fp16-level). Pre-fix: NaN from amp ≥ 11.
- **End-to-end DiffusionGemma sym_int4 TP=1 GSM8K** (BMG-G21, `bmg-g21` build): recovers to **90–93%** (matching TP=2), invalid 0%, at concurrency 1/2/4.
- **Throughput**: no measurable change (A/B at conc 1 = 159 vs 161 tok/s, within noise).

AI assistance (Claude) was used for the investigation and patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)