### PR TITLE
[XPU][FMHA] Add per-seq-causal mixed-attn to vllm_xpu_kernels patch

### DIFF
--- a/vllm/patches/vllm_xpu_kernels.patch
+++ b/vllm/patches/vllm_xpu_kernels.patch
@@ -1,3 +1,272 @@
+diff --git a/csrc/flash_attn/flash_api.cpp b/csrc/flash_attn/flash_api.cpp
+index 8d12b68..9cc057b 100644
+--- a/csrc/flash_attn/flash_api.cpp
++++ b/csrc/flash_attn/flash_api.cpp
+@@ -118,7 +118,11 @@ std::vector<at::Tensor> mha_varlen_fwd(
+     const bool return_softmax,
+     std::optional<at::Generator> gen_,
+     std::optional<int> num_splits,
+-    bool mix_batch) {
++    bool mix_batch,
++    // Per-sequence causal mask [num_seqs] bool: true=causal, false=bidir.
++    // When provided, one launch handles a mixed causal/bidirectional batch
++    // (DiffusionGemma encoder+denoise) instead of splitting into 2 FA2 calls.
++    std::optional<const at::Tensor>& per_seq_causal_) {
+   auto q_type = q.scalar_type();
+   auto k_type = k.scalar_type();
+   TORCH_CHECK(
+@@ -228,7 +232,8 @@ std::vector<at::Tensor> mha_varlen_fwd(
+         is_local,
+         is_sink,
+         softmax_lse_opt,
+-        no_mask);
++        no_mask,
++        per_seq_causal_);
+   } else if (max_seqlen_q > 1) {
+     if (!out_.has_value()) {
+       out = torch::empty_like(q);
+@@ -262,7 +267,8 @@ std::vector<at::Tensor> mha_varlen_fwd(
+         is_local,
+         is_sink,
+         softmax_lse_opt,
+-        is_prefill_opt);
++        is_prefill_opt,
++        per_seq_causal_);
+ 
+     // Paged decode: processes only decode batches (skips prefill)
+     int eff_window_left =
+@@ -439,7 +445,8 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
+       "float softmax_scale, Tensor? softmax_sink, bool zero_tensors, "
+       "bool is_causal, int window_size_left, int window_size_right, float "
+       "softcap, bool return_softmax, "
+-      "Generator? gen, int? num_splits, bool mix_batch) -> Tensor[]");
++      "Generator? gen, int? num_splits, bool mix_batch, "
++      "Tensor? per_seq_causal) -> Tensor[]");
+   ops.impl(
+       "varlen_fwd",
+       torch::kXPU,
+diff --git a/csrc/xpu/attn/attn_interface.cpp b/csrc/xpu/attn/attn_interface.cpp
+index 60cc5a9..5d958e2 100644
+--- a/csrc/xpu/attn/attn_interface.cpp
++++ b/csrc/xpu/attn/attn_interface.cpp
+@@ -29,7 +29,8 @@ void cutlass_chunk_prefill_interface(
+     bool is_local,
+     bool is_sink,
+     std::optional<at::Tensor>& softmax_lse,
+-    std::optional<const at::Tensor>& is_prefill) {
++    std::optional<const at::Tensor>& is_prefill,
++    std::optional<const at::Tensor>& per_seq_causal) {
+   if (vllm::xpu::is_xe2_arch() || vllm::xpu::is_xe3_arch()) {
+ #ifdef VLLM_XPU_ENABLE_XE2
+     // Use XE2 cutlass kernel (also used as WA for XE3/XE3P)
+@@ -56,7 +57,8 @@ void cutlass_chunk_prefill_interface(
+         is_local,
+         is_sink,
+         softmax_lse,
+-        is_prefill);
++        is_prefill,
++        per_seq_causal);
+ #else
+     TORCH_CHECK(false, "XE2 cutlass kernel is not enabled in this build.");
+ #endif
+diff --git a/csrc/xpu/attn/attn_interface.h b/csrc/xpu/attn/attn_interface.h
+index 65d2f24..c2acd2d 100644
+--- a/csrc/xpu/attn/attn_interface.h
++++ b/csrc/xpu/attn/attn_interface.h
+@@ -22,7 +22,8 @@ void cutlass_chunk_prefill_interface(
+     bool is_local,
+     bool is_sink,
+     std::optional<at::Tensor>& softmax_lse,
+-    std::optional<const at::Tensor>& is_prefill);
++    std::optional<const at::Tensor>& is_prefill,
++    std::optional<const at::Tensor>& per_seq_causal);
+ 
+ void cutlass_paged_decode_interface(
+     sycl::queue& queue,
+diff --git a/csrc/xpu/attn/xe_2/chunk_prefill.hpp b/csrc/xpu/attn/xe_2/chunk_prefill.hpp
+index 44f9dd0..f5f38bb 100644
+--- a/csrc/xpu/attn/xe_2/chunk_prefill.hpp
++++ b/csrc/xpu/attn/xe_2/chunk_prefill.hpp
+@@ -74,6 +74,11 @@ struct chunk_prefill_args_t {
+   int o_stride_batch = 0;
+   // per-batch mask: true = prefill, false = decode; nullptr = process all
+   void* is_prefill = nullptr;
++  // per-sequence causal mask: true = causal, false = bidirectional;
++  // nullptr = all sequences follow the compile-time CausalMask flag.
++  // Used by DiffusionGemma to handle encoder(causal)+denoise(bidir) in one
++  // launch instead of splitting the batch into two FA2 calls.
++  void* per_seq_causal = nullptr;
+ };
+ 
+ template <class FMHAKernel, bool isVarLen>
+@@ -174,7 +179,8 @@ struct KernelLauncher {
+          reinterpret_cast<ElementQ*>(args.sm_sink),
+          args.softmax_lse,
+          args.lse_stride,
+-         static_cast<const bool*>(args.is_prefill)},
++         static_cast<const bool*>(args.is_prefill),
++         static_cast<const bool*>(args.per_seq_causal)},
+         {args.sm_scale,
+          args.k_scale,
+          args.v_scale,
+diff --git a/csrc/xpu/attn/xe_2/chunk_prefill_utils.hpp b/csrc/xpu/attn/xe_2/chunk_prefill_utils.hpp
+index 0561534..aae4154 100644
+--- a/csrc/xpu/attn/xe_2/chunk_prefill_utils.hpp
++++ b/csrc/xpu/attn/xe_2/chunk_prefill_utils.hpp
+@@ -69,4 +69,5 @@ void cutlass_chunk_prefill_impl(
+     bool is_local,
+     bool is_sink,
+     std::optional<at::Tensor>& softmax_lse,
+-    std::optional<const at::Tensor>& is_prefill);
++    std::optional<const at::Tensor>& is_prefill,
++    std::optional<const at::Tensor>& per_seq_causal);
+diff --git a/csrc/xpu/attn/xe_2/collective/chunk_prefill_mainloop.hpp b/csrc/xpu/attn/xe_2/collective/chunk_prefill_mainloop.hpp
+index f4f7344..e6ec3bd 100644
+--- a/csrc/xpu/attn/xe_2/collective/chunk_prefill_mainloop.hpp
++++ b/csrc/xpu/attn/xe_2/collective/chunk_prefill_mainloop.hpp
+@@ -269,7 +269,8 @@ struct FMHAFwdMainloop<
+       int blk_k1_causal,
+       int thr_id,
+       int seq_len,
+-      int full_tile_offset) {
++      int full_tile_offset,
++      bool seq_is_causal = true) {  // per-seq: false => bidirectional
+     using namespace sycl::ext::oneapi::this_work_item;
+ 
+     // Short dimension names:
+@@ -469,12 +470,18 @@ struct FMHAFwdMainloop<
+         Tensor gP = local_tile(
+             cPgP, take<0, 2>(TileShapeQK{}), make_coord(get<0>(blk_qv), K));
+         auto cS_thread = thr_mma_qk.partition_C(gP);
++        // For a bidirectional sequence (per-seq causal == false) inside a
++        // causal-windowed kernel, the right window is one-sided (local_right
++        // is 0 for causal sliding layers), which would wrongly re-impose
++        // causal masking. Make the window SYMMETRIC for bidirectional seqs by
++        // mirroring local_left on the right.
++        int eff_right = seq_is_causal ? params.local_right : params.local_left;
+         CUTLASS_PRAGMA_UNROLL
+         for (int i = 0; i < tSrS.size(); ++i) {
+           int row_idx = get<0>(cS_thread(i));
+           int col_idx = get<1>(cS_thread(i)) - full_tile_offset;
+           bool left_mask = col_idx < row_idx - params.local_left;
+-          bool right_mask = col_idx > row_idx + params.local_right;
++          bool right_mask = col_idx > row_idx + eff_right;
+           if (left_mask || right_mask) {
+             tSrS(i) = ElementS(-INFINITY);
+           }
+diff --git a/csrc/xpu/attn/xe_2/fmha_xe2.cpp b/csrc/xpu/attn/xe_2/fmha_xe2.cpp
+index 4286270..32995e4 100644
+--- a/csrc/xpu/attn/xe_2/fmha_xe2.cpp
++++ b/csrc/xpu/attn/xe_2/fmha_xe2.cpp
+@@ -27,7 +27,8 @@ void cutlass_chunk_prefill_xe2(
+     bool is_local,
+     bool is_sink,
+     std::optional<at::Tensor>& softmax_lse,
+-    std::optional<const at::Tensor>& is_prefill) {
++    std::optional<const at::Tensor>& is_prefill,
++    std::optional<const at::Tensor>& per_seq_causal) {
+   cutlass_chunk_prefill_impl(
+       queue,
+       query,
+@@ -51,7 +52,8 @@ void cutlass_chunk_prefill_xe2(
+       is_local,
+       is_sink,
+       softmax_lse,
+-      is_prefill);
++      is_prefill,
++      per_seq_causal);
+ }
+ 
+ void cutlass_chunk_prefill_impl(
+@@ -77,7 +79,8 @@ void cutlass_chunk_prefill_impl(
+     bool is_local,
+     bool is_sink,
+     std::optional<at::Tensor>& softmax_lse,
+-    std::optional<const at::Tensor>& is_prefill) {
++    std::optional<const at::Tensor>& is_prefill,
++    std::optional<const at::Tensor>& per_seq_causal) {
+   // general params
+   int batch_size, num_heads_q, num_heads_kv, head_size;
+   // additional params
+@@ -166,6 +169,9 @@ void cutlass_chunk_prefill_impl(
+   // Per-batch prefill/decode mask (nullptr -> process all batches)
+   args.is_prefill =
+       is_prefill.has_value() ? is_prefill.value().data_ptr() : nullptr;
++  // Per-sequence causal mask (nullptr -> all follow compile-time CausalMask)
++  args.per_seq_causal =
++      per_seq_causal.has_value() ? per_seq_causal.value().data_ptr() : nullptr;
+   // Extract Q, K, V, O strides from tensors
+   if (is_varlen) {
+     // Q/O: [total_seq, num_heads, head_size]
+diff --git a/csrc/xpu/attn/xe_2/fmha_xe2.h b/csrc/xpu/attn/xe_2/fmha_xe2.h
+index a666921..f91c3b1 100644
+--- a/csrc/xpu/attn/xe_2/fmha_xe2.h
++++ b/csrc/xpu/attn/xe_2/fmha_xe2.h
+@@ -23,4 +23,5 @@ void cutlass_chunk_prefill_xe2(
+     bool is_local,
+     bool is_sink,
+     std::optional<at::Tensor>& softmax_lse,
+-    std::optional<const at::Tensor>& is_prefill);
++    std::optional<const at::Tensor>& is_prefill,
++    std::optional<const at::Tensor>& per_seq_causal);
+diff --git a/csrc/xpu/attn/xe_2/kernel/chunk_prefill_kernel.hpp b/csrc/xpu/attn/xe_2/kernel/chunk_prefill_kernel.hpp
+index 90bd62b..4ac3f36 100644
+--- a/csrc/xpu/attn/xe_2/kernel/chunk_prefill_kernel.hpp
++++ b/csrc/xpu/attn/xe_2/kernel/chunk_prefill_kernel.hpp
+@@ -153,6 +153,9 @@ class XeFMHAFwdKernel {
+ 
+     // per-batch mask: true = prefill, false = decode; nullptr = process all
+     const bool* is_prefill;
++    // per-sequence causal mask: true = causal, false = bidirectional;
++    // nullptr = follow the compile-time CausalMask flag for all sequences.
++    const bool* per_seq_causal;
+   };
+   using KernelParams = KernelArguments;
+ 
+@@ -271,9 +274,17 @@ class XeFMHAFwdKernel {
+       int seq_coord =
+           cute::min(seq_len_qo, (blk_q * get<0>(TileShapeQK{}) + q_offset_sg));
+ 
++      // Per-sequence causal: when compiled CausalMask=true but this sequence
++      // is bidirectional (per_seq_causal[idx_b]==false), treat it as
++      // non-causal — use the FULL kv range (un-pruned) and skip the triangular
++      // mask. nullptr => follow the compile-time CausalMask for all sequences.
++      const bool seq_is_causal =
++          CausalMask &&
++          (p.per_seq_causal == nullptr || p.per_seq_causal[idx_b]);
++
+       // calc sg level seq_len_kv
+       const int seq_len =
+-          CausalMask
++          seq_is_causal
+               ? LocalMask
+                     ? cute::min(
+                           seq_len_kv,
+@@ -290,9 +301,12 @@ class XeFMHAFwdKernel {
+                     get<1>(TileShapeQK{})
+               : 0;
+       const int k_blocks = cute::ceil_div(seq_len, get<1>(TileShapeQK{}));
++      // For a bidirectional sequence inside a CausalMask=true kernel, set the
++      // causal boundary at/above k_blocks so the mainloop's
++      // need_causal = (K >= blk_k1_causal) is NEVER true → no triangular mask.
+       const int k_blocks_causal =
+-          CausalMask ? (seq_coord + full_tile_offset) / get<1>(TileShapeQK{})
+-                     : 0;
++          seq_is_causal ? (seq_coord + full_tile_offset) / get<1>(TileShapeQK{})
++                        : k_blocks;
+ 
+       int offset_q = 0, offset_k = 0, offset_v = 0, offset_o = 0;
+       if constexpr (is_var_len) {
+@@ -355,7 +369,8 @@ class XeFMHAFwdKernel {
+           k_blocks_causal,
+           thr_id,
+           seq_len,
+-          full_tile_offset);
++          full_tile_offset,
++          seq_is_causal);
+ 
+       // return softmax_lse
+       if constexpr (SoftmaxLSE) {
 diff --git a/csrc/xpu/gdn_attn/xe_2/chunk_causal_conv1d_xe2.hpp b/csrc/xpu/gdn_attn/xe_2/chunk_causal_conv1d_xe2.hpp
 index b9729cd..20fff80 100644
 --- a/csrc/xpu/gdn_attn/xe_2/chunk_causal_conv1d_xe2.hpp
@@ -286,3 +555,25 @@ index ac2d7d6..fb51306 100644
          auto next_scales_tensor = make_tensor(
              make_gmem_ptr(
                  reinterpret_cast<const ElementS*>(
+diff --git a/vllm_xpu_kernels/flash_attn_interface.py b/vllm_xpu_kernels/flash_attn_interface.py
+index 70df0b2..c43f92d 100644
+--- a/vllm_xpu_kernels/flash_attn_interface.py
++++ b/vllm_xpu_kernels/flash_attn_interface.py
+@@ -53,6 +53,7 @@ def flash_attn_varlen_func(
+     s_aux: Optional[torch.Tensor] = None,
+     num_splits_kv: Optional[int] = None,
+     is_mix_batch: bool = True,
++    per_seq_causal: Optional[torch.Tensor] = None,
+ ):
+     """
+     FlashAttention interface for variable-length sequences, with optional
+@@ -151,7 +152,8 @@ def flash_attn_varlen_func(
+             return_softmax_lse,
+             None,
+             num_splits_kv,
+-            is_mix_batch
++            is_mix_batch,
++            per_seq_causal,
+         )
+     else:
+         raise NotImplementedError("not support yet")


### PR DESCRIPTION
## What

Extends `vllm/patches/vllm_xpu_kernels.patch` with the **per-sequence causal mask** changes for the CUTLASS-SYCL chunk-prefill flash kernel (originally `analytics-zoo/vllm-xpu-kernels@4e70546`).

This lets a single kernel launch handle a packed batch that **mixes causal and bidirectional sequences** — required by DiffusionGemma (encoder phase = causal, denoise phase = bidirectional). Previously such a batch had to be split into two groups and run through two separate `varlen_fwd` calls plus host-side gather/scatter.

An optional `per_seq_causal` bool tensor `[num_seqs]` is threaded from `mha_varlen_fwd` → `cutlass_chunk_prefill_*` → `KernelArguments`; default `None` preserves existing behavior.

## Scope of the diff

- **+291 lines, 0 deletions.** The existing `gdn_attn` + `grouped_gemm` fixes are preserved **byte-for-byte**.
- **10 new attention files** added to the patch:
  `csrc/flash_attn/flash_api.cpp`, `csrc/xpu/attn/attn_interface.{cpp,h}`,
  `csrc/xpu/attn/xe_2/{chunk_prefill.hpp,chunk_prefill_utils.hpp,fmha_xe2.cpp,fmha_xe2.h}`,
  `csrc/xpu/attn/xe_2/collective/chunk_prefill_mainloop.hpp`,
  `csrc/xpu/attn/xe_2/kernel/chunk_prefill_kernel.hpp`,
  `vllm_xpu_kernels/flash_attn_interface.py`

## Base / pin

Regenerated against the pinned base `3cab97a` (the commit this branch's Dockerfile checks out). No Dockerfile change needed.

## Validation

- `git checkout 3cab97a && git apply <patch>` applies **cleanly** (mirrors the Dockerfile install flow).
- The resulting tree is **byte-identical** (sha1, all 13 files) to the upstream fork tip that carries both this commit and the pre-existing fixes.
- Patch pre-image `index` hashes match `3cab97a` blobs exactly (no fuzz).
- Kernel itself validated bit-identical to the 2-call split path (`max_abs=0.0000`) across mixed / all-causal / all-bidirectional batches, sliding-window {0,32,1024}, on DiffusionGemma-26B-A4B (BMG, fp16, head_dim=256, GQA 16:8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)