### PR TITLE
page_attn_decode: native GQA=2 path (no q-head padding)

### DIFF
--- a/vllm/custom-esimd-kernels-vllm/csrc/eagle/eagle.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/eagle/eagle.sycl
@@ -197,7 +197,11 @@ void page_attention_forward_kernel(
   const torch::Device& device) {
   uint32_t groupH, groupV, groupD;
   uint32_t flag = maxKvSeqLen > 1024 ? 0 : 1;
-  uint32_t gqaGroups = gqaRatio / 4;
+  // GQA=2 native: one work-group per kv-head (owns 2 q-heads), same 4-thread /
+  // 2-thread geometry as GQA=4.  Launch grid is identical to "gqaGroups==1".
+  // GQA=4k: gqaGroups = gqaRatio/4 work-groups per kv-head (4 q-heads each).
+  bool isGqa2 = (gqaRatio == 2);
+  uint32_t gqaGroups = isGqa2 ? 1 : (gqaRatio / 4);
   // Phase1: each work group of 4 threads handles 4 q-heads sharing one kv-head
   // Total groups in dim0 = headV * gqaGroups (one group per 4-q-head chunk)
   groupH = headV * gqaGroups;
@@ -228,54 +232,105 @@ void page_attention_forward_kernel(
   switch (kvDtype) {
     case torch::kHalf: {
       // FP16 KV path: untouched from original implementation.
-      kernelPhase1 = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class paPhase1Forward>(
-          rangePaPhase1, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
-            sdpaDecodeGqa4Phase1(qState, kvCache, (uint8_t*)pState, pGroupMax, pGlobalMax, pPollP, pageTable, kvSeqLens,
-              batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, gqaRatio, idx);
-          });
-        };
-      kernelPhase2 = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class paPhase2Forward>(
-          rangePaPhase2, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
-            sdpaDecodeGqa4Phase2((uint8_t*)pState, pGroupMax, kvCache, pGlobalMax, pTempOut, pGlobalSoftmaxSum, out, pageTable, kvSeqLens,
-              batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, maxKvSeqLen, flag, gqaRatio, idx);
-          });
-        };
+      if (isGqa2) {
+        kernelPhase1 = [&](sycl::handler& cgh) {
+          cgh.parallel_for<class paPhase1Gqa2Forward>(
+            rangePaPhase1, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
+              sdpaDecodeGqa2Phase1(qState, kvCache, (uint8_t*)pState, pGroupMax, pGlobalMax, pPollP, pageTable, kvSeqLens,
+                batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, gqaRatio, idx);
+            });
+          };
+        kernelPhase2 = [&](sycl::handler& cgh) {
+          cgh.parallel_for<class paPhase2Gqa2Forward>(
+            rangePaPhase2, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
+              sdpaDecodeGqa2Phase2((uint8_t*)pState, pGroupMax, kvCache, pGlobalMax, pTempOut, pGlobalSoftmaxSum, out, pageTable, kvSeqLens,
+                batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, maxKvSeqLen, flag, gqaRatio, idx);
+            });
+          };
+      } else {
+        kernelPhase1 = [&](sycl::handler& cgh) {
+          cgh.parallel_for<class paPhase1Forward>(
+            rangePaPhase1, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
+              sdpaDecodeGqa4Phase1(qState, kvCache, (uint8_t*)pState, pGroupMax, pGlobalMax, pPollP, pageTable, kvSeqLens,
+                batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, gqaRatio, idx);
+            });
+          };
+        kernelPhase2 = [&](sycl::handler& cgh) {
+          cgh.parallel_for<class paPhase2Forward>(
+            rangePaPhase2, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
+              sdpaDecodeGqa4Phase2((uint8_t*)pState, pGroupMax, kvCache, pGlobalMax, pTempOut, pGlobalSoftmaxSum, out, pageTable, kvSeqLens,
+                batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, maxKvSeqLen, flag, gqaRatio, idx);
+            });
+          };
+      }
       break;
     }
     case at::kFloat8_e4m3fn: {
-      kernelPhase1 = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class paPhase1Fp8E4m3Forward>(
-          rangePaPhase1, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
-            sdpaDecodeGqa4Phase1Fp8<Fp8Variant::E4M3FN>(qState, kvCache, (uint8_t*)pState, pGroupMax, pGlobalMax, pPollP, pageTable, kvSeqLens,
-              batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, gqaRatio, k_scale, idx);
-          });
-        };
-      kernelPhase2 = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class paPhase2Fp8E4m3Forward>(
-          rangePaPhase2, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
-            sdpaDecodeGqa4Phase2Fp8<Fp8Variant::E4M3FN>((uint8_t*)pState, pGroupMax, kvCache, pGlobalMax, pTempOut, pGlobalSoftmaxSum, out, pageTable, kvSeqLens,
-              batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, maxKvSeqLen, flag, gqaRatio, v_scale, idx);
-          });
-        };
+      if (isGqa2) {
+        kernelPhase1 = [&](sycl::handler& cgh) {
+          cgh.parallel_for<class paPhase1Gqa2Fp8E4m3Forward>(
+            rangePaPhase1, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
+              sdpaDecodeGqa2Phase1Fp8<Fp8Variant::E4M3FN>(qState, kvCache, (uint8_t*)pState, pGroupMax, pGlobalMax, pPollP, pageTable, kvSeqLens,
+                batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, gqaRatio, k_scale, idx);
+            });
+          };
+        kernelPhase2 = [&](sycl::handler& cgh) {
+          cgh.parallel_for<class paPhase2Gqa2Fp8E4m3Forward>(
+            rangePaPhase2, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
+              sdpaDecodeGqa2Phase2Fp8<Fp8Variant::E4M3FN>((uint8_t*)pState, pGroupMax, kvCache, pGlobalMax, pTempOut, pGlobalSoftmaxSum, out, pageTable, kvSeqLens,
+                batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, maxKvSeqLen, flag, gqaRatio, v_scale, idx);
+            });
+          };
+      } else {
+        kernelPhase1 = [&](sycl::handler& cgh) {
+          cgh.parallel_for<class paPhase1Fp8E4m3Forward>(
+            rangePaPhase1, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
+              sdpaDecodeGqa4Phase1Fp8<Fp8Variant::E4M3FN>(qState, kvCache, (uint8_t*)pState, pGroupMax, pGlobalMax, pPollP, pageTable, kvSeqLens,
+                batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, gqaRatio, k_scale, idx);
+            });
+          };
+        kernelPhase2 = [&](sycl::handler& cgh) {
+          cgh.parallel_for<class paPhase2Fp8E4m3Forward>(
+            rangePaPhase2, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
+              sdpaDecodeGqa4Phase2Fp8<Fp8Variant::E4M3FN>((uint8_t*)pState, pGroupMax, kvCache, pGlobalMax, pTempOut, pGlobalSoftmaxSum, out, pageTable, kvSeqLens,
+                batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, maxKvSeqLen, flag, gqaRatio, v_scale, idx);
+            });
+          };
+      }
       break;
     }
     case at::kFloat8_e5m2: {
-      kernelPhase1 = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class paPhase1Fp8E5m2Forward>(
-          rangePaPhase1, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
-            sdpaDecodeGqa4Phase1Fp8<Fp8Variant::E5M2>(qState, kvCache, (uint8_t*)pState, pGroupMax, pGlobalMax, pPollP, pageTable, kvSeqLens,
-              batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, gqaRatio, k_scale, idx);
-          });
-        };
-      kernelPhase2 = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class paPhase2Fp8E5m2Forward>(
-          rangePaPhase2, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
-            sdpaDecodeGqa4Phase2Fp8<Fp8Variant::E5M2>((uint8_t*)pState, pGroupMax, kvCache, pGlobalMax, pTempOut, pGlobalSoftmaxSum, out, pageTable, kvSeqLens,
-              batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, maxKvSeqLen, flag, gqaRatio, v_scale, idx);
-          });
-        };
+      if (isGqa2) {
+        kernelPhase1 = [&](sycl::handler& cgh) {
+          cgh.parallel_for<class paPhase1Gqa2Fp8E5m2Forward>(
+            rangePaPhase1, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
+              sdpaDecodeGqa2Phase1Fp8<Fp8Variant::E5M2>(qState, kvCache, (uint8_t*)pState, pGroupMax, pGlobalMax, pPollP, pageTable, kvSeqLens,
+                batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, gqaRatio, k_scale, idx);
+            });
+          };
+        kernelPhase2 = [&](sycl::handler& cgh) {
+          cgh.parallel_for<class paPhase2Gqa2Fp8E5m2Forward>(
+            rangePaPhase2, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
+              sdpaDecodeGqa2Phase2Fp8<Fp8Variant::E5M2>((uint8_t*)pState, pGroupMax, kvCache, pGlobalMax, pTempOut, pGlobalSoftmaxSum, out, pageTable, kvSeqLens,
+                batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, maxKvSeqLen, flag, gqaRatio, v_scale, idx);
+            });
+          };
+      } else {
+        kernelPhase1 = [&](sycl::handler& cgh) {
+          cgh.parallel_for<class paPhase1Fp8E5m2Forward>(
+            rangePaPhase1, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
+              sdpaDecodeGqa4Phase1Fp8<Fp8Variant::E5M2>(qState, kvCache, (uint8_t*)pState, pGroupMax, pGlobalMax, pPollP, pageTable, kvSeqLens,
+                batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, gqaRatio, k_scale, idx);
+            });
+          };
+        kernelPhase2 = [&](sycl::handler& cgh) {
+          cgh.parallel_for<class paPhase2Fp8E5m2Forward>(
+            rangePaPhase2, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
+              sdpaDecodeGqa4Phase2Fp8<Fp8Variant::E5M2>((uint8_t*)pState, pGroupMax, kvCache, pGlobalMax, pTempOut, pGlobalSoftmaxSum, out, pageTable, kvSeqLens,
+                batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, maxKvSeqLen, flag, gqaRatio, v_scale, idx);
+            });
+          };
+      }
       break;
     }
     default:
@@ -407,7 +462,8 @@ void page_attn_decode(
   TORCH_CHECK(headV > 0, "num_kv_heads must be positive");
   uint32_t gqaRatio = headQk / headV;
   TORCH_CHECK(gqaRatio * headV == headQk, "num_q_heads must be a multiple of num_kv_heads");
-  TORCH_CHECK(gqaRatio >= 4 && gqaRatio % 4 == 0, "gqaRatio must be a multiple of 4, got ", gqaRatio);
+  TORCH_CHECK(gqaRatio == 2 || (gqaRatio >= 4 && gqaRatio % 4 == 0),
+    "gqaRatio must be 2 or a multiple of 4, got ", gqaRatio);
   uint32_t maxSeqLen = max_seq_len;
   uint32_t hiddenDimP = ((maxSeqLen + 63) / 64) * 64;
   uint32_t hiddenDimPMax = ((maxSeqLen + 63) / 64);

--- a/vllm/custom-esimd-kernels-vllm/csrc/eagle/page.attn.fp8.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/eagle/page.attn.fp8.h
@@ -664,3 +664,516 @@ ESIMD_INLINE void sdpaDecodeGqa4Phase2Fp8(
     }
   }
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GQA = 2 native variants (fp8 KV).  Mirror the fp16 GQA=2 kernels: same
+// work-group geometry as GQA=4 (4 threads phase1 / 2 threads phase2), but only
+// 2 q-heads owned per work-group.  The DPAS C accumulator stays 8 rows wide
+// (RepeatCount=8 is the working BMG path); only the first QPER rows of A are
+// filled, the rest stay zero and contribute 0×B.  Surplus threads exit after
+// the barrier.  Phase3 is reused unchanged.
+template <Fp8Variant V>
+ESIMD_INLINE void sdpaDecodeGqa2Phase1Fp8(
+  uint8_t* qState,
+  uint8_t* kState,
+  uint8_t* pState,
+  float* pGroupMax,
+  float* pGlobalMax,
+  uint32_t* pPollP,
+  uint32_t* pageTable,
+  uint32_t* batchKvSeqLen,
+  uint32_t batchSize,
+  uint32_t kvCacheBatchStride0,
+  uint32_t kvCacheBatchStride1,
+  uint32_t pageTableBatchStride,
+  uint32_t pageTableSizeLog2,
+  uint32_t pStride,
+  uint32_t maxStride,
+  uint32_t headKv,
+  uint32_t gqaRatio,
+  float k_scale,
+  sycl::nd_item<3>& ndi) {
+  constexpr uint32_t baseOffsetInc16[16] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+  constexpr float matMulQuantCoeffBase = 0.0625f;
+  const float matMulQuantCoeff = matMulQuantCoeffBase * k_scale;
+  constexpr uint32_t headDim = 256;
+  constexpr uint32_t maxPGroupOut = 128;
+  constexpr uint32_t outputPerGroup = 64;
+  constexpr uint32_t loopCount = outputPerGroup / 16;
+  constexpr uint32_t QPER = 2;                       // q-heads per work-group
+  constexpr uint32_t slmSizePhase1 = 4 * maxPGroupOut * 4 * sizeof(float);
+  __ESIMD_NS::slm_init<slmSizePhase1>();
+  int localLinearId = ndi.get_local_id(0);
+  int globalLinearId0 = ndi.get_group(0);
+  int globalLinearId1 = ndi.get_group(1);
+  int globalLinearId2 = ndi.get_group(2);
+  int hh = localLinearId & 0x3;
+  int batchIdx = globalLinearId2;
+  int kvHeadIdx = globalLinearId0;                   // one work-group per kv-head
+  int qHeadIdx = kvHeadIdx * gqaRatio;
+  uint32_t pageTableSize = 1 << pageTableSizeLog2;
+  uint32_t pageTableLoopMask = pageTableSize - 1;
+  uint32_t kvSeqLen = batchKvSeqLen[batchIdx];
+  uint32_t pageTableBase = pageTableBatchStride * batchIdx;
+  simd<uint32_t, 16> simdOffsetsK;
+
+  simd<uint32_t, 16> baseOffsetInc16AsSimd(baseOffsetInc16);
+  simd<fp16, 64 * 4> qqFp16;
+  simd<float, 16 * 8> ppFp32;                        // DPAS C: 8 rows (first QPER real)
+  simd<fp16, 16 * 64> kkCache;
+  simd<float, 1> ppMax;
+
+  uint32_t headQ = headKv * gqaRatio;
+  uint64_t outputOffset = qHeadIdx * pStride + globalLinearId1 * outputPerGroup + hh * pStride + batchIdx * headQ * pStride;
+  uint32_t outputMaxOffset = qHeadIdx * maxStride + globalLinearId1 + hh * maxStride + batchIdx * headQ * maxStride;
+  uint32_t offsetQ = qHeadIdx * headDim * sizeof(fp16) + hh * 32 * sizeof(fp16) + batchIdx * headQ * headDim * sizeof(fp16);
+  uint32_t baseCoordK = globalLinearId1 * outputPerGroup;
+  uint32_t offsetBaseK = hh * 32 * sizeof(uint8_t) + headDim * kvHeadIdx * sizeof(uint8_t);
+  uint32_t kvSeqOffset = baseCoordK;
+
+  if (baseCoordK >= kvSeqLen) {
+    return;
+  }
+
+#pragma unroll
+  for (int qn = 0; qn < QPER; qn++) {
+#pragma unroll
+    for (int qk = 0; qk < 2; qk++) {
+      qqFp16.template bit_cast_view<uint8_t>().select<64, 1>(128 * qn + 64 * qk) =
+        __ESIMD_ENS::lsc_block_load<
+        uint8_t,
+        64,
+        __ESIMD_ENS::lsc_data_size::default_size,
+        __ESIMD_ENS::cache_hint::cached,
+        __ESIMD_ENS::cache_hint::cached>((uint8_t*)qState + offsetQ + qn * headDim * sizeof(fp16) + qk * 4 * 32 * sizeof(fp16));
+    }
+  }
+
+  // Pre-build padded dpas-A tiles (only first QPER rows filled; rest zero).
+  simd<fp16, 8 * 16> aPadAll[2][2];
+#pragma unroll
+  for (int kk = 0; kk < 2; kk++) {
+#pragma unroll
+    for (int k_dpas = 0; k_dpas < 2; k_dpas++) {
+      simd<fp16, 8 * 16> aPad = 0;
+#pragma unroll
+      for (int qn = 0; qn < QPER; qn++) {
+        aPad.template select<16, 1>(qn * 16) =
+          qqFp16.template select<16, 1>(qn * 64 + kk * 32 + k_dpas * 16);
+      }
+      aPadAll[kk][k_dpas] = aPad;
+    }
+  }
+
+#pragma unroll
+  for (int loopIdx = 0; loopIdx < loopCount; loopIdx++) {
+    ppFp32 = 0.0f;
+    if (kvSeqOffset < kvSeqLen) {
+      uint32_t pageTableIdx = kvSeqOffset >> pageTableSizeLog2;
+      uint32_t pageTableOffset = kvSeqOffset & pageTableLoopMask;
+      uint32_t pageIdx = pageTable[pageTableBase + pageTableIdx];
+      simd<uint16_t, 16> mask;
+      simd<uint16_t, 16> maskNeg;
+      simd<uint32_t, 16> logicSimdOffsetK;
+      logicSimdOffsetK = baseOffsetInc16AsSimd + kvSeqOffset;
+      mask = logicSimdOffsetK < kvSeqLen;
+      maskNeg = logicSimdOffsetK >= kvSeqLen;
+      simdOffsetsK = baseOffsetInc16AsSimd;
+
+      simdOffsetsK =
+        simdOffsetsK * headKv * headDim * sizeof(uint8_t) +
+        offsetBaseK +
+        pageIdx * kvCacheBatchStride1 * sizeof(uint8_t) +
+        pageTableOffset * headKv * headDim * sizeof(uint8_t)
+        ;
+
+#pragma unroll
+      for (int kk = 0; kk < 2; kk++) {
+        simd<uint32_t, 16 * 8> raw =
+          __ESIMD_ENS::lsc_gather<
+          uint32_t,
+          8,
+          __ESIMD_ENS::lsc_data_size::u32,
+          __ESIMD_ENS::cache_hint::cached,
+          __ESIMD_ENS::cache_hint::cached,
+          16,
+          uint32_t
+          >((uint32_t*)kState, simdOffsetsK, mask);
+        simd<uint8_t, 512> rawBytes = raw.template bit_cast_view<uint8_t>();
+        kkCache.template select<256, 1>(512 * kk + 0)   = dequantFp8<V, 256>(rawBytes.template select<256, 1>(0));
+        kkCache.template select<256, 1>(512 * kk + 256) = dequantFp8<V, 256>(rawBytes.template select<256, 1>(256));
+
+        simdOffsetsK += 128 * sizeof(uint8_t);
+
+#pragma unroll
+        for (int k_dpas = 0; k_dpas < 2; k_dpas++) {
+          simd<fp16, 16 * 16> bVnni;
+          auto bVnniU16 = bVnni.template bit_cast_view<uint16_t>();
+#pragma unroll
+          for (int kp = 0; kp < 8; kp++) {
+            int c_lo = k_dpas * 16 + 2 * kp;
+            int s_lo = c_lo >> 2;
+            int p_lo = c_lo & 0x3;
+            int c_hi = c_lo + 1;
+            int s_hi = c_hi >> 2;
+            int p_hi = c_hi & 0x3;
+
+            simd<fp16, 16> lo =
+              kkCache.template select<16, 4>(512 * kk + 64 * s_lo + p_lo);
+            simd<fp16, 16> hi =
+              kkCache.template select<16, 4>(512 * kk + 64 * s_hi + p_hi);
+            lo.merge(fp16(0.0f), maskNeg);
+            hi.merge(fp16(0.0f), maskNeg);
+
+            simd<uint16_t, 16> loU = lo.template bit_cast_view<uint16_t>();
+            simd<uint16_t, 16> hiU = hi.template bit_cast_view<uint16_t>();
+            simd<uint32_t, 16> packed =
+              simd<uint32_t, 16>(loU) | (simd<uint32_t, 16>(hiU) << 16);
+            auto dst = bVnniU16.template select<32, 1>(kp * 32);
+            dst.template bit_cast_view<uint32_t>() = packed;
+          }
+
+          ppFp32 = sycl::ext::intel::esimd::xmx::dpas<
+            8, 8, float, float, fp16, fp16,
+            sycl::ext::intel::esimd::xmx::dpas_argument_type::fp16,
+            sycl::ext::intel::esimd::xmx::dpas_argument_type::fp16>(
+              ppFp32, bVnni, aPadAll[kk][k_dpas]);
+        }
+      }
+
+#pragma unroll
+      for (int pn = 0; pn < QPER; pn++) {
+        ppFp32.select<16, 1>(pn * 16).merge(FP32_MIN, maskNeg);
+      }
+    }
+    else {
+      ppFp32 = FP32_MIN;
+    }
+
+#pragma unroll
+    for (int pn = 0; pn < QPER; pn++) {
+      slm_block_store<float, 16>(
+        loopIdx * 4 * 64 * sizeof(float) +
+        pn * 64 * sizeof(float) +
+        hh * 16 * sizeof(float),
+        ppFp32.select<16, 1>(16 * pn));
+    }
+    kvSeqOffset += 16;
+  }
+
+  barrier();
+
+  if (hh >= QPER) {
+    return;
+  }
+
+  {
+    simd<float, 16 * 4> ppOut;
+    simd<float, 16> maxTemp;
+    simd<float, 64> ppTemp;
+#pragma unroll
+    for (int pk = 0; pk < 4; pk++) {
+      ppTemp = slm_block_load<float, 64>(pk * 64 * 4 * sizeof(float) + hh * 64 * sizeof(float));
+#pragma unroll
+      for (int pn = 0; pn < 1; pn++) {
+        ppOut.select<16, 1>(4 * 16 * pn + 16 * pk) = ppTemp.select<16, 1>(64 * pn) + ppTemp.select<16, 1>(64 * pn + 16);
+        ppOut.select<16, 1>(4 * 16 * pn + 16 * pk) = ppOut.select<16, 1>(4 * 16 * pn + 16 * pk) + ppTemp.select<16, 1>(64 * pn + 32);
+        ppOut.select<16, 1>(4 * 16 * pn + 16 * pk) = ppOut.select<16, 1>(4 * 16 * pn + 16 * pk) + ppTemp.select<16, 1>(64 * pn + 48);
+      }
+    }
+
+    ppOut = ppOut * matMulQuantCoeff;
+    maxTemp = ppOut.select<16, 1>(0);
+#pragma unroll
+    for (int pk = 1; pk < 4; pk++) {
+      maxTemp = __ESIMD_NS::max<float, 16, float>(maxTemp, ppOut.select<16, 1>(16 * pk));
+    }
+
+    maxTemp.select<8, 1>(0) = __ESIMD_NS::max<float, 8, float>(maxTemp.select<8, 1>(0), maxTemp.select<8, 1>(8));
+    maxTemp.select<4, 1>(0) = __ESIMD_NS::max<float, 4, float>(maxTemp.select<4, 1>(0), maxTemp.select<4, 1>(4));
+    maxTemp.select<2, 1>(0) = __ESIMD_NS::max<float, 2, float>(maxTemp.select<2, 1>(0), maxTemp.select<2, 1>(2));
+    ppMax[0] = __ESIMD_NS::max<float>(maxTemp[0], maxTemp[1]);
+    ppOut.select<64, 1>(0) = ppOut.select<64, 1>(0) - ppMax[0];
+    ppOut = __ESIMD_NS::pow<float, 64, float>(2.718281828459f, ppOut);
+
+    {
+      block_store<float, 64>((float*)pState + outputOffset, ppOut.select<64, 1>(0));
+      simd<float, 1> zeros = 0.0f;
+      pGroupMax[outputMaxOffset] = ppMax[0];
+      uint32_t atomicOffset = (batchIdx * gqaRatio * headKv + qHeadIdx + hh) * sizeof(float);
+      uint32_t arrivalId =
+        atomic_update<
+        __ESIMD_NS::atomic_op::inc,
+        uint32_t,
+        1,
+        uint32_t>(pPollP, atomicOffset);
+
+      if (0 == arrivalId) {
+        atomic_update<
+          __ESIMD_NS::atomic_op::fcmpxchg,
+          float,
+          1,
+          uint32_t>(pGlobalMax, atomicOffset, ppMax, zeros);
+      }
+      else {
+        atomic_update<
+          __ESIMD_NS::atomic_op::fmax,
+          float,
+          1,
+          uint32_t>(pGlobalMax, atomicOffset, ppMax);
+      }
+    }
+  }
+}
+
+template <Fp8Variant V>
+ESIMD_INLINE void sdpaDecodeGqa2Phase2Fp8(
+  uint8_t* pState,
+  float* pGroupMax,
+  uint8_t* vState,
+  float* pGlobalMax,
+  float* pTempOut,
+  float* pSoftmaxSum,
+  uint8_t* out,
+  uint32_t* pageTable,
+  uint32_t* batchKvSeqLen,
+  uint32_t batchSize,
+  uint32_t kvCacheBatchStride0,
+  uint32_t kvCacheBatchStride1,
+  uint32_t pageTableBatchStride,
+  uint32_t pageTableSizeLog2,
+  uint32_t pStride,
+  uint32_t maxStride,
+  uint32_t headKv,
+  uint32_t longestBatch,
+  uint32_t flag,
+  uint32_t gqaRatio,
+  float v_scale,
+  sycl::nd_item<3>& ndi) {
+  constexpr uint32_t headDim = 256;
+  constexpr uint32_t maxPGroupOut = 128;
+  constexpr uint32_t outputPerGroup = 64;
+  constexpr float matMulQuantCoeff = 0.0625f;
+  constexpr uint32_t QPER = 2;                       // q-heads per work-group
+  constexpr uint32_t slmSizeOut = 2 * 4 * 16 * sizeof(float);
+  constexpr uint32_t slmSizeSoftmaxSum = 2 * 4 * sizeof(float);
+  constexpr uint32_t slmSize = slmSizeOut + slmSizeSoftmaxSum;
+  __ESIMD_NS::slm_init<slmSize>();
+  constexpr uint32_t baseOffsetInc16[16] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+  int localLinearId = ndi.get_local_id(0);
+  int globalLinearId0 = ndi.get_group(0);
+  int globalLinearId1 = ndi.get_group(1);
+  int globalLinearId2 = ndi.get_group(2);
+  int hh = localLinearId & 0x1;
+  int batchIdx = globalLinearId2;
+  int kvHeadIdx = globalLinearId1;                   // one work-group per kv-head
+  uint32_t kvSeqLen = batchKvSeqLen[batchIdx];
+  int kvSeqOutGroup = (kvSeqLen + 1023) >> 10;
+  uint32_t pageTableSize = 1 << pageTableSizeLog2;
+  uint32_t pageTableLoopMask = (1 << pageTableSizeLog2) - 1;
+  uint32_t pageTableBase = pageTableBatchStride * batchIdx;
+  uint32_t channelOffset = globalLinearId0 & 0xf;
+  uint32_t groupIdx = globalLinearId0 >> 4;
+
+  simd<uint32_t, 16> simdOffsets(baseOffsetInc16);
+  simd<uint32_t, 16> pageTableIndice;
+  simd<uint32_t, 16> pageTableOffsets;
+
+  simd<uint32_t, 16> pageAlignedOffsets;
+  simd<uint32_t, 16> pageOffsetsInner;
+  simd<uint32_t, 16> pageNumbers;
+
+  simd<float, QPER * 32> ppFp32;
+  simd<float, QPER> historicMax;
+  simd<float, QPER * 16> softmaxSum;
+  simd<float, 8 * 16> outputFp32;                    // DPAS C: 8 rows (first QPER real)
+
+  if (groupIdx >= kvSeqOutGroup) {
+    return;
+  }
+  uint32_t reduceCount = (longestBatch + 1023) >> 10;
+  uint32_t headQ = headKv * gqaRatio;
+  uint32_t qBaseIdx = kvHeadIdx * gqaRatio;
+  uint32_t outputOffset = qBaseIdx * headDim + channelOffset * 16 + hh * 2 * headDim + batchIdx * headQ * headDim;
+  uint32_t outTempOffset = qBaseIdx * headDim + channelOffset * 16 + hh * 2 * headDim + groupIdx * headQ * headDim + batchIdx * reduceCount * headQ * headDim;
+  uint32_t outOffsetSoftmaxSum = qBaseIdx + hh * 2 + groupIdx * headQ + batchIdx * reduceCount * headQ;
+  uint32_t offsetP = qBaseIdx * pStride + hh * 32 + groupIdx * 1024 + batchIdx * headQ * pStride;
+  uint32_t offsetMax = qBaseIdx * maxStride + batchIdx * headQ * maxStride + groupIdx * 16;
+  uint32_t offsetGlobalMax = batchIdx * headQ + qBaseIdx;
+  uint32_t widthV = headKv * headDim * sizeof(uint8_t) - 1;
+  uint32_t heightV = pageTableSize - 1;
+  uint32_t vX = channelOffset * 16 + headDim * kvHeadIdx;
+  uint32_t vY = 32 * hh;
+  uint32_t totalPages = (kvSeqLen + pageTableSize - 1) >> pageTableSizeLog2;
+  uint32_t lastPageHeight = (kvSeqLen - 1) & (pageTableSize - 1);
+  if (kvSeqLen == 0) {
+    lastPageHeight = 0;
+  }
+  uint8_t* vPtrBase = (uint8_t*)vState + kvCacheBatchStride0;
+
+  historicMax = FP32_MIN * matMulQuantCoeff;
+  softmaxSum = 0;
+  outputFp32 = 0;
+
+  simd<float, QPER> globalMax;
+  simd<float, QPER> currMax;
+  simd<float, QPER> compensationP;
+  simd<uint16_t, 16> mask;
+  simd<uint16_t, 16> maskNeg;
+
+  uint32_t kvSeqOffset = groupIdx * 1024;
+  simdOffsets = simdOffsets * 64 + kvSeqOffset;
+  mask = simdOffsets < kvSeqLen;
+  maskNeg = simdOffsets >= kvSeqLen;
+  pageTableIndice = (simdOffsets >> pageTableSizeLog2);
+  pageTableOffsets = pageTableIndice * sizeof(uint32_t) + pageTableBase * sizeof(uint32_t);
+  pageOffsetsInner = simdOffsets & pageTableLoopMask;
+  pageNumbers =
+    gather<
+    uint32_t,
+    16,
+    1,
+    uint32_t>(pageTable, pageTableOffsets, mask);
+
+  pageAlignedOffsets = pageNumbers * kvCacheBatchStride1;
+  pageAlignedOffsets.merge(0, maskNeg);
+  globalMax = block_load<float, QPER>(pGlobalMax + offsetGlobalMax);
+
+#pragma unroll
+  for (uint32_t loop = 0; loop < 16; loop++) {
+    if (kvSeqOffset + loop * 64 < kvSeqLen) {
+      uint8_t* currPtrV = vPtrBase + pageAlignedOffsets[loop];
+      if (pageTableIndice[loop] + 1 < totalPages) {
+        heightV = pageTableSize - 1;
+      }
+      else {
+        heightV = lastPageHeight;
+      }
+      vY = pageOffsetsInner[loop] + 32 * hh;
+
+#pragma unroll
+      for (int pn = 0; pn < QPER; pn++) {
+        ppFp32.select<32, 1>(32 * pn) = block_load<float, 32>((float*)pState + offsetP + pStride * pn);
+        currMax[pn] = pGroupMax[offsetMax + maxStride * pn];
+      }
+
+      simd<uint8_t, 512> vRawAll =
+        __ESIMD_ENS::lsc_load_2d<
+        uint8_t,
+        16,
+        32,
+        1,
+        false,
+        false,
+        __ESIMD_ENS::cache_hint::cached,
+        __ESIMD_ENS::cache_hint::cached
+        >(currPtrV, widthV, heightV, widthV, vX, vY);
+
+      compensationP = currMax - globalMax;
+      compensationP = exp(compensationP);
+
+#pragma unroll
+      for (int oc = 0; oc < QPER; oc++) {
+        ppFp32.select<32, 1>(32 * oc) = ppFp32.select<32, 1>(32 * oc) * compensationP[oc];
+      }
+
+#pragma unroll
+      for (int oc = 0; oc < QPER; oc++) {
+#pragma unroll
+        for (int pk = 0; pk < 2; pk++) {
+          softmaxSum.select<16, 1>(16 * oc) = softmaxSum.select<16, 1>(16 * oc) + ppFp32.select<16, 1>(32 * oc + 16 * pk);
+        }
+      }
+
+#pragma unroll
+      for (int vk = 0; vk < 2; vk++) {
+        simd<fp16, 256> vHalf = dequantFp8<V, 256>(vRawAll.template select<256, 1>(256 * vk));
+
+        simd<fp16, 16 * 16> bVnni;
+        auto bVnniU16 = bVnni.template bit_cast_view<uint16_t>();
+        auto vHalfU16 = vHalf.template bit_cast_view<uint16_t>();
+#pragma unroll
+        for (int kp = 0; kp < 8; kp++) {
+          simd<uint16_t, 16> lo = vHalfU16.template select<16, 1>((2 * kp + 0) * 16);
+          simd<uint16_t, 16> hi = vHalfU16.template select<16, 1>((2 * kp + 1) * 16);
+          simd<uint32_t, 16> packed = simd<uint32_t, 16>(lo) | (simd<uint32_t, 16>(hi) << 16);
+          auto dst = bVnniU16.template select<32, 1>(kp * 32);
+          dst.template bit_cast_view<uint32_t>() = packed;
+        }
+
+        simd<fp16, 8 * 16> aPad = 0;
+#pragma unroll
+        for (int oc = 0; oc < QPER; oc++) {
+          aPad.template select<16, 1>(oc * 16) =
+            ppFp32.template select<16, 1>(32 * oc + 16 * vk);
+        }
+        outputFp32 = sycl::ext::intel::esimd::xmx::dpas<
+          8, 8, float, float, fp16, fp16,
+          sycl::ext::intel::esimd::xmx::dpas_argument_type::fp16,
+          sycl::ext::intel::esimd::xmx::dpas_argument_type::fp16>(
+            outputFp32, bVnni, aPad);
+      }
+
+      offsetP += 64;
+      offsetMax += 1;
+    }
+  }
+
+#pragma unroll
+  for (int32_t kk = 0; kk < QPER; kk++) {
+    slm_block_store<float, 16>(hh * 16 * sizeof(float) + 32 * kk * sizeof(float), outputFp32.select<16, 1>(16 * kk));
+  }
+
+#pragma unroll
+  for (int32_t kk = 0; kk < QPER; kk++) {
+    float slmTempSoftmaxSum;
+    slmTempSoftmaxSum = __ESIMD_DNS::sum<float, float, 16>(softmaxSum.select<16, 1>(16 * kk));
+    slm_block_store<float, 1>(slmSizeOut + hh * sizeof(float) + 2 * kk * sizeof(float), slmTempSoftmaxSum);
+  }
+
+  barrier();
+
+  // GQA=2: only thread hh==0 owns real q-heads (0,1).
+  if (hh >= 1) {
+    return;
+  }
+
+  {
+    simd<float, 4> dividor;
+    simd<float, QPER> softmaxMul;
+    simd<float, QPER * 32> outputTempFp32;
+    dividor = slm_block_load<float, 4>(slmSizeOut);
+    softmaxMul = dividor.select<2, 2>(0) + dividor.select<2, 2>(1);
+    outputTempFp32 = slm_block_load<float, QPER * 32>(0);
+
+#pragma unroll
+    for (int oc = 0; oc < QPER; oc++) {
+      outputFp32.select<16, 1>(16 * oc) = outputTempFp32.select<16, 1>(32 * oc) + outputTempFp32.select<16, 1>(32 * oc + 16);
+    }
+
+    if ((flag & 0x1) == 1) {
+      softmaxMul = v_scale / softmaxMul;
+#pragma unroll
+      for (int oc = 0; oc < QPER; oc++) {
+        outputFp32.select<16, 1>(16 * oc) = outputFp32.select<16, 1>(16 * oc) * softmaxMul[oc];
+      }
+      simd<fp16, QPER * 16> outputTemp = outputFp32.select<QPER * 16, 1>(0);
+#pragma unroll
+      for (int oc = 0; oc < QPER; oc++) {
+        block_store<fp16, 16>((fp16*)out + outputOffset + oc * headDim, outputTemp.select<16, 1>(16 * oc));
+      }
+    }
+    else {
+#pragma unroll
+      for (int oc = 0; oc < QPER; oc++) {
+        outputFp32.select<16, 1>(16 * oc) = outputFp32.select<16, 1>(16 * oc) * v_scale;
+      }
+#pragma unroll
+      for (int oc = 0; oc < QPER; oc++) {
+        block_store<float, 16>((float*)pTempOut + outTempOffset + oc * headDim, outputFp32.select<16, 1>(16 * oc));
+      }
+
+      block_store<float, QPER>((float*)pSoftmaxSum + outOffsetSoftmaxSum, softmaxMul);
+    }
+  }
+}

--- a/vllm/custom-esimd-kernels-vllm/csrc/eagle/page.attn.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/eagle/page.attn.h
@@ -549,3 +549,483 @@ ESIMD_INLINE void sdpaDecodeGqa4Phase3(
   simd<fp16, 16> outputTemp = output.select<16, 1>(0);
   block_store<fp16, 16>((fp16*)out + outOffset, outputTemp);
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GQA = 2 native variants (fp16 KV).
+//
+// Same work-group geometry as the GQA=4 kernels — 4 threads in phase1 (one per
+// 64-col head_dim segment), 2 threads in phase2 (one per 32-token segment) — but
+// each work-group now owns ONLY 2 q-heads (one kv-head's full group) instead of 4.
+// The head_dim / token tiling and all simd widths are byte-for-byte identical to
+// the GQA=4 path; the only differences are:
+//   * q-head loop bounds 4 -> 2  (qn / pn / oc)
+//   * q-head mapping qHeadIdx = kvHeadIdx * gqaRatio   (gqaRatio == 2 here)
+//   * in the softmax/output stage the surplus threads (hh >= 2 in phase1,
+//     hh >= 1 in phase2) return after the barrier — there is no 3rd/4th q-head.
+// This computes exactly 2 q-heads of QK·PV, i.e. half the work of padding to 4.
+// Phase3 is reused unchanged (it is per-q-head, gqa-agnostic).
+ESIMD_INLINE void sdpaDecodeGqa2Phase1(
+  uint8_t* qState,
+  uint8_t* kState,
+  uint8_t* pState,
+  float* pGroupMax,
+  float* pGlobalMax,
+  uint32_t* pPollP,
+  uint32_t* pageTable,
+  uint32_t* batchKvSeqLen,
+  uint32_t batchSize,
+  uint32_t kvCacheBatchStride0,
+  uint32_t kvCacheBatchStride1,
+  uint32_t pageTableBatchStride,
+  uint32_t pageTableSizeLog2,
+  uint32_t pStride,
+  uint32_t maxStride,
+  uint32_t headKv,
+  uint32_t gqaRatio,
+  sycl::nd_item<3>& ndi) {
+  constexpr uint32_t baseOffsetInc16[16] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+  constexpr float matMulQuantCoeff = 0.0625f;
+  constexpr uint32_t headDim = 256;
+  constexpr uint32_t maxPGroupOut = 128;
+  constexpr uint32_t outputPerGroup = 64;
+  constexpr uint32_t loopCount = outputPerGroup / 16;
+  constexpr uint32_t QPER = 2;                       // q-heads per work-group
+  constexpr uint32_t slmSizePhase1 = 4 * maxPGroupOut * 4 * sizeof(float);
+  __ESIMD_NS::slm_init<slmSizePhase1>();
+  int localLinearId = ndi.get_local_id(0);
+  int globalLinearId0 = ndi.get_group(0); // [0, kvHead)
+  int globalLinearId1 = ndi.get_group(1); // [0, keSeqLen / 64)
+  int globalLinearId2 = ndi.get_group(2); // [0, bs)
+  int hh = localLinearId & 0x3;
+  int batchIdx = globalLinearId2;
+  int kvHeadIdx = globalLinearId0;                   // one work-group per kv-head
+  int qHeadIdx = kvHeadIdx * gqaRatio;               // 2 q-heads start here
+  uint32_t pageTableSize = 1 << pageTableSizeLog2;
+  uint32_t pageTableLoopMask = pageTableSize - 1;
+  uint32_t kvSeqLen = batchKvSeqLen[batchIdx];
+  uint32_t pageTableBase = pageTableBatchStride * batchIdx;
+  simd<uint32_t, 16> simdOffsetsK;
+
+  simd<uint32_t, 16> baseOffsetInc16AsSimd(baseOffsetInc16);
+  simd<float, 64 * QPER> qqFp32;
+  simd<fp16, 64 * QPER> qqFp16;
+  simd<float, 16 * QPER> ppFp32;
+  simd<fp16, 16 * 64> kkCache;
+  simd<float, 1> ppMax;
+
+  uint32_t headQ = headKv * gqaRatio;
+  uint64_t outputOffset = qHeadIdx * pStride + globalLinearId1 * outputPerGroup + hh * pStride + batchIdx * headQ * pStride;
+  uint32_t outputMaxOffset = qHeadIdx * maxStride + globalLinearId1 + hh * maxStride + batchIdx * headQ * maxStride;
+  uint32_t offsetQ = qHeadIdx * headDim * sizeof(fp16) + hh * 32 * sizeof(fp16) + batchIdx * headQ * headDim * sizeof(fp16);
+  uint32_t baseCoordK = globalLinearId1 * outputPerGroup;
+  uint32_t offsetBaseK = hh * 32 * sizeof(fp16) + headDim * kvHeadIdx * sizeof(fp16);
+  uint32_t kvSeqOffset = baseCoordK;
+
+  if (baseCoordK >= kvSeqLen) {
+    return;
+  }
+
+#pragma unroll
+  for (int qn = 0; qn < QPER; qn++) {
+#pragma unroll
+    for (int qk = 0; qk < 2; qk++) {
+      qqFp16.template bit_cast_view<uint8_t>().select<64, 1>(128 * qn + 64 * qk) =
+        __ESIMD_ENS::lsc_block_load<
+        uint8_t,
+        64,
+        __ESIMD_ENS::lsc_data_size::default_size,
+        __ESIMD_ENS::cache_hint::cached,
+        __ESIMD_ENS::cache_hint::cached>((uint8_t*)qState + offsetQ + qn * headDim * sizeof(fp16) + qk * 4 * 32 * sizeof(fp16));
+    }
+  }
+
+  qqFp32 = qqFp16;
+
+#pragma unroll
+  for (int loopIdx = 0; loopIdx < loopCount; loopIdx++) {
+    ppFp32 = 0.0f;
+    if (kvSeqOffset < kvSeqLen) {
+      uint32_t pageTableIdx = kvSeqOffset >> pageTableSizeLog2;
+      uint32_t pageTableOffset = kvSeqOffset & pageTableLoopMask;
+      uint32_t pageIdx = pageTable[pageTableBase + pageTableIdx];
+      simd<uint16_t, 16> mask;
+      simd<uint16_t, 16> maskNeg;
+      simd<float, 16 * 32> kkFp32;
+      simd<uint32_t, 16> logicSimdOffsetK;
+      logicSimdOffsetK = baseOffsetInc16AsSimd + kvSeqOffset;
+      mask = logicSimdOffsetK < kvSeqLen;
+      maskNeg = logicSimdOffsetK >= kvSeqLen;
+      simdOffsetsK = baseOffsetInc16AsSimd;
+
+      simdOffsetsK =
+        simdOffsetsK * headKv * headDim * sizeof(fp16) +
+        offsetBaseK +
+        pageIdx * kvCacheBatchStride1 * sizeof(fp16) +
+        pageTableOffset * headKv * headDim * sizeof(fp16)
+        ;
+
+#pragma unroll
+      for (int kk = 0; kk < 2; kk++) {
+#pragma unroll
+        for (int kkk = 0; kkk < 4; kkk++) {
+          kkCache.template bit_cast_view<uint32_t>().select<64, 1>(256 * kk + 64 * kkk) =
+            __ESIMD_ENS::lsc_gather<
+            uint32_t,
+            4,
+            __ESIMD_ENS::lsc_data_size::u32,
+            __ESIMD_ENS::cache_hint::cached,
+            __ESIMD_ENS::cache_hint::cached,
+            16,
+            uint32_t
+            >((uint32_t*)kState, simdOffsetsK, mask);
+          simdOffsetsK += 8 * sizeof(fp16);
+        }
+
+        simdOffsetsK += 3 * 32 * sizeof(fp16);
+
+#pragma unroll
+        for (int kkk = 0; kkk < 16; kkk++) {
+          kkFp32.select<16, 1>(32 * kkk + 16 * 0) = kkCache.select<16, 2>(512 * kk + 32 * kkk + 0);
+          kkFp32.select<16, 1>(32 * kkk + 16 * 1) = kkCache.select<16, 2>(512 * kk + 32 * kkk + 1);
+        }
+
+#pragma unroll
+        for (int kkk = 0; kkk < 32; kkk++) {
+#pragma unroll
+          for (int pn = 0; pn < QPER; pn++) {
+            ppFp32.select<16, 1>(16 * pn) = ppFp32.select<16, 1>(16 * pn) + kkFp32.select<16, 1>(16 * kkk) * qqFp32[64 * pn + 32 * kk + kkk];
+          }
+        }
+      }
+
+#pragma unroll
+      for (int pn = 0; pn < QPER; pn++) {
+        ppFp32.select<16, 1>(pn * 16).merge(FP32_MIN, maskNeg);
+      }
+    }
+    else {
+      ppFp32 = FP32_MIN;
+    }
+
+#pragma unroll
+    for (int pn = 0; pn < QPER; pn++) {
+      slm_block_store<float, 16>(
+        loopIdx * 4 * 64 * sizeof(float) +
+        pn * 64 * sizeof(float) +
+        hh * 16 * sizeof(float),
+        ppFp32.select<16, 1>(16 * pn));
+    }
+    kvSeqOffset += 16;
+  }
+
+  barrier();
+
+  // Only the first QPER threads correspond to real q-heads; the rest exit.
+  if (hh >= QPER) {
+    return;
+  }
+
+  {
+    simd<float, 16 * 4> ppOut;
+    simd<float, 16> maxTemp;
+    simd<float, 64> ppTemp;
+#pragma unroll
+    for (int pk = 0; pk < 4; pk++) {
+      ppTemp = slm_block_load<float, 64>(pk * 64 * 4 * sizeof(float) + hh * 64 * sizeof(float));
+#pragma unroll
+      for (int pn = 0; pn < 1; pn++) {
+        ppOut.select<16, 1>(4 * 16 * pn + 16 * pk) = ppTemp.select<16, 1>(64 * pn) + ppTemp.select<16, 1>(64 * pn + 16);
+        ppOut.select<16, 1>(4 * 16 * pn + 16 * pk) = ppOut.select<16, 1>(4 * 16 * pn + 16 * pk) + ppTemp.select<16, 1>(64 * pn + 32);
+        ppOut.select<16, 1>(4 * 16 * pn + 16 * pk) = ppOut.select<16, 1>(4 * 16 * pn + 16 * pk) + ppTemp.select<16, 1>(64 * pn + 48);
+      }
+    }
+
+    ppOut = ppOut * matMulQuantCoeff;
+    maxTemp = ppOut.select<16, 1>(0);
+#pragma unroll
+    for (int pk = 1; pk < 4; pk++) {
+      maxTemp = __ESIMD_NS::max<float, 16, float>(maxTemp, ppOut.select<16, 1>(16 * pk));
+    }
+
+    maxTemp.select<8, 1>(0) = __ESIMD_NS::max<float, 8, float>(maxTemp.select<8, 1>(0), maxTemp.select<8, 1>(8));
+    maxTemp.select<4, 1>(0) = __ESIMD_NS::max<float, 4, float>(maxTemp.select<4, 1>(0), maxTemp.select<4, 1>(4));
+    maxTemp.select<2, 1>(0) = __ESIMD_NS::max<float, 2, float>(maxTemp.select<2, 1>(0), maxTemp.select<2, 1>(2));
+    ppMax[0] = __ESIMD_NS::max<float>(maxTemp[0], maxTemp[1]);
+    ppOut.select<64, 1>(0) = ppOut.select<64, 1>(0) - ppMax[0];
+    ppOut = __ESIMD_NS::pow<float, 64, float>(2.718281828459f, ppOut);
+
+    {
+      block_store<float, 64>((float*)pState + outputOffset, ppOut.select<64, 1>(0));
+      simd<float, 1> zeros = 0.0f;
+      pGroupMax[outputMaxOffset] = ppMax[0];
+      uint32_t atomicOffset = (batchIdx * gqaRatio * headKv + qHeadIdx + hh) * sizeof(float);
+      uint32_t arrivalId =
+        atomic_update<
+        __ESIMD_NS::atomic_op::inc,
+        uint32_t,
+        1,
+        uint32_t>(pPollP, atomicOffset);
+
+      if (0 == arrivalId) {
+        atomic_update<
+          __ESIMD_NS::atomic_op::fcmpxchg,
+          float,
+          1,
+          uint32_t>(pGlobalMax, atomicOffset, ppMax, zeros);
+      }
+      else {
+        atomic_update<
+          __ESIMD_NS::atomic_op::fmax,
+          float,
+          1,
+          uint32_t>(pGlobalMax, atomicOffset, ppMax);
+      }
+    }
+  }
+}
+
+ESIMD_INLINE void sdpaDecodeGqa2Phase2(
+  uint8_t* pState,
+  float* pGroupMax,
+  uint8_t* vState,
+  float* pGlobalMax,
+  float* pTempOut,
+  float* pSoftmaxSum,
+  uint8_t* out,
+  uint32_t* pageTable,
+  uint32_t* batchKvSeqLen,
+  uint32_t batchSize,
+  uint32_t kvCacheBatchStride0,
+  uint32_t kvCacheBatchStride1,
+  uint32_t pageTableBatchStride,
+  uint32_t pageTableSizeLog2,
+  uint32_t pStride,
+  uint32_t maxStride,
+  uint32_t headKv,
+  uint32_t longestBatch,
+  uint32_t flag,
+  uint32_t gqaRatio,
+  sycl::nd_item<3>& ndi) {
+  constexpr uint32_t headDim = 256;
+  constexpr uint32_t maxPGroupOut = 128;
+  constexpr uint32_t outputPerGroup = 64;
+  constexpr float matMulQuantCoeff = 0.0625f;
+  constexpr uint32_t QPER = 2;                       // q-heads per work-group
+  constexpr uint32_t slmSizeOut = 2 * 4 * 16 * sizeof(float);
+  constexpr uint32_t slmSizeSoftmaxSum = 2 * 4 * sizeof(float);
+  constexpr uint32_t slmSize = slmSizeOut + slmSizeSoftmaxSum;
+  __ESIMD_NS::slm_init<slmSize>();
+  constexpr uint32_t baseOffsetInc16[16] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+  int localLinearId = ndi.get_local_id(0);
+  int globalLinearId0 = ndi.get_group(0); // [0, head dim / 16)
+  int globalLinearId1 = ndi.get_group(1); // [0, kvHead)
+  int globalLinearId2 = ndi.get_group(2); // [0, bs)
+  int hh = localLinearId & 0x1;
+  int batchIdx = globalLinearId2;
+  int kvHeadIdx = globalLinearId1;                   // one work-group per kv-head
+  uint32_t kvSeqLen = batchKvSeqLen[batchIdx];
+  int kvSeqOutGroup = (kvSeqLen + 1023) >> 10;
+  uint32_t pageTableSize = 1 << pageTableSizeLog2;
+  uint32_t pageTableLoopMask = (1 << pageTableSizeLog2) - 1;
+  uint32_t pageTableBase = pageTableBatchStride * batchIdx;
+  uint32_t channelOffset = globalLinearId0 & 0xf;
+  uint32_t groupIdx = globalLinearId0 >> 4;
+
+  simd<uint32_t, 16> simdOffsets(baseOffsetInc16);
+  simd<uint32_t, 16> pageTableIndice;
+  simd<uint32_t, 16> pageTableOffsets;
+
+  simd<uint32_t, 16> pageAlignedOffsets;
+  simd<uint32_t, 16> pageOffsetsInner;
+  simd<uint32_t, 16> pageNumbers;
+
+  simd<float, QPER * 32> ppFp32;
+  simd<float, QPER> historicMax;
+  simd<fp16, 32 * 16> vvCache;
+  simd<float, 16 * 16> vvFp32;
+  simd<float, QPER * 16> softmaxSum;
+  simd<float, QPER * 16> outputFp32;
+
+  if (groupIdx >= kvSeqOutGroup) {
+    return;
+  }
+  uint32_t reduceCount = (longestBatch + 1023) >> 10;
+  uint32_t headQ = headKv * gqaRatio;
+  uint32_t qBaseIdx = kvHeadIdx * gqaRatio;
+  uint32_t outputOffset = qBaseIdx * headDim + channelOffset * 16 + hh * 2 * headDim + batchIdx * headQ * headDim;
+  uint32_t outTempOffset = qBaseIdx * headDim + channelOffset * 16 + hh * 2 * headDim + groupIdx * headQ * headDim + batchIdx * reduceCount * headQ * headDim;
+  uint32_t outOffsetSoftmaxSum = qBaseIdx + hh * 2 + groupIdx * headQ + batchIdx * reduceCount * headQ;
+  uint32_t offsetP = qBaseIdx * pStride + hh * 32 + groupIdx * 1024 + batchIdx * headQ * pStride;
+  uint32_t offsetMax = qBaseIdx * maxStride + batchIdx * headQ * maxStride + groupIdx * 16;
+  uint32_t offsetGlobalMax = batchIdx * headQ + qBaseIdx;
+  uint32_t widthV = headKv * headDim * sizeof(fp16) - 1;
+  uint32_t heightV = pageTableSize - 1;
+  uint32_t vX = channelOffset * 16 + headDim * kvHeadIdx;
+  uint32_t vY = 32 * hh;
+  uint32_t totalPages = (kvSeqLen + pageTableSize - 1) >> pageTableSizeLog2;
+  uint32_t lastPageHeight = (kvSeqLen - 1) & (pageTableSize - 1);
+  if (kvSeqLen == 0) {
+    lastPageHeight = 0;
+  }
+  fp16* vPtrBase = (fp16*)vState + kvCacheBatchStride0;
+
+  historicMax = FP32_MIN * matMulQuantCoeff;
+  softmaxSum = 0;
+  outputFp32 = 0;
+
+  simd<float, QPER> globalMax;
+  simd<float, QPER> currMax;
+  simd<float, QPER> compensationP;
+  simd<uint16_t, 16> mask;
+  simd<uint16_t, 16> maskNeg;
+
+  uint32_t kvSeqOffset = groupIdx * 1024;
+  simdOffsets = simdOffsets * 64 + kvSeqOffset;
+  mask = simdOffsets < kvSeqLen;
+  maskNeg = simdOffsets >= kvSeqLen;
+  pageTableIndice = (simdOffsets >> pageTableSizeLog2);
+  pageTableOffsets = pageTableIndice * sizeof(uint32_t) + pageTableBase * sizeof(uint32_t);
+  pageOffsetsInner = simdOffsets & pageTableLoopMask;
+  pageNumbers =
+    gather<
+    uint32_t,
+    16,
+    1,
+    uint32_t>(pageTable, pageTableOffsets, mask);
+
+  pageAlignedOffsets = pageNumbers * kvCacheBatchStride1;
+  pageAlignedOffsets.merge(0, maskNeg);
+  globalMax = block_load<float, QPER>(pGlobalMax + offsetGlobalMax);
+
+#pragma unroll
+  for (uint32_t loop = 0; loop < 16; loop++) {
+    if (kvSeqOffset + loop * 64 < kvSeqLen) {
+      fp16* currPtrV = vPtrBase + pageAlignedOffsets[loop];
+      if (pageTableIndice[loop] + 1 < totalPages) {
+        heightV = pageTableSize - 1;
+      }
+      else {
+        heightV = lastPageHeight;
+      }
+      vY = pageOffsetsInner[loop] + 32 * hh;
+
+#pragma unroll
+      for (int pn = 0; pn < QPER; pn++) {
+        ppFp32.select<32, 1>(32 * pn) = block_load<float, 32>((float*)pState + offsetP + pStride * pn);
+        currMax[pn] = pGroupMax[offsetMax + maxStride * pn];
+      }
+
+      vvCache.select<256, 1>(0 * 256) =
+        __ESIMD_ENS::lsc_load_2d<
+        fp16,
+        16,
+        16,
+        1,
+        false,
+        false,
+        __ESIMD_ENS::cache_hint::cached,
+        __ESIMD_ENS::cache_hint::cached
+        >(currPtrV, widthV, heightV, widthV, vX, vY);
+      vY += 16;
+
+      vvCache.select<256, 1>(1 * 256) =
+        __ESIMD_ENS::lsc_load_2d<
+        fp16,
+        16,
+        16,
+        1,
+        false,
+        false,
+        __ESIMD_ENS::cache_hint::cached,
+        __ESIMD_ENS::cache_hint::cached>
+        (currPtrV, widthV, heightV, widthV, vX, vY);
+
+      compensationP = currMax - globalMax;
+      compensationP = exp(compensationP);
+
+#pragma unroll
+      for (int oc = 0; oc < QPER; oc++) {
+        ppFp32.select<32, 1>(32 * oc) = ppFp32.select<32, 1>(32 * oc) * compensationP[oc];
+      }
+
+#pragma unroll
+      for (int oc = 0; oc < QPER; oc++) {
+#pragma unroll
+        for (int pk = 0; pk < 2; pk++) {
+          softmaxSum.select<16, 1>(16 * oc) = softmaxSum.select<16, 1>(16 * oc) + ppFp32.select<16, 1>(32 * oc + 16 * pk);
+        }
+      }
+
+#pragma unroll
+      for (int vk = 0; vk < 2; vk++) {
+        vvFp32 = vvCache.select<256, 1>(256 * vk);
+#pragma unroll
+        for (int oc = 0; oc < QPER; oc++) {
+#pragma unroll
+          for (int pk = 0; pk < 16; pk++) {
+            outputFp32.select<16, 1>(16 * oc) += vvFp32.select<16, 1>(16 * pk) * ppFp32[32 * oc + 16 * vk + pk];
+          }
+        }
+      }
+
+      offsetP += 64;
+      offsetMax += 1;
+    }
+  }
+
+#pragma unroll
+  for (int32_t kk = 0; kk < QPER; kk++) {
+    slm_block_store<float, 16>(hh * 16 * sizeof(float) + 32 * kk * sizeof(float), outputFp32.select<16, 1>(16 * kk));
+  }
+
+#pragma unroll
+  for (int32_t kk = 0; kk < QPER; kk++) {
+    float slmTempSoftmaxSum;
+    slmTempSoftmaxSum = __ESIMD_DNS::sum<float, float, 16>(softmaxSum.select<16, 1>(16 * kk));
+    slm_block_store<float, 1>(slmSizeOut + hh * sizeof(float) + 2 * kk * sizeof(float), slmTempSoftmaxSum);
+  }
+
+  barrier();
+
+  // GQA=2: only thread hh==0 owns real q-heads (0,1); hh==1 has no (2,3) pair.
+  if (hh >= 1) {
+    return;
+  }
+
+  {
+    // dividor holds both threads' token-partial softmax sums for the 2 q-heads:
+    //   [qhead0_t0, qhead0_t1, qhead1_t0, qhead1_t1]; sum the pairs (same as GQA=4).
+    simd<float, 4> dividor;
+    simd<float, QPER> softmaxMul;
+    simd<float, QPER * 32> outputTempFp32;
+    dividor = slm_block_load<float, 4>(slmSizeOut);          // hh==0 here
+    softmaxMul = dividor.select<2, 2>(0) + dividor.select<2, 2>(1);
+    outputTempFp32 = slm_block_load<float, QPER * 32>(0);    // hh==0 here
+
+#pragma unroll
+    for (int oc = 0; oc < QPER; oc++) {
+      outputFp32.select<16, 1>(16 * oc) = outputTempFp32.select<16, 1>(32 * oc) + outputTempFp32.select<16, 1>(32 * oc + 16);
+    }
+
+    if ((flag & 0x1) == 1) {
+      softmaxMul = 1.0f / softmaxMul;
+#pragma unroll
+      for (int oc = 0; oc < QPER; oc++) {
+        outputFp32.select<16, 1>(16 * oc) = outputFp32.select<16, 1>(16 * oc) * softmaxMul[oc];
+      }
+      simd<fp16, QPER * 16> outputTemp = outputFp32.select<QPER * 16, 1>(0);
+#pragma unroll
+      for (int oc = 0; oc < QPER; oc++) {
+        block_store<fp16, 16>((fp16*)out + outputOffset + oc * headDim, outputTemp.select<16, 1>(16 * oc));
+      }
+    }
+    else {
+#pragma unroll
+      for (int oc = 0; oc < QPER; oc++) {
+        block_store<float, 16>((float*)pTempOut + outTempOffset + oc * headDim, outputFp32.select<16, 1>(16 * oc));
+      }
+
+      block_store<float, QPER>((float*)pSoftmaxSum + outOffsetSoftmaxSum, softmaxMul);
+    }
+  }
+}


### PR DESCRIPTION
ESIMD page_attn_decode previously supported only gqaRatio that is a multiple of 4. GQA=2 models (gemma-4-26B-A4B: GQA=2, head_dim=256) had to pad q-heads up to 4 on the vllm side, computing twice the q-heads needed.

Add native GQA=2 device kernels for fp16 + fp8 (e4m3fn / e5m2):
  - page.attn.h:     sdpaDecodeGqa2Phase{1,2}
  - page.attn.fp8.h: sdpaDecodeGqa2Phase{1,2}Fp8<Fp8Variant>
Same work-group geometry as the GQA=4 kernels (4 threads phase1 splitting
head_dim, 2 threads phase2 splitting tokens) but each work-group owns only
2 q-heads; surplus threads exit after the barrier. Phase3 is per-q-head and
reused unchanged. host page_attention_forward_kernel dispatches by gqaRatio
(==2 -> Gqa2, %4==0 -> Gqa4); launch grid uses gqaGroups=1 for GQA=2.
TORCH_CHECK relaxed to allow gqaRatio in {2, 4, 8, ...}. host signature and
eagle_ops schema unchanged.

Verified: native vs padded-to-4 max|d| <= 8e-6 across fp16/e4m3/e5m2, seq 128..16384, batch>1, multi kv-head. Kernel-level native is 1.4-1.85x faster than padded (computes 2 q-heads instead of 4). GQA>=4 path numerics unchanged (zero regression).