### PR TITLE
[XPU] DiffusionGemma: declare qkv_split_norm_rope ops with (a!) mutation annotations

### DIFF
--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/torch_extension.cc
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/torch_extension.cc
@@ -56,20 +56,44 @@ TORCH_LIBRARY(custom_esimd_kernels_vllm, m) {
   m.impl("esimd_gemv_int4_fused2", torch::kXPU, &esimd_gemv_int4_fused2);
 
   // Fused QKV Split + RMSNorm + RoPE
+  // q_out/gate_out/k_out/v_out are written in place (mutated). Declared with
+  // (a!)..(d!) + void return so torch.compile's auto-functionalize (v1) can
+  // trace it -- a `-> Tensor(a!)` alias return is rejected by v1, hence the
+  // lambda-wrapped void impl that discards the kernel's (aliased) return.
   m.def("esimd_qkv_split_norm_rope(Tensor qkv_state, "
-        "Tensor q_out, Tensor gate_out, Tensor k_out, Tensor v_out, "
+        "Tensor(a!) q_out, Tensor(b!) gate_out, Tensor(c!) k_out, Tensor(d!) v_out, "
         "Tensor norm_wq, Tensor norm_wk, Tensor positions, "
         "int q_heads, int kv_heads, bool attn_output_gate, "
-        "int rotary_dim, Tensor cos_sin_cache) -> Tensor");
-  m.impl("esimd_qkv_split_norm_rope", torch::kXPU, &esimd_qkv_split_norm_rope);
+        "int rotary_dim, Tensor cos_sin_cache) -> ()");
+  m.impl("esimd_qkv_split_norm_rope", torch::kXPU,
+         [](at::Tensor qkv_state, at::Tensor q_out, at::Tensor gate_out,
+            at::Tensor k_out, at::Tensor v_out, at::Tensor norm_wq,
+            at::Tensor norm_wk, at::Tensor positions, int64_t q_heads,
+            int64_t kv_heads, bool attn_output_gate, int64_t rotary_dim,
+            at::Tensor cos_sin_cache) -> void {
+           esimd_qkv_split_norm_rope(qkv_state, q_out, gate_out, k_out, v_out,
+                                     norm_wq, norm_wk, positions, q_heads,
+                                     kv_heads, attn_output_gate, rotary_dim,
+                                     cos_sin_cache);
+         });
 
   // Variant with V-Norm (gemma4): same as above but also RMSNorms V heads.
   m.def("esimd_qkv_split_norm_rope_v(Tensor qkv_state, "
-        "Tensor q_out, Tensor gate_out, Tensor k_out, Tensor v_out, "
+        "Tensor(a!) q_out, Tensor(b!) gate_out, Tensor(c!) k_out, Tensor(d!) v_out, "
         "Tensor norm_wq, Tensor norm_wk, Tensor norm_wv, Tensor positions, "
         "int q_heads, int kv_heads, bool attn_output_gate, "
-        "int rotary_dim, Tensor cos_sin_cache) -> Tensor");
-  m.impl("esimd_qkv_split_norm_rope_v", torch::kXPU, &esimd_qkv_split_norm_rope_v);
+        "int rotary_dim, Tensor cos_sin_cache) -> ()");
+  m.impl("esimd_qkv_split_norm_rope_v", torch::kXPU,
+         [](at::Tensor qkv_state, at::Tensor q_out, at::Tensor gate_out,
+            at::Tensor k_out, at::Tensor v_out, at::Tensor norm_wq,
+            at::Tensor norm_wk, at::Tensor norm_wv, at::Tensor positions,
+            int64_t q_heads, int64_t kv_heads, bool attn_output_gate,
+            int64_t rotary_dim, at::Tensor cos_sin_cache) -> void {
+           esimd_qkv_split_norm_rope_v(qkv_state, q_out, gate_out, k_out, v_out,
+                                       norm_wq, norm_wk, norm_wv, positions,
+                                       q_heads, kv_heads, attn_output_gate,
+                                       rotary_dim, cos_sin_cache);
+         });
 
   // Fused ResidualAdd + RMSNorm + FP8 GEMV (post_attn_norm + router)
   m.def("esimd_resadd_norm_gemv_fp8_pert(Tensor hidden_states, Tensor residual, "


### PR DESCRIPTION
## Summary

Fixes empty/garbage output from DiffusionGemma once `torch.compile` / XPU graph is enabled (i.e. running **without `--enforce-eager`**).

`esimd_qkv_split_norm_rope` / `esimd_qkv_split_norm_rope_v` write their results **in place** into the preallocated `q_out` / `gate_out` / `k_out` / `v_out` buffers (and return an alias of `q_out`), but the schemas declared them as pure `-> Tensor` with **no mutation annotation**. Under `torch.compile` functionalization an op declared side-effect-free whose return value is unused is a dead-code-elimination / storage-reuse candidate → the output buffers are left uninitialized → empty/garbage output.

## Change

Re-declare both ops with `(a!)..(d!)` mutation annotations on the four output buffers and a void `-> ()` return:

```
esimd_qkv_split_norm_rope_v(Tensor qkv_state,
    Tensor(a!) q_out, Tensor(b!) gate_out, Tensor(c!) k_out, Tensor(d!) v_out,
    ...) -> ()
```

- **void `-> ()`** (not `-> Tensor(a!)`): vLLM's compile uses auto_functionalize **v1**, which rejects ops returning an alias of a mutated input. The XPU impl is wrapped in a lambda that calls the kernel and discards its (aliased) return value.

Only `csrc/xpu/torch_extension.cc` changes (schema + impl registration); the SYCL kernel itself is unchanged.

## Rebuild

```
TORCH_XPU_ARCH_LIST=bmg-g21 MAX_JOBS=8 python3 setup.py build_ext --inplace
```
(incremental: only `torch_extension.cc` recompiles; `.sycl` objects are cached. ⚠️ `bmg-g21`, not `bmg`.)

## Companion

Goes with the vLLM-side XPU-graph enablement PR (register_fake meta impls + warmup sample-logprobs skip + `layer_scalar.item()` `is_compiling()` guard). Without this `(a!)` change the vLLM side compiles/captures but produces empty output.

## Testing

Verified end-to-end: int4 TP=1 + `VLLM_XPU_ENABLE_XPU_GRAPH=1` produces correct output and GSM8K 92% (no regression vs eager). The differential (ESIMD path on → empty; off → correct) confirmed the in-place-aliasing root cause before the fix.

AI assistance (Claude) was used for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)