### PR TITLE
[vllm-xpu-kernels patch] Wire gelu_tanh activation in XpuFusedMoe

### DIFF
--- a/vllm/patches/vllm_xpu_kernels.patch
+++ b/vllm/patches/vllm_xpu_kernels.patch
@@ -577,3 +577,34 @@ index 70df0b2..c43f92d 100644
          )
      else:
          raise NotImplementedError("not support yet")
+diff --git a/vllm_xpu_kernels/fused_moe_interface.py b/vllm_xpu_kernels/fused_moe_interface.py
+index e3049c9..0781f0b 100755
+--- a/vllm_xpu_kernels/fused_moe_interface.py
++++ b/vllm_xpu_kernels/fused_moe_interface.py
+@@ -97,6 +97,8 @@ def fused_moe_activation(act_output, gemm1_output, activation):
+         torch.ops._C.silu_and_mul(act_output, gemm1_output)
+     elif activation == "gelu":
+         torch.ops._C.gelu_and_mul(act_output, gemm1_output)
++    elif activation == "gelu_tanh":
++        torch.ops._C.gelu_tanh_and_mul(act_output, gemm1_output)
+     elif activation == "swigluoai" or ("SWIGLUOAI" in str(activation)):
+         torch.ops._C.swigluoai_and_mul(act_output, gemm1_output, 1.702, 7.0)
+     elif activation == "relu2_no_mul":
+@@ -111,6 +113,8 @@ def _naive_fused_moe_activation(gemm1_output, activation):
+         return torch.nn.functional.silu(gemm1_output)
+     elif activation == "gelu":
+         return torch.nn.functional.gelu(gemm1_output)
++    elif activation == "gelu_tanh":
++        return torch.nn.functional.gelu(gemm1_output, approximate="tanh")
+     elif activation == "swigluoai" or ("SWIGLUOAI" in str(activation)):
+         gate, up = gemm1_output.chunk(2, dim=-1)
+         return torch.nn.functional.silu(gate) * up * 1.702 * 7.0
+@@ -358,6 +362,8 @@ class XpuFusedMoe:
+             self.act_func = torch.ops._C.silu_and_mul
+         elif self.activation == "gelu":
+             self.act_func = torch.ops._C.gelu_and_mul
++        elif self.activation == "gelu_tanh":
++            self.act_func = torch.ops._C.gelu_tanh_and_mul
+         elif self.activation == "swigluoai" \
+             or ("SWIGLUOAI" in str(self.activation)):
+             self.act_func = torch.ops._C.swigluoai_and_mul


### PR DESCRIPTION
## What

Regenerate `vllm/patches/vllm_xpu_kernels.patch` (base `3cab97a`) to add the
missing `gelu_tanh` activation dispatch in
`vllm_xpu_kernels/fused_moe_interface.py`.

## Why

The `gelu_tanh_and_mul` SYCL kernel and its torch binding already exist in the
pinned base (`csrc/activation.cpp`, `csrc/torch_bindings.cpp`), but the Python
wrapper's activation dispatch never routed `activation="gelu_tanh"` to it.

As a result, any `FusedMoE` constructed with `activation="gelu_tanh"` — e.g.
Gemma-family MoE such as DiffusionGemma under `--quantization sym_int4` — crashed
during `profile_run`:

```
File ".../vllm_xpu_kernels/fused_moe_interface.py", in XpuFusedMoe.__init__
ValueError: Unsupported FusedMoe activation: gelu_tanh.
```

This is a Python-glue gap, not a missing kernel. The fix adds the `gelu_tanh`
branch in all three dispatch sites:
- `fused_moe_activation` (op path → `torch.ops._C.gelu_tanh_and_mul`)
- `_naive_fused_moe_activation` (ref path → `F.gelu(..., approximate="tanh")`)
- `XpuFusedMoe.__init__` (cutlass grouped `act_func` binding)

The patch change is purely additive (the other 13 patched files are byte-identical).

## Upstream kernel commit

Mirrored in the kernel fork: analytics-zoo/vllm-xpu-kernels @ `d634399`
(`[MoE] Wire gelu_tanh activation in XpuFusedMoe dispatch`).

## Testing

- `git apply --check vllm/patches/vllm_xpu_kernels.patch` passes cleanly on base `3cab97a`.
- DiffusionGemma 26B-A4B-it, `--quantization sym_int4`, TP=2, V1, eager: server
  starts (no longer crashes in `profile_run`) and a chat completion returns the
  correct answer ("The capital of France is Paris.").

AI assistance (Claude) was used for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)