### PR TITLE
Update vllm and xpu-kernels patches for v0.21.0 (b8.4-0630)

### DIFF
--- a/vllm/patches/vllm_for_multi_arc.patch
+++ b/vllm/patches/vllm_for_multi_arc.patch
@@ -350,6 +350,435 @@ index 3d6484a71..4c7f4112e 100644
  MODEL_PATH = "openbmb/MiniCPM-Llama3-V-2_5"
  
  PROMPT_TEMPLATE = (
+diff --git a/tests/test_bidir_sliding.py b/tests/test_bidir_sliding.py
+new file mode 100644
+index 000000000..461db8992
+--- /dev/null
++++ b/tests/test_bidir_sliding.py
+@@ -0,0 +1,89 @@
++"""Regression test for the mixed-causal-split SLIDING-WINDOW bug.
++
++Root cause: decoder sliding layers store the causal window as (left, 0). In the
++XPU mixed-causal split helper, the denoise group runs causal=False but, before
++the fix, passed (left, 0) unchanged -> each canvas token could not attend to
++tokens on its RIGHT -> broken bidirectional block denoising -> repetition.
++
++Fix: in the non-causal (denoise) group, symmetrize (left, 0) -> (left, left).
++
++This test (which test_bidir_attn.py did NOT cover) exercises q_len > window so
++the window actually masks, and checks:
++  A) buggy window (left, 0) + causal=False  != true symmetric-window bidir attn
++  B) fixed window (left, left) + causal=False == true symmetric-window bidir attn
++"""
++import torch
++from vllm._xpu_ops import xpu_ops
++
++fa = xpu_ops.flash_attn_varlen_func
++dev = "xpu"
++torch.manual_seed(0)
++
++NH, NKV, HD = 16, 8, 256
++BLOCK = 64
++dtype = torch.float16
++scale = HD ** -0.5
++GQA = NH // NKV
++
++# q_len/kv_len LARGER than window so the window genuinely masks.
++LEFT = 4                      # small window to make masking bite
++q_len = kv_len = 16
++
++q = torch.randn(q_len, NH, HD, device=dev, dtype=dtype) * 0.1
++nblk = (kv_len + BLOCK - 1) // BLOCK
++key_cache = torch.zeros(nblk + 1, BLOCK, NKV, HD, device=dev, dtype=dtype)
++value_cache = torch.zeros(nblk + 1, BLOCK, NKV, HD, device=dev, dtype=dtype)
++k_real = torch.randn(kv_len, NKV, HD, device=dev, dtype=dtype) * 0.1
++v_real = torch.randn(kv_len, NKV, HD, device=dev, dtype=dtype) * 0.1
++for t in range(kv_len):
++    key_cache[0, t] = k_real[t]
++    value_cache[0, t] = v_real[t]
++
++cu_q = torch.tensor([0, q_len], dtype=torch.int32, device=dev)
++seqused_k = torch.tensor([kv_len], dtype=torch.int32, device=dev)
++block_table = torch.tensor([[0]], dtype=torch.int32, device=dev)
++
++
++def run_fa(window):
++    out = torch.empty(q_len, NH, HD, device=dev, dtype=dtype)
++    fa(q=q, k=key_cache, v=value_cache, out=out, cu_seqlens_q=cu_q,
++       max_seqlen_q=q_len, seqused_k=seqused_k, max_seqlen_k=kv_len,
++       softmax_scale=scale, causal=False, window_size=window, block_table=block_table)
++    torch.xpu.synchronize()
++    return out
++
++
++def torch_ref(left, right):
++    """Naive bidirectional attention with window [i-left, i+right]."""
++    qf = q.float()
++    kf = k_real.float().repeat_interleave(GQA, dim=1)
++    vf = v_real.float().repeat_interleave(GQA, dim=1)
++    scores = torch.einsum("qhd,khd->hqk", qf, kf) * scale   # [NH, q, k]
++    qi = torch.arange(q_len, device=dev).view(1, q_len, 1)
++    ki = torch.arange(kv_len, device=dev).view(1, 1, kv_len)
++    # FA window convention: key j attends if -left <= (j - i) <= right
++    mask = (ki - qi >= -left) & (ki - qi <= right)
++    scores = scores.masked_fill(~mask, float("-inf"))
++    attn = scores.softmax(dim=-1)
++    return torch.einsum("hqk,khd->qhd", attn, vf)
++
++
++# A) buggy: (LEFT, 0) — single-sided left window under causal=False
++out_buggy = run_fa([LEFT, 0])
++ref_left_only = torch_ref(LEFT, 0)          # what (LEFT,0) actually computes
++ref_symmetric = torch_ref(LEFT, LEFT)        # what bidirectional SHOULD compute
++
++# B) fixed: (LEFT, LEFT) — symmetric window
++out_fixed = run_fa([LEFT, LEFT])
++
++d_buggy_vs_sym = (out_buggy.float() - ref_symmetric).abs().max().item()
++d_buggy_vs_leftonly = (out_buggy.float() - ref_left_only).abs().max().item()
++d_fixed_vs_sym = (out_fixed.float() - ref_symmetric).abs().max().item()
++
++print(f"buggy(LEFT,0)  vs symmetric-ref : max diff {d_buggy_vs_sym:.5f}  (should be LARGE — bug)")
++print(f"buggy(LEFT,0)  vs left-only-ref : max diff {d_buggy_vs_leftonly:.5f}  (should be ~0 — confirms it's left-only)")
++print(f"fixed(LEFT,LEFT) vs symmetric-ref: max diff {d_fixed_vs_sym:.5f}  (should be ~0 — fix correct)")
++
++ok = (d_buggy_vs_sym > 0.05) and (d_buggy_vs_leftonly < 5e-3) and (d_fixed_vs_sym < 5e-3)
++print("PASS" if ok else "FAIL",
++      "— bug reproduced (left-only != bidirectional) AND symmetrization fixes it" if ok else "— unexpected")
+diff --git a/tests/test_mixed_causal_split.py b/tests/test_mixed_causal_split.py
+new file mode 100644
+index 000000000..ebff2d7d5
+--- /dev/null
++++ b/tests/test_mixed_causal_split.py
+@@ -0,0 +1,124 @@
++"""Unit test: _xpu_split_mixed_causal_varlen must equal per-request scalar-causal
++varlen runs concatenated.
++
++Builds a packed paged-KV batch with a mix of causal (encoder-phase) and
++bidirectional (denoise-phase) requests, then checks:
++  A) helper run once with a per-request causal tensor
++  B) reference: each request run alone with its scalar causal flag, outputs
++     stitched back in token order
++A and B must match within fp16 tolerance.
++"""
++import torch
++from vllm._xpu_ops import xpu_ops
++from vllm.v1.attention.backends.flash_attn import _xpu_split_mixed_causal_varlen
++
++fa = xpu_ops.flash_attn_varlen_func
++dev = "xpu"
++torch.manual_seed(0)
++
++NH, NKV, HD = 16, 8, 256
++BLOCK = 64
++dtype = torch.float16
++scale = HD ** -0.5
++
++# Per-request (query_len, kv_len, causal)
++reqs = [
++    (4, 10, True),    # encoder-phase, causal
++    (6, 6, False),    # denoise-phase, bidirectional
++    (3, 20, True),    # causal, kv spans 1 block boundary-ish
++    (5, 5, False),    # bidirectional
++]
++num_reqs = len(reqs)
++q_lens = [r[0] for r in reqs]
++kv_lens = [r[1] for r in reqs]
++causal_flags = [r[2] for r in reqs]
++total_q = sum(q_lens)
++
++# Shared paged KV cache. Give each request its own contiguous block range so
++# the reference (single-request) and helper (batched) runs read identical KV.
++blocks_per_req = [(kv + BLOCK - 1) // BLOCK for kv in kv_lens]
++max_blocks = max(blocks_per_req)
++num_blocks_total = sum(blocks_per_req) + 1  # +1 spare
++key_cache = torch.randn(num_blocks_total, BLOCK, NKV, HD, device=dev, dtype=dtype) * 0.1
++value_cache = torch.randn(num_blocks_total, BLOCK, NKV, HD, device=dev, dtype=dtype) * 0.1
++
++# Assign block ids per request (contiguous, distinct), padded with 0.
++block_table = torch.zeros(num_reqs, max_blocks, dtype=torch.int32, device=dev)
++nxt = 1
++for i, nb in enumerate(blocks_per_req):
++    block_table[i, :nb] = torch.arange(nxt, nxt + nb, dtype=torch.int32, device=dev)
++    nxt += nb
++
++q = torch.randn(total_q, NH, HD, device=dev, dtype=dtype) * 0.1
++cu_seqlens_q = torch.zeros(num_reqs + 1, dtype=torch.int32, device=dev)
++cu_seqlens_q[1:] = torch.cumsum(torch.tensor(q_lens, dtype=torch.int32, device=dev), 0)
++seqused_k = torch.tensor(kv_lens, dtype=torch.int32, device=dev)
++max_seqlen_q = max(q_lens)
++max_seqlen_k = max(kv_lens)
++causal_per_req = torch.tensor(causal_flags, dtype=torch.bool, device=dev)
++
++# ---- B) reference: per-request scalar-causal runs ----
++ref = torch.empty(total_q, NH, HD, device=dev, dtype=dtype)
++for i in range(num_reqs):
++    s = int(cu_seqlens_q[i].item())
++    e = int(cu_seqlens_q[i + 1].item())
++    q_i = q[s:e].contiguous()
++    out_i = torch.empty(q_lens[i], NH, HD, device=dev, dtype=dtype)
++    fa(
++        q=q_i,
++        k=key_cache,
++        v=value_cache,
++        out=out_i,
++        cu_seqlens_q=torch.tensor([0, q_lens[i]], dtype=torch.int32, device=dev),
++        max_seqlen_q=q_lens[i],
++        seqused_k=seqused_k[i:i + 1],
++        max_seqlen_k=kv_lens[i],
++        softmax_scale=scale,
++        causal=causal_flags[i],
++        block_table=block_table[i:i + 1],
++    )
++    ref[s:e] = out_i
++torch.xpu.synchronize()
++
++# ---- A) helper: single batched call with per-request causal tensor ----
++got = torch.empty(total_q, NH, HD, device=dev, dtype=dtype)
++_xpu_split_mixed_causal_varlen(
++    fa,
++    query=q,
++    key_cache=key_cache,
++    value_cache=value_cache,
++    output=got,
++    cu_seqlens_q=cu_seqlens_q,
++    seqused_k=seqused_k,
++    max_seqlen_q=max_seqlen_q,
++    max_seqlen_k=max_seqlen_k,
++    softmax_scale=scale,
++    causal_per_req=causal_per_req,
++    alibi_slopes=None,
++    window_size=None,
++    block_table=block_table,
++    softcap=0.0,
++    fa_version=2,
++    q_descale=None,
++    k_descale=None,
++    v_descale=None,
++    num_splits=0,
++    s_aux=None,
++)
++torch.xpu.synchronize()
++
++diff = (got.float() - ref.float()).abs()
++print("max abs diff:", float(diff.max()))
++print("mean abs diff:", float(diff.mean()))
++print("ref norm:", float(ref.float().norm()), "got norm:", float(got.float().norm()))
++# Per-request breakdown
++for i in range(num_reqs):
++    s = int(cu_seqlens_q[i].item()); e = int(cu_seqlens_q[i + 1].item())
++    d = (got[s:e].float() - ref[s:e].float()).abs().max()
++    print(f"  req{i} qlen={q_lens[i]} kv={kv_lens[i]} causal={causal_flags[i]}: max diff {float(d):.6f}")
++
++tol = 5e-3
++if float(diff.max()) < tol:
++    print(f"PASS (max diff < {tol})")
++else:
++    print(f"FAIL (max diff {float(diff.max())} >= {tol})")
+diff --git a/tests/test_mixed_causal_split2.py b/tests/test_mixed_causal_split2.py
+new file mode 100644
+index 000000000..783e45855
+--- /dev/null
++++ b/tests/test_mixed_causal_split2.py
+@@ -0,0 +1,76 @@
++"""Edge-case sweep for _xpu_split_mixed_causal_varlen vs per-request reference.
++Covers: all-causal, all-bidirectional, single request, many small reqs,
++interleaved flags, and a decode-like shape (q_len==canvas chunk)."""
++import torch
++from vllm._xpu_ops import xpu_ops
++from vllm.v1.attention.backends.flash_attn import _xpu_split_mixed_causal_varlen
++
++fa = xpu_ops.flash_attn_varlen_func
++dev = "xpu"
++NH, NKV, HD = 16, 8, 256
++BLOCK = 64
++dtype = torch.float16
++scale = HD ** -0.5
++
++
++def run_case(name, reqs, seed=0):
++    torch.manual_seed(seed)
++    q_lens = [r[0] for r in reqs]
++    kv_lens = [r[1] for r in reqs]
++    causal_flags = [r[2] for r in reqs]
++    num_reqs = len(reqs)
++    total_q = sum(q_lens)
++
++    blocks_per_req = [(kv + BLOCK - 1) // BLOCK for kv in kv_lens]
++    max_blocks = max(blocks_per_req)
++    num_blocks_total = sum(blocks_per_req) + 1
++    key_cache = torch.randn(num_blocks_total, BLOCK, NKV, HD, device=dev, dtype=dtype) * 0.1
++    value_cache = torch.randn(num_blocks_total, BLOCK, NKV, HD, device=dev, dtype=dtype) * 0.1
++
++    block_table = torch.zeros(num_reqs, max_blocks, dtype=torch.int32, device=dev)
++    nxt = 1
++    for i, nb in enumerate(blocks_per_req):
++        block_table[i, :nb] = torch.arange(nxt, nxt + nb, dtype=torch.int32, device=dev)
++        nxt += nb
++
++    q = torch.randn(total_q, NH, HD, device=dev, dtype=dtype) * 0.1
++    cu = torch.zeros(num_reqs + 1, dtype=torch.int32, device=dev)
++    cu[1:] = torch.cumsum(torch.tensor(q_lens, dtype=torch.int32, device=dev), 0)
++    seqused_k = torch.tensor(kv_lens, dtype=torch.int32, device=dev)
++    causal_per_req = torch.tensor(causal_flags, dtype=torch.bool, device=dev)
++
++    ref = torch.empty(total_q, NH, HD, device=dev, dtype=dtype)
++    for i in range(num_reqs):
++        s, e = int(cu[i]), int(cu[i + 1])
++        out_i = torch.empty(q_lens[i], NH, HD, device=dev, dtype=dtype)
++        fa(q=q[s:e].contiguous(), k=key_cache, v=value_cache, out=out_i,
++           cu_seqlens_q=torch.tensor([0, q_lens[i]], dtype=torch.int32, device=dev),
++           max_seqlen_q=q_lens[i], seqused_k=seqused_k[i:i + 1], max_seqlen_k=kv_lens[i],
++           softmax_scale=scale, causal=causal_flags[i], block_table=block_table[i:i + 1])
++        ref[s:e] = out_i
++
++    got = torch.empty(total_q, NH, HD, device=dev, dtype=dtype)
++    _xpu_split_mixed_causal_varlen(
++        fa, query=q, key_cache=key_cache, value_cache=value_cache, output=got,
++        cu_seqlens_q=cu, seqused_k=seqused_k, max_seqlen_q=max(q_lens),
++        max_seqlen_k=max(kv_lens), softmax_scale=scale, causal_per_req=causal_per_req,
++        alibi_slopes=None, window_size=None, block_table=block_table, softcap=0.0,
++        fa_version=2, q_descale=None, k_descale=None, v_descale=None,
++        num_splits=0, s_aux=None)
++    torch.xpu.synchronize()
++
++    d = float((got.float() - ref.float()).abs().max())
++    status = "PASS" if d < 5e-3 else "FAIL"
++    print(f"[{status}] {name}: max diff {d:.6f}")
++    return d < 5e-3
++
++
++ok = True
++ok &= run_case("all-causal", [(4, 10, True), (6, 6, True), (3, 8, True)])
++ok &= run_case("all-bidirectional", [(4, 4, False), (6, 6, False), (5, 5, False)])
++ok &= run_case("single-causal", [(7, 12, True)])
++ok &= run_case("single-bidir", [(7, 7, False)])
++ok &= run_case("interleaved-8", [(2, 5, i % 2 == 0) for i in range(8)])
++ok &= run_case("decode-canvas-like", [(16, 16, False), (16, 32, True), (16, 16, False)])
++ok &= run_case("bidir-first", [(5, 5, False), (4, 10, True)])
++print("ALL PASS" if ok else "SOME FAILED")
+diff --git a/tests/test_triton_per_seq_causal.py b/tests/test_triton_per_seq_causal.py
+new file mode 100644
+index 000000000..caf1c3054
+--- /dev/null
++++ b/tests/test_triton_per_seq_causal.py
+@@ -0,0 +1,116 @@
++"""Kernel-level regression test for the TRITON per-seq-causal port (PR #45163).
++
++Verifies the ported `unified_attention(causal=<tensor>)` path against a naive
++torch reference, for a packed 2-sequence batch that mixes:
++  - seq 0: causal (encoder)        -> key j attends iff j <= i
++  - seq 1: non-causal (denoise)    -> bidirectional within sliding window
++
++Two layer kinds are checked, mirroring DiffusionGemma's 30 layers:
++  - full attention (no sliding window)
++  - sliding window (so the bidirectional [i-W, i+W] symmetrization actually
++    bites; this is the q_len>window case test_bidir_attn.py missed).
++
++The kernel reads window_size[0] (left) only and constructs the symmetric
++non-causal window in-kernel, so we pass window=(W-1, 0) exactly as the triton
++backend's __init__ stores it for a decoder sliding layer.
++"""
++import torch
++from vllm.v1.attention.ops.triton_unified_attention import unified_attention
++
++dev = "xpu"
++torch.manual_seed(0)
++
++NH, NKV, HD = 16, 8, 256
++BLOCK = 64
++dtype = torch.float16
++scale = HD ** -0.5
++GQA = NH // NKV
++
++# Two sequences packed in one batch (prefill-shaped, max_seqlen_q > 1).
++LENS = [16, 16]                       # q_len == kv_len per seq (fresh prefill)
++N = len(LENS)
++total = sum(LENS)
++cu_q = torch.tensor([0, 16, 32], dtype=torch.int32, device=dev)
++seqused_k = torch.tensor(LENS, dtype=torch.int32, device=dev)
++
++# Per-seq causal flags: seq0 causal, seq1 bidirectional.
++causal_t = torch.tensor([True, False], dtype=torch.bool, device=dev)
++
++# Block table: one block per seq.
++block_table = torch.tensor([[0], [1]], dtype=torch.int32, device=dev)
++nblk = N + 1
++key_cache = torch.zeros(nblk, BLOCK, NKV, HD, device=dev, dtype=dtype)
++value_cache = torch.zeros(nblk, BLOCK, NKV, HD, device=dev, dtype=dtype)
++
++q = torch.randn(total, NH, HD, device=dev, dtype=dtype) * 0.1
++k_real, v_real = [], []
++off = 0
++for si, L in enumerate(LENS):
++    k = torch.randn(L, NKV, HD, device=dev, dtype=dtype) * 0.1
++    v = torch.randn(L, NKV, HD, device=dev, dtype=dtype) * 0.1
++    for t in range(L):
++        key_cache[si, t] = k[t]
++        value_cache[si, t] = v[t]
++    k_real.append(k)
++    v_real.append(v)
++    off += L
++
++
++def run_triton(window):
++    out = torch.empty(total, NH, HD, device=dev, dtype=dtype)
++    unified_attention(
++        q=q, k=key_cache, v=value_cache, out=out,
++        cu_seqlens_q=cu_q, max_seqlen_q=16, seqused_k=seqused_k, max_seqlen_k=16,
++        softmax_scale=scale, causal=causal_t, window_size=window,
++        block_table=block_table, softcap=0.0,
++        q_descale=None, k_descale=None, v_descale=None,
++    )
++    torch.xpu.synchronize()
++    return out
++
++
++def torch_ref(window):
++    """Naive per-seq attention. window=(left,0) as stored; for non-causal seqs
++    the kernel symmetrizes to [i-left, i+left]."""
++    left = window[0]
++    outs = []
++    off = 0
++    for si, L in enumerate(LENS):
++        qf = q[off:off + L].float()
++        kf = k_real[si].float().repeat_interleave(GQA, dim=1)
++        vf = v_real[si].float().repeat_interleave(GQA, dim=1)
++        scores = torch.einsum("qhd,khd->hqk", qf, kf) * scale
++        qi = torch.arange(L, device=dev).view(1, L, 1)
++        ki = torch.arange(L, device=dev).view(1, 1, L)
++        if causal_t[si]:
++            mask = (ki <= qi)
++            if left >= 0:
++                mask = mask & ((qi - ki) <= left)
++        else:
++            # bidirectional symmetric window
++            if left >= 0:
++                mask = (ki - qi >= -left) & (ki - qi <= left)
++            else:
++                mask = torch.ones(1, L, L, dtype=torch.bool, device=dev)
++        scores = scores.masked_fill(~mask, float("-inf"))
++        attn = scores.softmax(dim=-1)
++        outs.append(torch.einsum("hqk,khd->qhd", attn, vf))
++        off += L
++    return torch.cat(outs, dim=0)
++
++
++def check(name, window):
++    out = run_triton(window)
++    ref = torch_ref(window)
++    d = (out.float() - ref).abs().max().item()
++    ok = d < 5e-3
++    print(f"{name}: max diff {d:.6f}  {'PASS' if ok else 'FAIL'}")
++    return ok
++
++
++# full attention: window=(-1,-1) -> SLIDING_WINDOW disabled
++ok_full = check("full   (causal seq0 + bidir seq1, no window)", [-1, -1])
++# sliding window: decoder stores (W-1, 0); kernel symmetrizes non-causal seq
++ok_sw = check("sliding(causal seq0 + bidir seq1, W=4)", [3, 0])
++
++print("ALL PASS" if (ok_full and ok_sw) else "SOME FAILED")
 diff --git a/vllm/_custom_ops.py b/vllm/_custom_ops.py
 index 553513de6..2a4edb703 100644
 --- a/vllm/_custom_ops.py
@@ -371,10 +800,20 @@ index 553513de6..2a4edb703 100644
  
  def convert_fp8(
 diff --git a/vllm/_xpu_ops.py b/vllm/_xpu_ops.py
-index 6a2e5e841..bf22fc452 100644
+index 6a2e5e841..f1966da5f 100644
 --- a/vllm/_xpu_ops.py
 +++ b/vllm/_xpu_ops.py
-@@ -379,7 +379,11 @@ class xpu_ops:
+@@ -365,6 +365,9 @@ class xpu_ops:
+         return_softmax_lse: bool | None = False,
+         s_aux: torch.Tensor | None = None,
+         return_attn_probs: bool | None = False,
++        # Per-sequence causal mask [num_seqs] bool (DiffusionGemma mixed
++        # causal/bidirectional in one launch). None => scalar `causal`.
++        per_seq_causal: torch.Tensor | None = None,
+     ):
+         assert cu_seqlens_k is not None or seqused_k is not None, (
+             "cu_seqlens_k or seqused_k must be provided"
+@@ -379,7 +382,11 @@ class xpu_ops:
              "when block_table is disabled, cu_seqlens_k is needed"
          )
          if out is None:
@@ -387,6 +826,131 @@ index 6a2e5e841..bf22fc452 100644
          real_window_size: tuple[int, int]
          if window_size is None:
              real_window_size = (-1, -1)
+@@ -408,6 +415,7 @@ class xpu_ops:
+             q_descale=q_descale,
+             k_descale=k_descale,
+             v_descale=v_descale,
++            per_seq_causal=per_seq_causal,
+         )
+ 
+     @staticmethod
+diff --git a/vllm/config/__init__.py b/vllm/config/__init__.py
+index b189c45c8..82ab1842f 100644
+--- a/vllm/config/__init__.py
++++ b/vllm/config/__init__.py
+@@ -10,6 +10,7 @@ from vllm.config.compilation import (
+     PassConfig,
+ )
+ from vllm.config.device import DeviceConfig
++from vllm.config.diffusion import DiffusionConfig
+ from vllm.config.ec_transfer import ECTransferConfig
+ from vllm.config.kernel import KernelConfig
+ from vllm.config.kv_events import KVEventsConfig
+@@ -72,6 +73,8 @@ __all__ = [
+     "PassConfig",
+     # From vllm.config.device
+     "DeviceConfig",
++    # From vllm.config.diffusion
++    "DiffusionConfig",
+     # From vllm.config.ec_transfer
+     "ECTransferConfig",
+     # From vllm.config.kernel
+diff --git a/vllm/config/diffusion.py b/vllm/config/diffusion.py
+new file mode 100644
+index 000000000..6f59c40a8
+--- /dev/null
++++ b/vllm/config/diffusion.py
+@@ -0,0 +1,26 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++"""Configuration for discrete diffusion (dLLM) models."""
++
++from pydantic import Field
++
++from vllm.config.utils import config
++
++
++@config
++class DiffusionConfig:
++    """Configuration for discrete diffusion language models (dLLMs).
++
++    dLLMs generate tokens via iterative denoising over a fixed-length canvas
++    rather than left-to-right autoregressive decoding. They reuse the
++    speculative-decoding data path (draft token ids, scheduled spec decode
++    tokens) with overloaded semantics for block-based generation.
++    """
++
++    canvas_length: int = Field(default=None, gt=0)  # type: ignore[assignment]
++    """Length of the denoising canvas (block).  Also determines the number of
++    speculative tokens scheduled per step."""
++
++    max_denoising_steps: int | None = None
++    """Maximum number of denoising iterations per canvas block.
++    If not set, read from the model's generation_config.json."""
+diff --git a/vllm/config/model.py b/vllm/config/model.py
+index 22a1f6a42..a6317ce65 100644
+--- a/vllm/config/model.py
++++ b/vllm/config/model.py
+@@ -1502,6 +1502,11 @@ class ModelConfig:
+         """Extract the HF encoder/decoder model flag."""
+         return is_encoder_decoder(self.hf_config)
+ 
++    @cached_property
++    def is_diffusion(self) -> bool:
++        """Detect discrete diffusion (dLLM) models from HF config."""
++        return getattr(self.hf_config, "canvas_length", None) is not None
++
+     @property
+     def uses_alibi(self) -> bool:
+         cfg = self.hf_text_config
+diff --git a/vllm/config/vllm.py b/vllm/config/vllm.py
+index 53f91e1b6..e50a11b0a 100644
+--- a/vllm/config/vllm.py
++++ b/vllm/config/vllm.py
+@@ -31,6 +31,7 @@ from .attention import AttentionConfig
+ from .cache import CacheConfig
+ from .compilation import CompilationConfig, CompilationMode, CUDAGraphMode
+ from .device import DeviceConfig
++from .diffusion import DiffusionConfig
+ from .ec_transfer import ECTransferConfig
+ from .kernel import KernelConfig
+ from .kv_events import KVEventsConfig
+@@ -299,6 +300,9 @@ class VllmConfig:
+     """LoRA configuration."""
+     speculative_config: SpeculativeConfig | None = None
+     """Speculative decoding configuration."""
++    diffusion_config: DiffusionConfig | None = None
++    """Diffusion LLM (dLLM) configuration."""
++
+     structured_outputs_config: StructuredOutputsConfig = Field(
+         default_factory=StructuredOutputsConfig
+     )
+@@ -474,6 +478,11 @@ class VllmConfig:
+             and self.speculative_config.num_speculative_tokens is not None
+         ):
+             return self.speculative_config.num_speculative_tokens
++        if (
++            self.diffusion_config is not None
++            and self.diffusion_config.canvas_length is not None
++        ):
++            return self.diffusion_config.canvas_length
+         return 0
+ 
+     @property
+@@ -1527,12 +1536,7 @@ class VllmConfig:
+                 self.compilation_config.max_cudagraph_capture_size
+             )
+             if max_cudagraph_capture_size is None:
+-                decode_query_len = 1
+-                if (
+-                    self.speculative_config
+-                    and self.speculative_config.num_speculative_tokens
+-                ):
+-                    decode_query_len += self.speculative_config.num_speculative_tokens
++                decode_query_len = 1 + self.num_speculative_tokens
+                 max_cudagraph_capture_size = min(
+                     self.scheduler_config.max_num_seqs * decode_query_len * 2, 512
+                 )
 diff --git a/vllm/distributed/device_communicators/xpu_communicator.py b/vllm/distributed/device_communicators/xpu_communicator.py
 index 209005c5b..29c731fbc 100644
 --- a/vllm/distributed/device_communicators/xpu_communicator.py
@@ -400,6 +964,94 @@ index 209005c5b..29c731fbc 100644
          dist.all_reduce(output, group=self.device_group)
          return output
  
+diff --git a/vllm/distributed/parallel_state.py b/vllm/distributed/parallel_state.py
+index 58c49c09d..0c21e39f7 100644
+--- a/vllm/distributed/parallel_state.py
++++ b/vllm/distributed/parallel_state.py
+@@ -471,15 +471,16 @@ class GroupCoordinator:
+ 
+         # only cuda uses this function,
+         # so we don't abstract it into the base class
++        # NOTE(xpu-graph): the custom all-reduce graph-capture hook only
++        # exists on CUDA's CudaCommunicator. XPU (xccl) and other backends do
++        # not have a ``ca_comm``; instead of asserting CudaCommunicator (which
++        # blocked multi-card XPU graph capture entirely), softly probe for the
++        # hook and fall back to a no-op context. (ported from xy ptl-poc)
+         maybe_ca_context = nullcontext()
+         maybe_aiter_context = nullcontext()
+-        from vllm.distributed.device_communicators.cuda_communicator import (
+-            CudaCommunicator,
+-        )
+ 
+         if self.device_communicator is not None:
+-            assert isinstance(self.device_communicator, CudaCommunicator)
+-            ca_comm = self.device_communicator.ca_comm
++            ca_comm = getattr(self.device_communicator, "ca_comm", None)
+             if ca_comm is not None:
+                 maybe_ca_context = ca_comm.capture()  # type: ignore
+ 
+diff --git a/vllm/engine/arg_utils.py b/vllm/engine/arg_utils.py
+index e65ef6e42..87453a56a 100644
+--- a/vllm/engine/arg_utils.py
++++ b/vllm/engine/arg_utils.py
+@@ -38,6 +38,7 @@ from vllm.config import (
+     CompilationConfig,
+     ConfigType,
+     DeviceConfig,
++    DiffusionConfig,
+     ECTransferConfig,
+     EPLBConfig,
+     KernelConfig,
+@@ -599,6 +600,7 @@ class EngineArgs:
+     reasoning_parser_plugin: str | None = None
+ 
+     speculative_config: dict[str, Any] | None = None
++    diffusion_config: dict[str, Any] | None = None
+ 
+     show_hidden_metrics_for_version: str | None = (
+         ObservabilityConfig.show_hidden_metrics_for_version
+@@ -1416,6 +1418,10 @@ class EngineArgs:
+         vllm_group.add_argument(
+             "--speculative-config", "-sc", **vllm_kwargs["speculative_config"]
+         )
++        vllm_kwargs["diffusion_config"]["type"] = optional_type(json.loads)
++        vllm_group.add_argument(
++            "--diffusion-config", "-dc", **vllm_kwargs["diffusion_config"]
++        )
+         vllm_group.add_argument(
+             "--kv-transfer-config", **vllm_kwargs["kv_transfer_config"]
+         )
+@@ -1633,6 +1639,14 @@ class EngineArgs:
+         )
+         return SpeculativeConfig(**self.speculative_config)
+ 
++    def create_diffusion_config(self) -> DiffusionConfig | None:
++        if self.diffusion_config is None:
++            return None
++        cfg = self.diffusion_config
++        if isinstance(cfg, str):
++            cfg = json.loads(cfg)
++        return DiffusionConfig(**cfg)
++
+     def create_engine_config(
+         self,
+         usage_context: UsageContext | None = None,
+@@ -1946,6 +1960,7 @@ class EngineArgs:
+             target_model_config=model_config,
+             target_parallel_config=parallel_config,
+         )
++        diffusion_config = self.create_diffusion_config()
+ 
+         self._set_default_max_num_seqs_and_batched_tokens_args(
+             usage_context,
+@@ -2169,6 +2184,7 @@ class EngineArgs:
+             kernel_config=kernel_config,
+             lora_config=lora_config,
+             speculative_config=speculative_config,
++            diffusion_config=diffusion_config,
+             structured_outputs_config=self.structured_outputs_config,
+             observability_config=observability_config,
+             compilation_config=compilation_config,
 diff --git a/vllm/envs.py b/vllm/envs.py
 index ded474dc0..7a29d18c0 100755
 --- a/vllm/envs.py
@@ -434,22 +1086,36 @@ index ded474dc0..7a29d18c0 100755
  
  
 diff --git a/vllm/model_executor/kernels/linear/scaled_mm/xpu.py b/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
-index 6d75a420e..db38290d8 100644
+index 6d75a420e..146cf77cc 100644
 --- a/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
 +++ b/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
-@@ -9,6 +9,11 @@ from vllm.model_executor.kernels.linear import (  # noqa: E501
+@@ -9,6 +9,13 @@ from vllm.model_executor.kernels.linear import (  # noqa: E501
      FP8ScaledMMLinearKernel,
      FP8ScaledMMLinearLayerConfig,
  )
 +from vllm.model_executor.layers.esimd_utils import (
 +    ESIMD_AVAILABLE,
 +    disable_esimd_gemv,
++    disable_esimd_gemm,
 +    esimd_gemv_fp8_pert,
++    esimd_gemm_fp8_pert,
 +)
  from vllm.model_executor.layers.quantization.utils.quant_utils import (
      kFp8StaticChannelSym,
      kFp8StaticTensorSym,
-@@ -46,6 +51,14 @@ class XPUFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
+@@ -16,6 +23,11 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
+ from vllm.model_executor.utils import replace_parameter
+ from vllm.platforms import current_platform
+ 
++# Upper bound on the decode batch (M) that takes the ESIMD GEMM fast path. Keeps
++# the path scoped to decode-shaped work (matches the GDN-core / attn decode
++# buffers which are sized for 128); prefill (M in the thousands) stays on onednn.
++_ESIMD_GEMM_MAX_M = 128
++
+ 
+ class XPUFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
+     @classmethod
+@@ -46,6 +58,14 @@ class XPUFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
          self.layer_param_names = layer_param_names
  
      def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
@@ -464,7 +1130,7 @@ index 6d75a420e..db38290d8 100644
          replace_parameter(layer, "weight", layer.weight.data.t())
  
      def apply_weights(
-@@ -54,9 +67,35 @@ class XPUFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
+@@ -54,9 +74,58 @@ class XPUFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
          x: torch.Tensor,
          bias: torch.Tensor | None = None,
      ) -> torch.Tensor:
@@ -497,17 +1163,259 @@ index 6d75a420e..db38290d8 100644
 +            esimd_gemv_fp8_pert(x, weight, weight_scale, out)
 +            return out
 +
++        # ESIMD GEMM decode fast path (2 <= M <= 128, per-tensor, no bias).
++        # Same [out, in] contiguous weight + scalar scale as the GEMV path, so it
++        # too runs copy-free. K must be a multiple of 128: the kernel has no tail
++        # handling, so non-aligned K (e.g. gemma4's 1056/704) would read garbage
++        # -- gate it out and let those fall through to onednn. Covers every M>1
++        # FP8 proj (qkv/o/in_proj_qkvz/in_proj_ba/MoE shared-expert/dense-MLP),
++        # since v0.21.0 routes all of them through this one Linear kernel.
++        # x must be fp16 (the kernel's only supported activation dtype).
++        if (
++            ESIMD_AVAILABLE
++            and not disable_esimd_gemm()
++            and bias is None
++            and 2 <= x.shape[0] <= _ESIMD_GEMM_MAX_M
++            and x.dtype == torch.float16
++            and weight_scale.numel() == 1
++            and weight.shape[1] % 128 == 0
++        ):
++            M = x.shape[0]
++            N = weight.shape[0]
++            out = torch.empty(M, N, dtype=torch.float16, device=x.device)
++            esimd_gemm_fp8_pert(x, weight, weight_scale, out)
++            return out
++
 +        # gemm wants [in, out]; weight is [out, in] -> zero-copy transposed view.
 +        return torch.ops._xpu_C.fp8_gemm_w8a16(x, weight.t(), weight_scale, bias)
  
      def apply_scaled_mm(
          self,
+diff --git a/vllm/model_executor/layers/activation.py b/vllm/model_executor/layers/activation.py
+index d5b67ef04..872d2b3ff 100644
+--- a/vllm/model_executor/layers/activation.py
++++ b/vllm/model_executor/layers/activation.py
+@@ -369,6 +369,30 @@ class GeluAndMul(CustomOp):
+         return out
+ 
+     def forward_xpu(self, x: torch.Tensor) -> torch.Tensor:
++        # ESIMD fast path for tanh-approximation GELU on XPU. Uses the same
++        # esimd_moe_gelu_tanh_mul op as the FusedMoE activation path
++        # (commit eef4cbf2e), but here we apply it to the dense-MLP module so
++        # the gemma4 / phi-3 / glm-4 fp8 dense paths skip the _C dispatch +
++        # PyTorch GELU launch overhead. Constraint: contiguous input + the
++        # output dim N_half is a multiple of 64 (kernel SIMD width).
++        if self.approximate == "tanh" and x.is_contiguous():
++            d = x.shape[-1] // 2
++            # NaN guard for large d (e.g. gemma4-31B intermediate=21504 / TP=2
++            # → d=10752 produces NaN logits in this kernel). Verified safe:
++            # gemma4-26B dense MLP d=1056. DISABLE_GEMMA4_GELU_ESIMD=1
++            # disables this fast path entirely.
++            import os as _os
++            if (d % 64 == 0 and d <= 4096
++                    and _os.environ.get("DISABLE_GEMMA4_GELU_ESIMD", "0") != "1"):
++                try:
++                    from custom_esimd_kernels_vllm import esimd_moe_gelu_tanh_mul
++                    output_shape = x.shape[:-1] + (d,)
++                    out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
++                    n_rows = int(x.numel() // x.shape[-1])
++                    esimd_moe_gelu_tanh_mul(x, out, x.shape[-1], d, n_rows)
++                    return out
++                except ImportError:
++                    pass
+         return self.forward_cuda(x)
+ 
+     def extra_repr(self) -> str:
+diff --git a/vllm/model_executor/layers/esimd_fake_ops.py b/vllm/model_executor/layers/esimd_fake_ops.py
+new file mode 100644
+index 000000000..d2f68abb7
+--- /dev/null
++++ b/vllm/model_executor/layers/esimd_fake_ops.py
+@@ -0,0 +1,178 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++"""Fake (meta) implementations for the external ``custom_esimd_kernels_vllm``
++ops so they can be traced by ``torch.compile`` (XPU graph mode, i.e. running
++*without* ``--enforce-eager``).
++
++Background
++----------
++The ESIMD kernels are registered in C++ (TORCH_LIBRARY) with an XPU impl only.
++``torch.compile`` traces the model graph with fake/meta tensors; an op with no
++fake/meta kernel raises::
++
++    NotImplementedError: custom_esimd_kernels_vllm::esimd_qkv_split_norm_rope_v:
++    attempted to run this operator with Meta tensors, but there was no fake impl
++    or Meta kernel registered.
++
++Registering a fake (a pure-Python shape/dtype propagation function) lets dynamo
++build the graph. This mirrors how vLLM registers fakes for its own XPU ops
++(see ``vllm/_xpu_ops.py``) and the sglang approach.
++
++⚠️ Mutation caveat (read before trusting output)
++-------------------------------------------------
++Most of these ops follow a "write into a preallocated output buffer, ignore the
++return value" pattern (e.g. ``esimd_qkv_split_norm_rope_v`` writes q/k/v and the
++caller reads those buffers). The C++ schemas declare those buffers as plain
++``Tensor`` (no ``(a!)`` mutation annotation) and the void ops as ``-> ()``.
++Under torch.compile functionalization, an op declared side-effect-free whose
++result is unused is a candidate for dead-code elimination -- which would leave
++the output buffers uninitialised (garbage / empty output).
++
++Registering a fake is therefore necessary but NOT sufficient for correctness.
++We additionally pin the op as having side effects via the fake returning the
++buffer alias where the real kernel does, but the proper fix is to re-declare the
++schemas with ``(a!)`` mutation annotations (requires a C++ rebuild) or wrap them
++as Python custom ops with ``mutates_args``. Until then, VERIFY output end-to-end
++(GSM8K / direct compare vs eager) -- do not assume graph mode is correct just
++because it runs.
++
++This module is import-safe and idempotent: it no-ops if the package is missing
++and guards against double registration.
++"""
++
++import torch
++
++from vllm.logger import init_logger
++
++logger = init_logger(__name__)
++
++_REGISTERED = False
++
++
++def _try_register(qualname: str, fn) -> None:
++    """Register a fake impl, tolerating ops that are absent (different kernel
++    build) or already have a fake registered."""
++    try:
++        torch.library.register_fake(qualname, fn)
++    except Exception as exc:  # noqa: BLE001 - best-effort, log and continue
++        logger.debug("esimd fake registration skipped for %s: %s", qualname, exc)
++
++
++def register_esimd_fakes() -> None:
++    """Register fake/meta impls for the ESIMD ops reachable from the
++    torch.compile'd model graph. Safe to call multiple times."""
++    global _REGISTERED
++    if _REGISTERED:
++        return
++    _REGISTERED = True
++
++    NS = "custom_esimd_kernels_vllm"
++
++    # --- Fused QKV split + RMSNorm + RoPE -----------------------------------
++    # Mutates q_out/gate_out/k_out/v_out in place; void return (schema declares
++    # (a!)..(d!) + -> ()). The fake just propagates nothing.
++    def _qkv_split_norm_rope(qkv_state, q_out, gate_out, k_out, v_out,
++                             norm_wq, norm_wk, positions,
++                             q_heads, kv_heads, attn_output_gate,
++                             rotary_dim, cos_sin_cache):
++        return None
++
++    def _qkv_split_norm_rope_v(qkv_state, q_out, gate_out, k_out, v_out,
++                               norm_wq, norm_wk, norm_wv, positions,
++                               q_heads, kv_heads, attn_output_gate,
++                               rotary_dim, cos_sin_cache):
++        return None
++
++    _try_register(f"{NS}::esimd_qkv_split_norm_rope", _qkv_split_norm_rope)
++    _try_register(f"{NS}::esimd_qkv_split_norm_rope_v", _qkv_split_norm_rope_v)
++
++    # --- RMSNorm family ------------------------------------------------------
++    # esimd_rms_norm(input, output, weight, eps) -> output
++    _try_register(f"{NS}::esimd_rms_norm",
++                  lambda input, output, weight, eps: torch.empty_like(output))
++    # esimd_fused_add_rms_norm(hidden_states, residual, weight, eps)
++    #   -> hidden_states (residual also updated in place)
++    _try_register(f"{NS}::esimd_fused_add_rms_norm",
++                  lambda hidden_states, residual, weight, eps:
++                  torch.empty_like(hidden_states))
++    _try_register(f"{NS}::esimd_fused_add_rms_norm_batched",
++                  lambda hidden_states, residual, weight, eps:
++                  torch.empty_like(hidden_states))
++    # esimd_fused_scaled_add_rms_norm(h, r, w, eps, scalar) -> hidden_states
++    _try_register(f"{NS}::esimd_fused_scaled_add_rms_norm",
++                  lambda hidden_states, residual, weight, eps, scalar:
++                  torch.empty_like(hidden_states))
++    # esimd_rms_norm_gated(x, z, weight, output, eps) -> output
++    _try_register(f"{NS}::esimd_rms_norm_gated",
++                  lambda x, z, weight, output, eps: torch.empty_like(output))
++
++    # --- Fused norm + GEMV combos (void: -> ()) ------------------------------
++    # esimd_norm_gemv_norm_fp16(residual, scale_with_root, proj_w, pre_ff_w,
++    #                           router_logits, moe_input, eps) -> ()
++    _try_register(f"{NS}::esimd_norm_gemv_norm_fp16",
++                  lambda residual, scale_with_root, proj_w, pre_ff_w,
++                  router_logits, moe_input, eps: None)
++    # esimd_norm_add_norm(h2_raw, h1, w1, w2, out, eps1, eps2) -> ()
++    _try_register(f"{NS}::esimd_norm_add_norm",
++                  lambda h2_raw, h1, w1, w2, out, eps1, eps2: None)
++
++    # --- Decode GEMV / GEMM --------------------------------------------------
++    # esimd_gemv_fp16(input, weight, output) -> output
++    _try_register(f"{NS}::esimd_gemv_fp16",
++                  lambda input, weight, output: torch.empty_like(output))
++    # esimd_gemv_fp8_pert(input, weight, weight_scale, output) -> output
++    _try_register(f"{NS}::esimd_gemv_fp8_pert",
++                  lambda input, weight, weight_scale, output:
++                  torch.empty_like(output))
++    # esimd_gemm_fp8_pert(input, weight, weight_scale, output) -> output
++    _try_register(f"{NS}::esimd_gemm_fp8_pert",
++                  lambda input, weight, weight_scale, output:
++                  torch.empty_like(output))
++
++    # --- MoE auxiliary -------------------------------------------------------
++    # esimd_moe_topk(router_logits, top_values, top_indices, T) -> top_values
++    _try_register(f"{NS}::esimd_moe_topk",
++                  lambda router_logits, top_values, top_indices, T:
++                  torch.empty_like(top_values))
++
++    # --- moe_ops namespace (gemma4 fused MoE) --------------------------------
++    # These are M==1 (decode) gated, so the M=256 diffusion canvas trace should
++    # not hit them -- registered defensively so a future M==1 compiled path or
++    # a different config does not crash tracing.
++    MOE = "moe_ops"
++    # moe_topk(logits, top_k, norm) -> (topk_idx int32, topk_weight fp16)
++    def _moe_topk(logits, top_k, norm):
++        n = logits.shape[0]
++        idx = logits.new_empty((n, top_k), dtype=torch.int32)
++        wts = logits.new_empty((n, top_k), dtype=torch.float16)
++        return idx, wts
++    _try_register(f"{MOE}::moe_topk", _moe_topk)
++
++    # gelu_tanh fused forwards: out is [n_tokens, hidden] like x.
++    _try_register(f"{MOE}::moe_forward_full_gelu_tanh_routed",
++                  lambda x, topk_weights, topk_indices, gate_up_weight,
++                  gate_up_scale, down_weight, down_scale, top_k,
++                  n_routed_experts: torch.empty_like(x))
++    _try_register(f"{MOE}::moe_forward_full_gelu_tanh_routed_decode",
++                  lambda x, topk_weights, topk_indices, gate_up_weight,
++                  gate_up_scale, down_weight, down_scale, top_k,
++                  n_routed_experts: torch.empty_like(x))
++    _try_register(f"{MOE}::moe_forward_full_gelu_tanh_decode",
++                  lambda x, logits, gate_up_weight, gate_up_scale, down_weight,
++                  down_scale, per_expert_scale, top_k, n_routed_experts:
++                  torch.empty_like(x))
++    # moe_up_fp8_grouped -> [n_tokens*top_k, intermediate] (=gate_up_weight.size(1)//2)
++    _try_register(
++        f"{MOE}::moe_up_fp8_grouped",
++        lambda x, gate_up_weight, gate_up_scale, expert_offsets, expert_tokens,
++        top_k, n_routed_experts: x.new_empty(
++            (x.shape[0] * top_k, gate_up_weight.shape[1] // 2)))
++    # moe_down_fp8_grouped -> [n_tokens*top_k, hidden] (=down_weight.size(1))
++    _try_register(
++        f"{MOE}::moe_down_fp8_grouped",
++        lambda intermediate, down_weight, down_scale, routing_weights,
++        expert_offsets, expert_tokens, top_k, n_routed_experts:
++        intermediate.new_empty((intermediate.shape[0], down_weight.shape[1])))
++
++    logger.info_once("Registered fake impls for custom_esimd_kernels_vllm / "
++                     "moe_ops ops (torch.compile / XPU graph support).")
 diff --git a/vllm/model_executor/layers/esimd_utils.py b/vllm/model_executor/layers/esimd_utils.py
 new file mode 100644
-index 000000000..43dce8d29
+index 000000000..046f8a36c
 --- /dev/null
 +++ b/vllm/model_executor/layers/esimd_utils.py
-@@ -0,0 +1,89 @@
+@@ -0,0 +1,269 @@
 +# SPDX-License-Identifier: Apache-2.0
 +# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 +"""Shared infrastructure for the XPU ESIMD decode fast paths (Feature 1a).
@@ -544,6 +1452,14 @@ index 000000000..43dce8d29
 +    _esimd = None
 +    ESIMD_AVAILABLE = False
 +
++# Register fake/meta impls so the ESIMD ops can be traced by torch.compile
++# (XPU graph mode, i.e. running without --enforce-eager). No-op if the package
++# is missing. See esimd_fake_ops for the mutation-correctness caveat.
++if ESIMD_AVAILABLE:
++    from vllm.model_executor.layers.esimd_fake_ops import register_esimd_fakes
++
++    register_esimd_fakes()
++
 +
 +# --------------------------------------------------------------------------- #
 +# 2. Per-feature DISABLE_<FEATURE> switches (read once, cached).
@@ -556,6 +1472,32 @@ index 000000000..43dce8d29
 +_DISABLE_ESIMD_GEMV = _env_disabled("DISABLE_ESIMD_GEMV")
 +# Fused RMSNorm / gated-RMSNorm decode fast path in layernorm.py.
 +_DISABLE_ESIMD_NORM = _env_disabled("DISABLE_ESIMD_NORM")
++# FP8 M>1 GEMM short-circuit (BSZ 2-64 decode).
++_DISABLE_ESIMD_GEMM = _env_disabled("DISABLE_ESIMD_GEMM")
++# Fused RMSNormGated + out_proj GEMV decode fast path in the GDN attention
++# (gdn_linear_attn.py) Part-3 output projection.
++_DISABLE_ESIMD_GDN_OUTPROJ = _env_disabled("DISABLE_ESIMD_GDN_OUTPROJ")
++# Fused QKV split + q/k RMSNorm + RoPE (+ sigmoid gate) in Qwen3NextAttention.
++_DISABLE_ESIMD_QKV = _env_disabled("DISABLE_ESIMD_QKV")
++# Fused conv1d + GDN delta-rule decode core in GatedDeltaNetAttention (Part 2).
++_DISABLE_ESIMD_GDN_CONV = _env_disabled("DISABLE_ESIMD_GDN_CONV")
++# Fused MoE decode (topk + up + down + finalize) in Qwen3NextSparseMoeBlock.
++_DISABLE_ESIMD_MOE = _env_disabled("DISABLE_ESIMD_MOE")
++# Fused residual-add + post_attn RMSNorm + router GEMV for MoE decode, in the
++# Qwen3NextDecoderLayer (precomputes router logits for the SparseMoeBlock).
++_DISABLE_ESIMD_MOE_NORM = _env_disabled("DISABLE_ESIMD_MOE_NORM")
++# Fused dual-GEMV for GDN in_proj_qkvz + in_proj_ba (Part 1).
++_DISABLE_ESIMD_GDN_PROJ = _env_disabled("DISABLE_ESIMD_GDN_PROJ")
++# Fused residual-add + input RMSNorm + GDN in_proj dual-GEMV in the
++# Qwen3NextDecoderLayer (folds input_layernorm into the GDN Part-1 dual-GEMV).
++_DISABLE_ESIMD_GDN_INPUT_NORM = _env_disabled("DISABLE_ESIMD_GDN_INPUT_NORM")
++# Fused residual-add + input RMSNorm + attention qkv_proj GEMV in the
++# Qwen3NextDecoderLayer (folds input_layernorm into the full-attn qkv GEMV).
++_DISABLE_ESIMD_ATTN_INPUT_NORM = _env_disabled("DISABLE_ESIMD_ATTN_INPUT_NORM")
++# ESIMD paged-attention decode in flash_attn.py.
++_DISABLE_ESIMD_PA = _env_disabled("DISABLE_ESIMD_PA")
++# INT4 ESIMD GEMV for sym_int4 decode (M==1) in GDN/Attention projections.
++_DISABLE_ESIMD_INT4 = _env_disabled("DISABLE_ESIMD_INT4")
 +
 +
 +def disable_esimd_gemv() -> bool:
@@ -564,6 +1506,50 @@ index 000000000..43dce8d29
 +
 +def disable_esimd_norm() -> bool:
 +    return _DISABLE_ESIMD_NORM
++
++
++def disable_esimd_gemm() -> bool:
++    return _DISABLE_ESIMD_GEMM
++
++
++def disable_esimd_gdn_outproj() -> bool:
++    return _DISABLE_ESIMD_GDN_OUTPROJ
++
++
++def disable_esimd_qkv() -> bool:
++    return _DISABLE_ESIMD_QKV
++
++
++def disable_esimd_gdn_conv() -> bool:
++    return _DISABLE_ESIMD_GDN_CONV
++
++
++def disable_esimd_moe() -> bool:
++    return _DISABLE_ESIMD_MOE
++
++
++def disable_esimd_moe_norm() -> bool:
++    return _DISABLE_ESIMD_MOE_NORM
++
++
++def disable_esimd_gdn_proj() -> bool:
++    return _DISABLE_ESIMD_GDN_PROJ
++
++
++def disable_esimd_gdn_input_norm() -> bool:
++    return _DISABLE_ESIMD_GDN_INPUT_NORM
++
++
++def disable_esimd_attn_input_norm() -> bool:
++    return _DISABLE_ESIMD_ATTN_INPUT_NORM
++
++
++def disable_esimd_pa() -> bool:
++    return _DISABLE_ESIMD_PA
++
++
++def disable_esimd_int4() -> bool:
++    return _DISABLE_ESIMD_INT4
 +
 +
 +# --------------------------------------------------------------------------- #
@@ -591,12 +1577,142 @@ index 000000000..43dce8d29
 +    # read incorrectly by the kernel, so weight must be passed as the contiguous
 +    # [out, in] tensor. (Calibrated vs fp8_gemm_w8a16 on XPU, rel_err ~1.9e-4.)
 +    esimd_gemv_fp8_pert = _esimd.esimd_gemv_fp8_pert
++    esimd_gemm_fp8_pert = _esimd.esimd_gemm_fp8_pert
 +    esimd_fused_add_rms_norm = _esimd.esimd_fused_add_rms_norm
++    # Batched residual-add + RMSNorm(Gemma w+1), in place: residual += hidden,
++    # hidden = rmsnorm(residual) * norm_w. The decode (M==1) norm v0.14.0 pairs
++    # with a plain GEMV instead of folding norm into the GEMV -- profiled faster
++    # than the esimd_resadd_norm_gemv* fused kernels at the large in_proj/qkv
++    # output dims (the fusion regresses there).
++    esimd_fused_add_rms_norm_batched = _esimd.esimd_fused_add_rms_norm_batched
++    esimd_fused_scaled_add_rms_norm = _esimd.esimd_fused_scaled_add_rms_norm
++    esimd_rms_norm = _esimd.esimd_rms_norm
 +    esimd_rms_norm_gated = _esimd.esimd_rms_norm_gated
++    esimd_norm_gemv_norm_fp16 = _esimd.esimd_norm_gemv_norm_fp16
++    # Fused RMSNormGated + per-tensor FP8 GEMV for the GDN out_proj decode tail.
++    # x/z are [HV, V] fp16, gemv_weight is FP8 [N, K=HV*V], gemv_scale is a
++    # scalar fp32, output is [1, N] fp16. Replaces the norm + rearrange +
++    # out_proj.apply 3-step tail with one kernel.
++    esimd_norm_gemv_fp8_pert = _esimd.esimd_norm_gemv_fp8_pert
++    # Fused QKV split + q/k GemmaRMSNorm(weight+1, eps=1e-6) + NeoX partial RoPE
++    # + sigmoid gate. headDim=256 only; reads rotary_emb.cos_sin_cache directly
++    # ([max_pos, rotary_dim] fp16, [cos||sin] per row). Plain-RoPE only -- caller
++    # must gate on positions.ndim == 1 (text); multimodal (3, n) needs the
++    # upstream mRoPE section remap which this kernel cannot express.
++    esimd_qkv_split_norm_rope = _esimd.esimd_qkv_split_norm_rope
++    # Fused conv1d + GDN delta-rule decode core. One kernel replaces the
++    # v0.21.0 decode path's causal_conv1d + gated_delta_rule (2 launches + 6
++    # tensor allocs). Reads projected qkvz/ba directly, writes core_attn_out +
++    # z_out. fp16 A_log/dt_bias/conv_weight/conv_bias expected; SD conv_state.
++    # Two variants, SAME signature, differing only in the in_proj_qkvz packing
++    # the kernel unpacks internally: ``esimd_gdn_conv_fused`` for the
++    # interleaved-GQA layout (Qwen3-Next, gqa_interleaved_layout=True);
++    # ``esimd_gdn_conv_fused_seq`` for the sequential [q|k|v|z] layout
++    # (Qwen3.5/3.6, gqa_interleaved_layout=False).
++    esimd_gdn_conv_fused = _esimd.esimd_gdn_conv_fused
++    esimd_gdn_conv_fused_seq = _esimd.esimd_gdn_conv_fused_seq
++    # Fused MoE decode: topk + routed up/down + shared expert + finalize in one
++    # call. moe_forward_full is the BSZ=1-optimal (down_finalize) path;
++    # moe_forward_full_v2 is the BSZ>1 standalone-down path. Both dispatch e4m3/
++    # e5m2 on the weight dtype (e4m3 finalize added for v0.21.0). Weights are
++    # consumed in their native v0.21.0 layout (w13 [E,hidden,2*inter], w2
++    # [E,inter,hidden], scale [E]) -- no transpose needed.
++    moe_forward_full = _esimd.moe_forward_full
++    moe_forward_full_v2 = _esimd.moe_ops.moe_forward_full_v2
++    # Fused FP8 GEMV for two weight matrices sharing one input (per-tensor
++    # scale). Used to fuse GDN's in_proj_qkvz + in_proj_ba into one launch.
++    # Both weights [N, K] contiguous, scalar fp32 scale, separate outputs.
++    esimd_gemv_fp8_pert_fused2 = _esimd.esimd_gemv_fp8_pert_fused2
++    # Fused residual-add + RMSNorm(Gemma w+1) + 2-matrix per-tensor FP8 GEMV.
++    # Folds the GDN layer's input_layernorm (residual-add + RMSNorm) into the
++    # Part-1 dual input projection: residual += hidden (in-place), normed =
++    # rmsnorm(residual)*norm_w, then two GEMVs (in_proj_qkvz, in_proj_ba) off
++    # the normed hidden. norm_weight is [K] fp16 (w+1 pre-applied); w0/w1 are
++    # FP8 [N,K] with scalar fp32 scales s0/s1; o0/o1 are [1,N*] fp16 outputs.
++    esimd_resadd_norm_gemv2_fp8_pert = _esimd.esimd_resadd_norm_gemv2_fp8_pert
++    # Fused residual-add + RMSNorm(Gemma w+1) + per-tensor FP8 GEMV. Folds the
++    # MoE layer's post_attention_layernorm and the router (gate) GEMV into one
++    # kernel: residual += hidden (in-place), normed = rmsnorm(residual)*norm_w,
++    # output = normed @ dequant(gemv_weight^T)*scale, normed_out = normed.
++    # hidden_states/residual/normed_out are [1, K] fp16, norm_weight is [K] fp16
++    # (w+1 pre-applied), gemv_weight is FP8 [N, K] with scalar fp32 scale,
++    # output is [1, N] fp16 router logits. Lets the SparseMoeBlock skip its
++    # own gate GEMV (consumes the precomputed logits + normed hidden).
++    esimd_resadd_norm_gemv_fp8_pert = _esimd.esimd_resadd_norm_gemv_fp8_pert
++    # ESIMD paged-attention decode (head_dim=256, max_query_len==1). Signature
++    # (9 args; the trailing k_scale/v_scale were added with fp8 KV support):
++    # page_attn_decode(q, kv_cache, block_table, seqused_k, out, 1, max_seq_len,
++    #                  k_scale, v_scale).
++    # fp16 KV passes k_scale=v_scale=1.0; fp8 KV passes layer._k_scale/_v_scale
++    # and a kv_cache reinterpreted to the writer's fp8 dtype. Requires GQA ratio
++    # >= 4 (q heads per kv head); 2..3 needs padding to 4.
++    page_attn_decode = _esimd.eagle_ops.page_attn_decode
++    # INT4 per-group decode GEMV. weight is [N, K/2] uint8 (packed int4),
++    # weight_scale is [N, K/128] fp16, input [1, K] fp16, output [1, N] fp16.
++    esimd_gemv_int4 = _esimd.esimd_gemv_int4
++    # Fused 2-matrix INT4 GEMV (shared input, two outputs). Saves one kernel
++    # launch. Used for GDN in_proj_qkvz + in_proj_ba.
++    esimd_gemv_int4_fused2 = _esimd.esimd_gemv_int4_fused2
++    # INT4 GEMM for M>=2 (complements esimd_gemv_int4 for M=1).
++    esimd_gemm_int4_pgrp = _esimd.esimd_gemm_int4_pgrp
++    # Fused RMSNormGated + INT4 GEMV for GDN out_proj decode. INT4 analogue
++    # of esimd_norm_gemv_fp8_pert. Weight is [N, K/8] int32, scale [N, K/128].
++    esimd_norm_gemv_int4_pert = _esimd.esimd_norm_gemv_int4_pert
++    # Fused residual-add + RMSNorm + INT4 GEMV. Combines post_attn_layernorm
++    # + router/dense-MLP GEMV. Weight is [N, K/8] int32, scale [N, K/128].
++    esimd_resadd_norm_gemv_int4_pert = _esimd.esimd_resadd_norm_gemv_int4_pert
 +else:
 +    esimd_gemv_fp8_pert = None
++    esimd_gemm_fp8_pert = None
 +    esimd_fused_add_rms_norm = None
++    esimd_fused_add_rms_norm_batched = None
++    esimd_fused_scaled_add_rms_norm = None
++    esimd_rms_norm = None
 +    esimd_rms_norm_gated = None
++    esimd_norm_gemv_norm_fp16 = None
++    esimd_norm_gemv_fp8_pert = None
++    esimd_qkv_split_norm_rope = None
++    esimd_gdn_conv_fused = None
++    esimd_gdn_conv_fused_seq = None
++    moe_forward_full = None
++    moe_forward_full_v2 = None
++    esimd_gemv_fp8_pert_fused2 = None
++    esimd_resadd_norm_gemv2_fp8_pert = None
++    esimd_resadd_norm_gemv_fp8_pert = None
++    page_attn_decode = None
++    esimd_gemv_int4 = None
++    esimd_gemv_int4_fused2 = None
++    esimd_gemm_int4_pgrp = None
++    esimd_norm_gemv_int4_pert = None
++    esimd_resadd_norm_gemv_int4_pert = None
+diff --git a/vllm/model_executor/layers/fused_moe/activation.py b/vllm/model_executor/layers/fused_moe/activation.py
+index b2e67e622..ff9bac521 100644
+--- a/vllm/model_executor/layers/fused_moe/activation.py
++++ b/vllm/model_executor/layers/fused_moe/activation.py
+@@ -126,7 +126,22 @@ def apply_moe_activation(
+     elif activation == MoEActivation.GELU:
+         torch.ops._C.gelu_and_mul(output, input)
+     elif activation == MoEActivation.GELU_TANH:
+-        torch.ops._C.gelu_tanh_and_mul(output, input)
++        # XPU ESIMD fast path for MoE gelu_tanh activation
++        from vllm.platforms import current_platform
++        if current_platform.is_xpu() and input.is_contiguous() and output.is_contiguous():
++            try:
++                from custom_esimd_kernels_vllm import esimd_moe_gelu_tanh_mul
++                N_gate_up = input.size(-1)
++                N_half = output.size(-1)
++                total_rows = input.size(0)
++                if N_half % 64 == 0:
++                    esimd_moe_gelu_tanh_mul(input, output, N_gate_up, N_half, total_rows)
++                else:
++                    torch.ops._C.gelu_tanh_and_mul(output, input)
++            except ImportError:
++                torch.ops._C.gelu_tanh_and_mul(output, input)
++        else:
++            torch.ops._C.gelu_tanh_and_mul(output, input)
+     elif activation == MoEActivation.SWIGLUOAI:
+         torch.ops._C.swigluoai_and_mul(output, input)
+     elif activation == MoEActivation.SWIGLUSTEP:
 diff --git a/vllm/model_executor/layers/fused_moe/experts/xpu_moe.py b/vllm/model_executor/layers/fused_moe/experts/xpu_moe.py
 index d6bd2b140..7ba577856 100644
 --- a/vllm/model_executor/layers/fused_moe/experts/xpu_moe.py
@@ -664,7 +1780,7 @@ index d6bd2b140..7ba577856 100644
  
  
 diff --git a/vllm/model_executor/layers/fused_moe/modular_kernel.py b/vllm/model_executor/layers/fused_moe/modular_kernel.py
-index 135a677ff..65b4e137a 100644
+index 135a677ff..437f47b3a 100644
 --- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
 +++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
 @@ -1398,6 +1398,35 @@ class FusedMoEKernelModularImpl:
@@ -680,7 +1796,7 @@ index 135a677ff..65b4e137a 100644
 +            # Only DP <=1 can go this path, cause
 +            # prepare/finalize handles the AllGather/ReduceScatter needed
 +            # to gather/dispatch tokens across DP ranks.
-+            if dp_size <= 1:
++            if dp_size <= 1 and self.fused_experts.expects_unquantized_inputs:
 +                self.fused_experts.apply(
 +                    output=output,
 +                    hidden_states=hidden_states,
@@ -751,6 +1867,760 @@ index 37b15ed40..ad283db37 100644
  
          # Apply transform for routed experts (e.g., latent projection
          # for latent MoE)
+diff --git a/vllm/model_executor/layers/layernorm.py b/vllm/model_executor/layers/layernorm.py
+index a5d4e4db7..a9f1eaa09 100644
+--- a/vllm/model_executor/layers/layernorm.py
++++ b/vllm/model_executor/layers/layernorm.py
+@@ -13,9 +13,20 @@ from vllm.config import get_current_vllm_config
+ from vllm.logger import init_logger
+ from vllm.model_executor.custom_op import CustomOp
+ from vllm.model_executor.layers.batch_invariant import rms_norm_batch_invariant
++from vllm.model_executor.layers.esimd_utils import (
++    ESIMD_AVAILABLE,
++    disable_esimd_norm,
++    esimd_fused_add_rms_norm,
++    esimd_fused_add_rms_norm_batched,
++)
+ 
+ logger = init_logger(__name__)
+ 
++# Upper bound on the decode batch (M) that takes the batched ESIMD fused
++# residual-add + RMSNorm path (matches the GDN-core / attn / MoE decode batch
++# caps of 128). Prefill (M in the thousands) stays on forward_native.
++_ESIMD_NORM_MAX_M = 128
++
+ 
+ def poly_norm(
+     x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor, variance_epsilon: float
+@@ -177,6 +188,38 @@ class GemmaRMSNorm(CustomOp):
+     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+         return self.forward_native(x, residual)
+ 
++    def forward_xpu(
++        self,
++        x: torch.Tensor,
++        residual: torch.Tensor | None = None,
++    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
++        if (
++            ESIMD_AVAILABLE
++            and not disable_esimd_norm()
++            and residual is not None
++            and x.dtype == torch.float16
++            and 1 <= x.shape[0] <= _ESIMD_NORM_MAX_M
++        ):
++            if not hasattr(self, "_gemma_w_fp16"):
++                self._gemma_w_fp16 = (self.weight.data + 1.0).half()
++            # M == 1 keeps the single-token kernel; 2..128 (decode batch) take
++            # the batched kernel -- same residual-add + RMSNorm(w+1) math, both
++            # in place. The normed value is written back so the subsequent
++            # attention / MoE forward runs off it unchanged (matches v0.14.0).
++            # Standalone (residual is None) esimd_rms_norm was reverted -- it
++            # produced !!! on q_norm/k_norm.
++            if x.shape[0] == 1:
++                esimd_fused_add_rms_norm(
++                    x, residual, self._gemma_w_fp16, self.variance_epsilon
++                )
++            else:
++                esimd_fused_add_rms_norm_batched(
++                    x, residual, self._gemma_w_fp16, self.variance_epsilon
++                )
++            return x, residual
++
++        return self.forward_native(x, residual)
++
+ 
+ # --8<-- [start:rms_norm_gated]
+ @CustomOp.register("rms_norm_gated")
+@@ -298,7 +341,29 @@ class RMSNormGated(CustomOp):
+     def forward_xpu(
+         self, x: torch.Tensor, z: torch.Tensor | None = None
+     ) -> torch.Tensor:
+-        return self.forward_cuda(x, z)
++        from vllm.model_executor.layers.fla.ops.layernorm_guard import (
++            layer_norm_fwd,
++        )
++
++        # Bypass rmsnorm_fn -> LayerNormFn.apply -> @input_guard path
++        # to avoid: unconditional .contiguous(), torch.xpu.device() ctx,
++        # autograd save_for_backward, and per-call tensor allocations.
++        x_shape_og = x.shape
++        x = x.reshape(-1, x.shape[-1])
++        if z is not None:
++            z = z.reshape(-1, z.shape[-1])
++        y, _, _ = layer_norm_fwd(
++            x,
++            self.weight,
++            self.bias,
++            self.eps,
++            z=z,
++            group_size=self.group_size,
++            norm_before_gate=self.norm_before_gate,
++            is_rms_norm=True,
++            activation=self.activation,
++        )
++        return y.reshape(x_shape_og)
+ 
+ 
+ class LayerNorm(nn.Module):
+diff --git a/vllm/model_executor/layers/mamba/gdn_linear_attn.py b/vllm/model_executor/layers/mamba/gdn_linear_attn.py
+index 4493ee783..35bedcd7d 100644
+--- a/vllm/model_executor/layers/mamba/gdn_linear_attn.py
++++ b/vllm/model_executor/layers/mamba/gdn_linear_attn.py
+@@ -37,6 +37,15 @@ from vllm.model_executor.layers.linear import (
+     MergedColumnParallelLinear,
+     RowParallelLinear,
+ )
++from vllm.model_executor.layers.esimd_utils import (
++    ESIMD_AVAILABLE,
++    disable_esimd_gdn_outproj,
++    esimd_gdn_conv_fused,
++    esimd_gdn_conv_fused_seq,
++    esimd_gemv_fp8_pert_fused2,
++    esimd_norm_gemv_fp8_pert,
++    esimd_rms_norm_gated,
++)
+ from vllm.model_executor.layers.mamba.abstract import MambaBase
+ from vllm.model_executor.layers.mamba.mamba_mixer2 import mamba_v2_sharded_weight_loader
+ from vllm.model_executor.layers.mamba.mamba_utils import (
+@@ -406,6 +415,80 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
+             raise ValueError(f"Duplicate layer name: {prefix}")
+         compilation_config.static_forward_context[prefix] = self
+ 
++        # Eligibility for the fused conv1d + GDN delta-rule decode core. Decided
++        # once. Two kernel variants with identical signatures unpack the
++        # in_proj_qkvz packing differently: esimd_gdn_conv_fused for the
++        # interleaved-GQA layout (Qwen3-Next, gqa_interleaved_layout=True) and
++        # esimd_gdn_conv_fused_seq for the sequential [q|k|v|z] layout
++        # (Qwen3.5/3.6, gqa_interleaved_layout=False) -- _gdn_conv_decode picks
++        # by layout. Both need head_{k,v}_dim==128. fp16 A_log/dt_bias/conv_weight
++        # + a zero conv_bias and the cached conv weight view are prepared lazily
++        # on first decode (weights are final by then). Per-call gating to
++        # num_prefills==0 & 0<num_decodes<=128 lives in forward_xpu.
++        from vllm.model_executor.layers.esimd_utils import (
++            ESIMD_AVAILABLE,
++            disable_esimd_gdn_conv,
++            disable_esimd_gdn_proj,
++            quant_is_fp8,
++        )
++
++        self._gdn_conv_esimd_ok = (
++            ESIMD_AVAILABLE
++            and not disable_esimd_gdn_conv()
++            and self.head_k_dim == 128
++            and self.head_v_dim == 128
++        )
++        self._gdn_conv_fp16_ready = False
++        # Lazily confirmed once kv_cache exists: the fused conv kernel needs an
++        # fp16 conv_state + ssm_state (see _gdn_conv_decode). False until proven.
++        self._gdn_conv_state_fp16_ok = False
++
++        # Eligibility for fusing the two input projections (in_proj_qkvz +
++        # in_proj_ba) into one ESIMD dual-GEMV at M==1 decode. Both must be FP8
++        # per-tensor (scalar weight_scale), checked lazily on first decode since
++        # weight_scale only exists after process_weights_after_loading.
++        self._gdn_proj_esimd_ok = (
++            ESIMD_AVAILABLE
++            and quant_is_fp8(quant_config)
++            and not disable_esimd_gdn_proj()
++        )
++        self._gdn_proj_fused_ready = None  # None=undecided, True/False once checked
++
++        # INT4 ESIMD fused2 GEMV for decode (M==1): both in_proj_qkvz + in_proj_ba
++        # in a single kernel launch. weight_esimd/scale_esimd are set up by
++        # sym_int4.py process_weights_after_loading.
++        from vllm.model_executor.layers.esimd_utils import (
++            disable_esimd_int4,
++            quant_is_sym_int4,
++        )
++        from vllm.model_executor.layers.quantization.sym_int4 import (
++            QK4_GROUP_SIZE,
++        )
++
++        self._gdn_proj_int4_esimd_ok = (
++            ESIMD_AVAILABLE
++            and quant_is_sym_int4(quant_config)
++            and not disable_esimd_int4()
++            and QK4_GROUP_SIZE == 128
++        )
++
++        # Preallocated decode buffers for Part-2 core_attn_out / z, sliced to
++        # num_tokens at <=128. Mirrors b8.3's _decode_attn_out_buf/_m_attn_out:
++        # avoids a torch.zeros + torch.empty_like every decode step (x48 layers).
++        # Only used when the ESIMD GDN conv decode path runs (it overwrites both
++        # buffers fully); otherwise per-call allocation is kept.
++        self._gdn_decode_max_bsz = 128
++        if self._gdn_conv_esimd_ok:
++            _dev = current_platform.current_device()
++            self._gdn_attn_out_buf = torch.zeros(
++                self._gdn_decode_max_bsz,
++                self.num_v_heads // self.tp_size,
++                self.head_v_dim,
++                dtype=torch.float16,
++                device=_dev,
++            )
++            self._gdn_z_buf = torch.empty_like(self._gdn_attn_out_buf)
++
+     def create_qkvz_proj(
+         self,
+         hidden_size: int,
+@@ -781,6 +864,154 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
+         # ============================================================
+         self._output_projection(core_attn_out, z, output, num_tokens)
+ 
++    def _gdn_proj_fused(self, hidden_states: torch.Tensor, num_tokens: int):
++        """Fuse in_proj_qkvz + in_proj_ba into one ESIMD dual-GEMV at M==1.
++
++        Returns (qkvz, ba) when it ran, else None to fall through to the two
++        standard projections. Eligibility (both projections FP8 per-tensor) is
++        decided lazily on the first decode -- weight_scale only exists after
++        process_weights_after_loading. The single-GEMV path already accelerates
++        each projection (PR #100); this saves one launch and reads hidden once.
++        """
++        if not self._gdn_proj_esimd_ok or num_tokens != 1:
++            return None
++        if self._gdn_proj_fused_ready is None:
++            wq = self.in_proj_qkvz.weight
++            wb = self.in_proj_ba.weight
++            sq = getattr(self.in_proj_qkvz, "weight_scale", None)
++            sb = getattr(self.in_proj_ba, "weight_scale", None)
++            self._gdn_proj_fused_ready = (
++                wq.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
++                and wb.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
++                and sq is not None
++                and sb is not None
++                and sq.numel() == 1
++                and sb.numel() == 1
++                and self.in_proj_qkvz.bias is None
++                and self.in_proj_ba.bias is None
++            )
++        if not self._gdn_proj_fused_ready:
++            return None
++
++        dev = hidden_states.device
++        qkvz = torch.empty(
++            1, self.in_proj_qkvz.weight.shape[0], dtype=torch.float16, device=dev
++        )
++        ba = torch.empty(
++            1, self.in_proj_ba.weight.shape[0], dtype=torch.float16, device=dev
++        )
++        esimd_gemv_fp8_pert_fused2(
++            hidden_states,
++            self.in_proj_qkvz.weight,
++            self.in_proj_qkvz.weight_scale,
++            qkvz,
++            self.in_proj_ba.weight,
++            self.in_proj_ba.weight_scale,
++            ba,
++        )
++        return qkvz, ba
++
++    def _gdn_conv_decode(
++        self,
++        projected_states_qkvz: torch.Tensor,
++        projected_states_ba: torch.Tensor,
++        core_attn_out: torch.Tensor,
++        z: torch.Tensor,
++    ) -> bool:
++        """Fused conv1d + GDN delta-rule decode core (esimd_gdn_conv_fused).
++
++        Returns True iff it handled the whole batch. Only takes pure-decode
++        batches (no prefill, 0 < num_decodes <= 128); anything else returns
++        False so the caller runs the upstream gdn_attention op. The conv/recur
++        math here is identical to the upstream decode path -- this is purely a
++        kernel-fusion / allocation-elimination win.
++        """
++        attn_metadata_raw = get_forward_context().attn_metadata
++        if attn_metadata_raw is None:
++            return False  # warmup/profile: let the upstream op handle it
++        attn_metadata = attn_metadata_raw[self.prefix]
++        if (
++            attn_metadata.num_prefills != 0
++            or attn_metadata.num_decodes <= 0
++            or attn_metadata.num_decodes > 128
++            or attn_metadata.spec_sequence_masks is not None
++        ):
++            return False
++
++        # The fused conv kernels read BOTH conv_state and ssm_state as fp16
++        # (lsc_load_state_64 over const fp16*). Models that force an fp32 SSM
++        # cache (Qwen3.6 sets mamba_ssm_dtype=float32 for accuracy; Qwen3-Next
++        # leaves it auto -> fp16) would have their fp32 state bytes
++        # reinterpreted as fp16 -> NaN/!!!! state cascade. Gate on the actual
++        # cache dtype and fall back to the upstream (unfused) decode otherwise.
++        # Decided once: state dtype is fixed for the cache's lifetime.
++        if not self._gdn_conv_state_fp16_ok:
++            if (
++                self.kv_cache[0].dtype == torch.float16
++                and self.kv_cache[1].dtype == torch.float16
++            ):
++                self._gdn_conv_state_fp16_ok = True
++            else:
++                return False
++
++        # Lazily cache fp16 params + conv-weight view on first decode (weights
++        # final by now). The kernel reads A_log/dt_bias/conv_weight/conv_bias as
++        # fp16; v0.21.0 stores A_log fp32 and conv1d has no bias.
++        if not self._gdn_conv_fp16_ready:
++            dev = projected_states_qkvz.device
++            self._gdn_conv_weight_2d = self.conv1d.weight.view(
++                self.conv1d.weight.size(0), self.conv1d.weight.size(2)
++            ).to(torch.float16)
++            self._gdn_conv_bias_zeros = torch.zeros(
++                self.conv_dim // self.tp_size, dtype=torch.float16, device=dev
++            )
++            self._gdn_A_log_fp16 = self.A_log.data.to(torch.float16).contiguous()
++            self._gdn_dt_bias_fp16 = self.dt_bias.data.to(torch.float16).contiguous()
++            self._gdn_attn_scale = float(self.head_k_dim**-0.5)
++            self._gdn_conv_fp16_ready = True
++
++        self_kv_cache = self.kv_cache
++        conv_state = self_kv_cache[0]  # SD layout: [slot, width-1, dim]
++        ssm_state = self_kv_cache[1]
++        n_dec = attn_metadata.num_decodes
++        state_idx = attn_metadata.non_spec_state_indices_tensor[:n_dec]
++
++        # Same signature, two variants for the in_proj_qkvz packing the kernel
++        # unpacks internally: esimd_gdn_conv_fused for the interleaved-GQA layout
++        # (Qwen3-Next), esimd_gdn_conv_fused_seq for the sequential [q|k|v|z]
++        # layout (Qwen3.5/3.6). BOTH take the raw in_proj_qkvz/ba projections
++        # directly (the _seq kernel reads sequential order itself -- no Python
++        # reorder; confirmed against the kernel's own e2e test). This is what
++        # lets the Qwen3.5/3.6 GDN decode skip the per-layer split/reshape/chunk/
++        # contiguous glue and fuse conv1d + delta-rule into one launch.
++        _conv_fn = (
++            esimd_gdn_conv_fused
++            if self.gqa_interleaved_layout
++            else esimd_gdn_conv_fused_seq
++        )
++
++        _conv_fn(
++            projected_states_qkvz,
++            conv_state,
++            self._gdn_conv_weight_2d,
++            self._gdn_conv_bias_zeros,
++            state_idx,
++            self._gdn_A_log_fp16,
++            self._gdn_dt_bias_fp16,
++            projected_states_ba,
++            ssm_state,
++            state_idx,
++            core_attn_out,
++            z,
++            n_dec,
++            self.num_k_heads // self.tp_size,
++            self.num_v_heads // self.tp_size,
++            self.head_k_dim,
++            self.head_v_dim,
++            self._gdn_attn_scale,
++        )
++        return True
++
+     def forward_xpu(
+         self,
+         hidden_states: torch.Tensor,
+@@ -797,30 +1028,235 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
+         # ============================================================
+         # Part 1: Input Projection
+         # ============================================================
+-        projected_states_qkvz, _ = self.in_proj_qkvz(hidden_states)
+-        projected_states_ba, _ = self.in_proj_ba(hidden_states)
++        proj = self._gdn_proj_fused(hidden_states, num_tokens)
++        if proj is not None:
++            projected_states_qkvz, projected_states_ba = proj
++        elif num_tokens == 1 and self._gdn_proj_int4_esimd_ok:
++            from vllm.model_executor.layers.esimd_utils import (
++                esimd_gemv_int4_fused2,
++            )
+ 
+-        # ============================================================
+-        # Part 2: Core Attention
+-        # ============================================================
+-        core_attn_out = torch.zeros(
+-            (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
+-            dtype=hidden_states.dtype,
+-            device=hidden_states.device,
++            if getattr(self, "_int4_qkvz_buf", None) is None:
++                qkvz_w = self.in_proj_qkvz.weight_esimd
++                ba_w = self.in_proj_ba.weight_esimd
++                dev = hidden_states.device
++                self._int4_qkvz_buf = torch.empty(
++                    1, qkvz_w.shape[0], dtype=torch.float16, device=dev
++                )
++                self._int4_ba_buf = torch.empty(
++                    1, ba_w.shape[0], dtype=torch.float16, device=dev
++                )
++            esimd_gemv_int4_fused2(
++                hidden_states,
++                self.in_proj_qkvz.weight_esimd,
++                self.in_proj_qkvz.scale_esimd,
++                self._int4_qkvz_buf,
++                self.in_proj_ba.weight_esimd,
++                self.in_proj_ba.scale_esimd,
++                self._int4_ba_buf,
++            )
++            projected_states_qkvz = self._int4_qkvz_buf
++            projected_states_ba = self._int4_ba_buf
++        elif num_tokens <= 64 and self._gdn_proj_int4_esimd_ok:
++            from vllm.model_executor.layers.esimd_utils import esimd_gemm_int4_pgrp
++            dev = hidden_states.device
++            N_qkvz = self.in_proj_qkvz.weight_esimd.shape[0]
++            N_ba = self.in_proj_ba.weight_esimd.shape[0]
++            projected_states_qkvz = torch.empty(
++                num_tokens, N_qkvz, dtype=torch.float16, device=dev
++            )
++            projected_states_ba = torch.empty(
++                num_tokens, N_ba, dtype=torch.float16, device=dev
++            )
++            esimd_gemm_int4_pgrp(
++                hidden_states,
++                self.in_proj_qkvz.weight_esimd,
++                self.in_proj_qkvz.scale_esimd,
++                projected_states_qkvz,
++            )
++            esimd_gemm_int4_pgrp(
++                hidden_states,
++                self.in_proj_ba.weight_esimd,
++                self.in_proj_ba.scale_esimd,
++                projected_states_ba,
++            )
++        else:
++            projected_states_qkvz, _ = self.in_proj_qkvz(hidden_states)
++            projected_states_ba, _ = self.in_proj_ba(hidden_states)
++
++        # Parts 2 (core attention) + 3 (output projection).
++        self._gdn_core_and_output(
++            projected_states_qkvz,
++            projected_states_ba,
++            hidden_states,
++            output,
++            num_tokens,
+         )
+-        z = torch.empty_like(core_attn_out)
+ 
+-        torch.ops.vllm.gdn_attention_core_xpu(
+-            core_attn_out,
+-            z,
++    def forward_xpu_precomputed_proj(
++        self,
++        projected_states_qkvz: torch.Tensor,
++        projected_states_ba: torch.Tensor,
++        output: torch.Tensor,
++    ):
++        """XPU forward when Part-1 input projection was already computed.
++
++        The DecoderLayer's fused input_norm + GDN in_proj kernel
++        (esimd_resadd_norm_gemv2_fp8_pert) produces qkvz/ba directly, so we skip
++        Part 1 here and run only the core attention + output projection. Decode
++        path only (num_tokens == 1); the proj tensors are [1, N] fp16.
++        """
++        num_tokens = projected_states_qkvz.size(0)
++        self._gdn_core_and_output(
+             projected_states_qkvz,
+             projected_states_ba,
+-            self.prefix,
++            # core_attn_out/z buffers and the out_proj dtype gate key off the
++            # proj tensor's device/dtype, which match hidden_states.
++            projected_states_qkvz,
++            output,
++            num_tokens,
++        )
++
++    def _gdn_core_and_output(
++        self,
++        projected_states_qkvz: torch.Tensor,
++        projected_states_ba: torch.Tensor,
++        hidden_states: torch.Tensor,
++        output: torch.Tensor,
++        num_tokens: int,
++    ):
++        # ============================================================
++        # Part 2: Core Attention
++        # ============================================================
++        # Reuse preallocated decode buffers (sliced to num_tokens, a leading
++        # slice so still contiguous) when they fit -- avoids a per-step
++        # torch.zeros + empty_like across 48 layers. The buffers are contiguous
++        # fp16; gate on dtype to stay safe.
++        _use_buf = (
++            getattr(self, "_gdn_attn_out_buf", None) is not None
++            and num_tokens <= self._gdn_decode_max_bsz
++            and hidden_states.dtype == torch.float16
++        )
++        if _use_buf:
++            core_attn_out = self._gdn_attn_out_buf[:num_tokens]
++            z = self._gdn_z_buf[:num_tokens]
++        else:
++            core_attn_out = torch.zeros(
++                (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
++                dtype=hidden_states.dtype,
++                device=hidden_states.device,
++            )
++            z = torch.empty_like(core_attn_out)
++
++        # Decode fast path: fuse conv1d + GDN delta-rule into one ESIMD kernel,
++        # replacing the upstream gdn_attention decode path (causal_conv1d +
++        # gated_delta_rule = 2 launches + 6 intermediate allocs). _gdn_conv_decode
++        # returns True only when it handled the batch (pure decode, no prefill,
++        # <=128 decode tokens) -- the GDN core is the !!!! OOB-corruption region,
++        # so prefill/mixed batches keep the upstream SYCL kernel. Otherwise (or
++        # with DISABLE_ESIMD_GDN_CONV) we fall through to the upstream op 1:1.
++        handled = self._gdn_conv_esimd_ok and self._gdn_conv_decode(
++            projected_states_qkvz, projected_states_ba, core_attn_out, z
+         )
++        if not handled:
++            if _use_buf:
++                core_attn_out.zero_()
++            torch.ops.vllm.gdn_attention_core_xpu(
++                core_attn_out,
++                z,
++                projected_states_qkvz,
++                projected_states_ba,
++                self.prefix,
++            )
+ 
+         # ============================================================
+         # Part 3: Output Projection
+         # ============================================================
++        # Decode fast path (single token): fuse RMSNormGated + the FP8 out_proj
++        # GEMV into one ESIMD kernel, replacing norm -> rearrange -> out_proj
++        # (three dispatches + a torch.empty) with one. Only the projection tail
++        # is fused -- the conv/recurrent core still runs through the upstream
++        # gdn_attention SYCL kernel above -- so this is unaffected by the BSZ>1
++        # GDN NaN trap and is gated purely on num_tokens == 1.
++        if self._gdn_outproj_esimd_eligible(num_tokens):
++            self._output_projection_esimd_decode(core_attn_out, z, output)
++            return
++
++        if num_tokens == 1 and self._gdn_proj_int4_esimd_ok:
++            self._output_projection_int4_esimd_decode(core_attn_out, z, output)
++            return
++
++        # Decode-batch fast path (2 <= M <= 128, PURE DECODE only): replace the
++        # RMSNormGated (layer_norm_fwd / Triton) with the ESIMD batched gated
++        # RMSNorm, then let out_proj run -- its M>1 GEMM takes the ESIMD
++        # scaled_mm fast path. Gated on `handled` (the conv/core ran the pure-
++        # decode ESIMD path: no prefill, <=128 decode tokens) so this never
++        # fires on prefill / mixed batches, where core_attn_out is prefill-
++        # shaped and the gated-norm + decode reshape would be invalid. Same
++        # RMSNormGated math constraints as the M==1 fused tail. Matches v0.14.0.
++        if handled and self._gdn_outproj_batched_esimd_eligible(num_tokens):
++            hv = self.num_v_heads // self.tp_size
++            v = self.head_v_dim
++            if getattr(self, "_norm_weight_fp16", None) is None:
++                # Private contiguous storage -- the XPU caching allocator may
++                # otherwise reuse a shared half() result mid-run (NaN cascade).
++                self._norm_weight_fp16 = (
++                    self.norm.weight.data.half().clone().contiguous()
++                )
++            # RMSNormGated normalizes per head over head_v_dim (the norm weight
++            # is [head_v_dim], not [hv*v]); flatten to [M*hv, head_v_dim] so each
++            # row is one head, matching the M==1 / slow-path RMSNormGated. Then
++            # reshape to [M, hv*v] for out_proj (its M>1 GEMM hits scaled_mm).
++            x_rows = core_attn_out.reshape(num_tokens * hv, v)
++            z_rows = z.reshape(num_tokens * hv, v)
++            normed_rows = torch.empty_like(x_rows)
++            esimd_rms_norm_gated(
++                x_rows, z_rows, self._norm_weight_fp16, normed_rows, self.norm.eps
++            )
++            normed = normed_rows.reshape(num_tokens, hv * v)
++            output[:num_tokens], _ = self.out_proj(normed)
++            return
++
++        # INT4 counterpart of the batched out_proj path: fused gated RMSNorm
++        # followed by the per-group INT4 GEMM (esimd_gemm_int4_pgrp) on the
++        # ESIMD-formatted out_proj weights.
++        if num_tokens <= 64 and self._gdn_proj_int4_esimd_ok:
++            from vllm.model_executor.layers.esimd_utils import (
++                esimd_gemm_int4_pgrp,
++            )
++            # NOTE: esimd_rms_norm_gated is already imported at module scope
++            # (top of file). Do NOT re-import it locally here -- a local import
++            # makes Python treat the name as function-local for the whole
++            # function, so the FP8 batched out_proj path above (which uses the
++            # module-level binding) hits UnboundLocalError on the branch that
++            # reaches it before this INT4 branch runs.
++            from vllm.distributed import tensor_model_parallel_all_reduce
++
++            hv = self.num_v_heads // self.tp_size
++            v = self.head_v_dim
++            x_2d = core_attn_out.reshape(-1, v)
++            z_2d = z.reshape(-1, v)
++            if getattr(self, "_norm_weight_fp16", None) is None:
++                self._norm_weight_fp16 = (
++                    self.norm.weight.data.half().clone().contiguous()
++                )
++            normed = torch.empty_like(x_2d)
++            esimd_rms_norm_gated(x_2d, z_2d, self._norm_weight_fp16, normed, self.norm.eps)
++            normed = normed.reshape(num_tokens, hv * v)
++            N = self.out_proj.weight_esimd.shape[0]
++            o_buf = torch.empty(num_tokens, N, dtype=torch.float16, device=output.device)
++            esimd_gemm_int4_pgrp(
++                normed,
++                self.out_proj.weight_esimd,
++                self.out_proj.scale_esimd,
++                o_buf,
++            )
++            if self.tp_size > 1 and self.out_proj.reduce_results:
++                output[:num_tokens] = tensor_model_parallel_all_reduce(o_buf)
++            else:
++                output[:num_tokens] = o_buf
++            return
++
+         z_shape_og = z.shape
+         # Reshape input data into 2D tensor
+         core_attn_out = core_attn_out.reshape(-1, core_attn_out.shape[-1])
+@@ -830,6 +1266,152 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
+         core_attn_out = rearrange(core_attn_out, "... h d -> ... (h d)")
+         output[:num_tokens], _ = self.out_proj(core_attn_out)
+ 
++    def _gdn_outproj_esimd_eligible(self, num_tokens: int) -> bool:
++        """Whether the fused RMSNormGated + FP8 GEMV out_proj tail can run.
++
++        Determined once on the first decode call and cached. Requires: single
++        decode token, the ESIMD kernels available and not disabled, an FP8
++        per-tensor out_proj with no bias, and a full-V (group_size None)
++        norm_before_gate silu/swish RMSNormGated -- exactly the math the fused
++        kernel implements. Anything else falls through to the generic tail.
++        """
++        if num_tokens != 1:
++            return False
++        cached = getattr(self, "_gdn_outproj_esimd_ok", None)
++        if cached is not None:
++            return cached
++
++        ok = False
++        if ESIMD_AVAILABLE and not disable_esimd_gdn_outproj():
++            w = self.out_proj.weight
++            ws = getattr(self.out_proj, "weight_scale", None)
++            ok = (
++                w is not None
++                and self.norm.activation in ("silu", "swish")
++                and self.norm.group_size is None
++                and self.norm.norm_before_gate
++                and self.out_proj.bias is None
++                and w.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
++                and ws is not None
++                and ws.numel() == 1
++            )
++        self._gdn_outproj_esimd_ok = ok
++        return ok
++
++    def _gdn_outproj_batched_esimd_eligible(self, num_tokens: int) -> bool:
++        """Whether the M>1 ESIMD gated-RMSNorm out_proj tail can run.
++
++        Same RMSNormGated math constraints as the M==1 fused tail (silu/swish,
++        full-V, norm_before_gate), but for a 2..128 decode batch: the norm runs
++        via the batched esimd_rms_norm_gated and out_proj is left to the M>1
++        ESIMD GEMM in scaled_mm. Decided once and cached. The out_proj's own
++        per-tensor / K%128==0 / fp16 guards live in scaled_mm; here we only need
++        the norm to be the kernel-expressible variant.
++        """
++        if num_tokens < 2 or num_tokens > self._gdn_decode_max_bsz:
++            return False
++        cached = getattr(self, "_gdn_outproj_batched_ok", None)
++        if cached is not None:
++            return cached
++
++        ok = False
++        if ESIMD_AVAILABLE and not disable_esimd_gdn_outproj():
++            w = self.out_proj.weight
++            ws = getattr(self.out_proj, "weight_scale", None)
++            ok = (
++                w is not None
++                and self.norm.activation in ("silu", "swish")
++                and self.norm.group_size is None
++                and self.norm.norm_before_gate
++                and self.out_proj.bias is None
++                and w.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
++                and ws is not None
++                and ws.numel() == 1
++            )
++        self._gdn_outproj_batched_ok = ok
++        return ok
++
++    def _output_projection_esimd_decode(
++        self,
++        core_attn_out: torch.Tensor,
++        z: torch.Tensor,
++        output: torch.Tensor,
++    ):
++        from vllm.distributed import tensor_model_parallel_all_reduce
++
++        hv = self.num_v_heads // self.tp_size
++        v = self.head_v_dim
++        # Cache the fp16 norm weight in private contiguous storage on first use
++        # (the norm weight is final by now). .clone() guards against the XPU
++        # caching allocator reusing a shared half() result's storage mid-run.
++        if getattr(self, "_norm_weight_fp16", None) is None:
++            self._norm_weight_fp16 = (
++                self.norm.weight.data.half().clone().contiguous()
++            )
++        if getattr(self, "_decode_outproj_buf", None) is None:
++            self._decode_outproj_buf = torch.empty(
++                (1, self.hidden_size),
++                dtype=torch.float16,
++                device=output.device,
++            )
++
++        esimd_norm_gemv_fp8_pert(
++            core_attn_out.view(hv, v),
++            z.view(hv, v),
++            self._norm_weight_fp16,
++            self.out_proj.weight,
++            self.out_proj.weight_scale,
++            self._decode_outproj_buf,
++            hv,
++            v,
++            self.norm.eps,
++        )
++
++        # out_proj is RowParallelLinear: reduce the partial product across TP.
++        if self.tp_size > 1 and self.out_proj.reduce_results:
++            output[:1] = tensor_model_parallel_all_reduce(self._decode_outproj_buf)
++        else:
++            output[:1] = self._decode_outproj_buf
++
++    def _output_projection_int4_esimd_decode(
++        self,
++        core_attn_out: torch.Tensor,
++        z: torch.Tensor,
++        output: torch.Tensor,
++    ):
++        from vllm.distributed import tensor_model_parallel_all_reduce
++        from vllm.model_executor.layers.esimd_utils import esimd_norm_gemv_int4_pert
++
++        hv = self.num_v_heads // self.tp_size
++        v = self.head_v_dim
++        if getattr(self, "_norm_weight_fp16", None) is None:
++            self._norm_weight_fp16 = (
++                self.norm.weight.data.half().clone().contiguous()
++            )
++        if getattr(self, "_decode_outproj_buf", None) is None:
++            self._decode_outproj_buf = torch.empty(
++                (1, self.hidden_size),
++                dtype=torch.float16,
++                device=output.device,
++            )
++
++        esimd_norm_gemv_int4_pert(
++            core_attn_out.view(hv, v),
++            z.view(hv, v),
++            self._norm_weight_fp16,
++            self.out_proj.weight_esimd.view(torch.int32),
++            self.out_proj.scale_esimd,
++            self._decode_outproj_buf,
++            hv,
++            v,
++            self.norm.eps,
++        )
++
++        if self.tp_size > 1 and self.out_proj.reduce_results:
++            output[:1] = tensor_model_parallel_all_reduce(self._decode_outproj_buf)
++        else:
++            output[:1] = self._decode_outproj_buf
++
+     def forward_cpu(
+         self,
+         hidden_states: torch.Tensor,
 diff --git a/vllm/model_executor/layers/quantization/__init__.py b/vllm/model_executor/layers/quantization/__init__.py
 index 9f2b4e702..7d830e4df 100644
 --- a/vllm/model_executor/layers/quantization/__init__.py
@@ -914,16 +2784,16 @@ index 458741478..380dfe0f9 100644
  
 diff --git a/vllm/model_executor/layers/quantization/sym_int4.py b/vllm/model_executor/layers/quantization/sym_int4.py
 new file mode 100644
-index 000000000..18aa39706
+index 000000000..dbb80d5b8
 --- /dev/null
 +++ b/vllm/model_executor/layers/quantization/sym_int4.py
-@@ -0,0 +1,659 @@
+@@ -0,0 +1,923 @@
 +# SPDX-License-Identifier: Apache-2.0
 +# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 +"""SYM_INT4 weight-only quantization for XPU.
 +
 +BF16/FP16 weights are quantized on the fly to GGML Q4_0 layout
-+(``qweight [N, K/8] int32`` + ``scale [N, K/128] fp16``, group size 128, with a
++(``qweight [N, K/8] int32`` + ``scale [N, K/group] fp16``, group size 32, with a
 +symmetric zero-point of 8) and executed through the vllm-xpu-kernels oneDNN
 +INT4 GEMM — the same IPEX-free backend the upstream ``gptq.py`` XPU path uses
 +(``transpose_onednn_woq_format`` + ``torch.ops._xpu_C.int4_gemm_w4a16``).
@@ -943,6 +2813,7 @@ index 000000000..18aa39706
 +"""
 +
 +import ctypes
++import os
 +from typing import Any, Optional
 +
 +import torch
@@ -951,6 +2822,10 @@ index 000000000..18aa39706
 +
 +from vllm.envs import VLLM_OFFLOAD_WEIGHTS_BEFORE_QUANT, VLLM_QUANTIZE_Q40_LIB
 +from vllm.logger import init_logger
++from vllm.model_executor.layers.quantization.fp8 import (
++    CopyNumelCounter,
++    _copy_missing_attrs,
++)
 +from vllm.model_executor.layers.fused_moe import (
 +    FusedMoE,
 +    FusedMoEConfig,
@@ -973,7 +2848,7 @@ index 000000000..18aa39706
 +
 +logger = init_logger(__name__)
 +
-+QK4_GROUP_SIZE: int = 128
++QK4_GROUP_SIZE: int = int(os.environ.get("VLLM_INT4_GROUP_SIZE", "128"))
 +QK4_PACK_FACTOR: int = 8
 +
 +
@@ -1168,29 +3043,96 @@ index 000000000..18aa39706
 +        layer.output_size_per_partition = output_size_per_partition
 +        layer.orig_dtype = params_dtype
 +
-+        if not VLLM_OFFLOAD_WEIGHTS_BEFORE_QUANT:
-+            # Meta-device streaming load lands in the follow-up streaming PR
-+            # (Feature 2a). Until then the only supported load is the legacy
-+            # CPU-buffer path; surface the requirement explicitly.
-+            raise NotImplementedError(
-+                "sym_int4 currently requires VLLM_OFFLOAD_WEIGHTS_BEFORE_QUANT=1; "
-+                "the streaming (meta-device) loader is added in the follow-up "
-+                "streaming PR (Feature 2a)."
++        if VLLM_OFFLOAD_WEIGHTS_BEFORE_QUANT:
++            # Legacy path: buffer BF16 weights on CPU. They are moved onto XPU
++            # by device_loading_context and quantized in
++            # process_weights_after_loading.
++            weight = ModelWeightParameter(
++                data=torch.empty(
++                    output_size_per_partition,
++                    input_size_per_partition,
++                    dtype=params_dtype,
++                    device="cpu",
++                ),
++                input_dim=1,
++                output_dim=0,
++                weight_loader=weight_loader,
 +            )
++            layer.register_parameter("weight", weight)
++            return
 +
-+        # Legacy path: buffer BF16 weights on CPU. They are moved onto XPU by
-+        # device_loading_context and quantized in process_weights_after_loading.
++        # Streaming path (VLLM_OFFLOAD_WEIGHTS_BEFORE_QUANT=0): allocate the
++        # weight on the meta device (zero real memory). A patched weight_loader
++        # materializes it on the target device on the first shard, counts the
++        # loaded elements, and quantizes in place once fully loaded -- releasing
++        # the BF16 intermediate before the next layer starts loading.
++        orig_weight_loader = weight_loader
++        layer._load_device = torch.get_default_device()
++
++        def patched_weight_loader(param, loaded_weight, *args, **kwargs):
++            # First call: materialize the meta placeholder on the target device
++            # and re-register the parameter so later loads write real storage.
++            if not hasattr(layer, "_loaded_numel"):
++                layer._loaded_numel = 0
++                materialized = ModelWeightParameter(
++                    data=torch.empty_like(
++                        layer.weight, device=layer._load_device,
++                    ),
++                    input_dim=1,
++                    output_dim=0,
++                    weight_loader=patched_weight_loader,
++                )
++                _copy_missing_attrs(layer.weight, materialized)
++                materialized._streaming_patched = True
++                layer.register_parameter("weight", materialized)
++
++            # Refresh to the live parameter after potential re-registration.
++            param = layer.weight
++
++            # Detect tuple shard_id (GDN fused projections use
++            # weight_loader_v2, which accepts tuple). The INT4 v1 weight_loader
++            # cannot handle a tuple, so dispatch through weight_loader_v2.
++            shard_id = kwargs.get("loaded_shard_id")
++            if shard_id is None:
++                shard_id = kwargs.get("shard_id")
++            if shard_id is None and args:
++                shard_id = args[0]
++
++            copy_numel_counter = CopyNumelCounter()
++            with copy_numel_counter:
++                if (isinstance(shard_id, tuple)
++                        and hasattr(layer, "weight_loader_v2")):
++                    layer.weight_loader_v2(param, loaded_weight, shard_id)
++                    res = None
++                else:
++                    res = orig_weight_loader(
++                        param, loaded_weight, *args, **kwargs,
++                    )
++            layer._loaded_numel += copy_numel_counter.copied_numel
++
++            # Fully loaded: quantize in place (this also sets the
++            # _already_called_process_weights_after_loading flag) and release
++            # the streaming bookkeeping before the next layer begins loading.
++            if layer._loaded_numel >= layer.weight.numel():
++                _quantize_linear_int4_inplace(layer)
++                del layer._loaded_numel
++                if hasattr(layer, "_load_device"):
++                    del layer._load_device
++
++            return res
++
 +        weight = ModelWeightParameter(
 +            data=torch.empty(
 +                output_size_per_partition,
 +                input_size_per_partition,
 +                dtype=params_dtype,
-+                device="cpu",
++                device="meta",
 +            ),
 +            input_dim=1,
 +            output_dim=0,
-+            weight_loader=weight_loader,
++            weight_loader=patched_weight_loader,
 +        )
++        weight._streaming_patched = True
 +        layer.register_parameter("weight", weight)
 +
 +    def process_weights_after_loading(self, layer: Module) -> None:
@@ -1198,6 +3140,25 @@ index 000000000..18aa39706
 +            layer, "_already_called_process_weights_after_loading", False
 +        ):
 +            return
++
++        # Meta fallback: a layer whose streaming weight_loader never fired
++        # (e.g. tied lm_head / skipped branch) still has its weight on meta.
++        # Materialize zeros on the load device so the quantizer does not read
++        # uninitialized / meta storage. No-op on the legacy CPU path.
++        if (getattr(layer, "weight", None) is not None
++                and layer.weight.device == torch.device("meta")):
++            device = getattr(layer, "_load_device", torch.device("xpu"))
++            wl = getattr(layer.weight, "weight_loader", None)
++            materialized = ModelWeightParameter(
++                data=torch.zeros_like(layer.weight, device=device),
++                input_dim=1,
++                output_dim=0,
++                weight_loader=wl,
++            )
++            layer.register_parameter("weight", materialized)
++            if hasattr(layer, "_load_device"):
++                del layer._load_device
++
 +        _quantize_linear_int4_inplace(layer)
 +
 +    def apply(
@@ -1210,6 +3171,15 @@ index 000000000..18aa39706
 +        # by the kernel. qzeros holds the symmetric scalar 8 set up by
 +        # transpose_onednn_woq_format.
 +        reshaped_x = x.reshape(-1, x.shape[-1])
++        # If the weight's K was zero-padded at quant time (in_features not a
++        # multiple of QK4_GROUP_SIZE), zero-pad the activation to match so the
++        # GEMM contracts over the same K; the padded weight cols are zero so
++        # the extra K contributes nothing (math-exact).
++        _k_pad = getattr(layer, "_int4_in_features_padded", None)
++        if _k_pad is not None and reshaped_x.shape[-1] < _k_pad:
++            reshaped_x = torch.nn.functional.pad(
++                reshaped_x, (0, _k_pad - reshaped_x.shape[-1])
++            )
 +        out = torch.ops._xpu_C.int4_gemm_w4a16(
 +            reshaped_x,
 +            layer.qweight,
@@ -1255,6 +3225,22 @@ index 000000000..18aa39706
 +        del bf16_cpu
 +    else:
 +        weight_cpu = bf16.float().contiguous()
++
++    # GGML Q4_0 needs in_features (the GEMM K / reduction dim) to be a multiple
++    # of QK4_GROUP_SIZE, else the C lib writes ceil(K/group) scale groups into a
++    # floor-sized buffer -> heap corruption. Some down_proj layers (e.g.
++    # DiffusionGemma mlp/self_conditioning in=2112, vision in=4304) violate this.
++    # Zero-pad K to a multiple; the padded weight columns are zero so the int4
++    # GEMM result is unchanged once apply() zero-pads x to the same K (extra
++    # K contributes 0*x = 0). Stash orig/padded K so apply() can pad the input.
++    in_features_orig = in_features
++    in_features = ((in_features + QK4_GROUP_SIZE - 1) // QK4_GROUP_SIZE) * QK4_GROUP_SIZE
++    if in_features != in_features_orig:
++        weight_cpu = torch.nn.functional.pad(
++            weight_cpu, (0, in_features - in_features_orig)
++        ).contiguous()
++    layer._int4_in_features_orig = in_features_orig
++    layer._int4_in_features_padded = in_features
 +
 +    qweight = torch.zeros(
 +        (out_features, in_features // QK4_PACK_FACTOR),
@@ -1346,6 +3332,34 @@ index 000000000..18aa39706
 +        raise RuntimeError(
 +            f"expected 3D MoE weight for {weight_name}, got {tuple(src.shape)}"
 +        )
++    # GGML Q4_0 quant (group_size=QK4_GROUP_SIZE) requires the reduction dim
++    # (in_features) to be a multiple of the group size; the C lib writes
++    # ceil(K/group) scale groups, so a non-multiple K overflows the scales
++    # buffer -> heap corruption. Whether a given MoE shape violates this
++    # depends on QK4_GROUP_SIZE (e.g. DiffusionGemma's intermediate=704 -> 352
++    # per TP=2 rank: 352 % 128 = 96 needs padding, but 352 % 32 = 0 does not).
++    # Keep this guard so any group size / shape combination stays safe.
++    # Zero-pad the inter dim up to a multiple of QK4_GROUP_SIZE. Padding is
++    # MATH-EXACT: w13's extra gate/up rows are zero (gemm1 -> act(0)*0 = 0 for
++    # act-and-mul) and w2's extra columns are zero (down reduces 0*x = 0); the
++    # kernel derives inter_size from the (padded) weight shape, so the internal
++    # intermediate is padded consistently and no kernel change is needed. w13 is
++    # [E, 2I, H] (pad the 2I out dim, per gate/up half); w2 is [E, H, I] (pad the
++    # I in dim). H is already a multiple of the group size for current targets.
++    if which == "w2":
++        _I = src.shape[2]
++        _I_pad = ((_I + QK4_GROUP_SIZE - 1) // QK4_GROUP_SIZE) * QK4_GROUP_SIZE
++        if _I_pad != _I:
++            src = torch.nn.functional.pad(src, (0, _I_pad - _I))  # pad last dim
++    else:  # w13: [E, 2I, H] -> pad each of gate/up halves' I dim
++        _twoI = src.shape[1]
++        _I = _twoI // 2
++        _I_pad = ((_I + QK4_GROUP_SIZE - 1) // QK4_GROUP_SIZE) * QK4_GROUP_SIZE
++        if _I_pad != _I:
++            E_, _, H_ = src.shape
++            src = src.reshape(E_, 2, _I, H_)
++            src = torch.nn.functional.pad(src, (0, 0, 0, _I_pad - _I))
++            src = src.reshape(E_, 2 * _I_pad, H_).contiguous()
 +    E_all, out_features, in_features = src.shape
 +    num_loop = getattr(layer, "local_num_experts", E_all)
 +
@@ -1456,39 +3470,68 @@ index 000000000..18aa39706
 +        layer._int4_hidden_size = hidden_size
 +        layer._int4_intermediate_size = intermediate_size_per_partition
 +
-+        if not VLLM_OFFLOAD_WEIGHTS_BEFORE_QUANT:
-+            raise NotImplementedError(
-+                "sym_int4 currently requires VLLM_OFFLOAD_WEIGHTS_BEFORE_QUANT=1; "
-+                "the streaming (meta-device) loader is added in the follow-up "
-+                "streaming PR (Feature 2a)."
-+            )
-+
 +        # w13 is built as [E, 2I, H] (gate+up fused), which assumes an
 +        # act-and-mul activation (e.g. SiLU). All current sym_int4 targets
 +        # (qwen3_moe / qwen3_5_moe) are act-and-mul; the FP8 MoE path makes the
 +        # same assumption. Fail loud rather than silently allocating the wrong
-+        # shape for a non-act-and-mul MoE.
++        # shape for a non-act-and-mul MoE. (Applies to both load paths.)
 +        if not self.moe.is_act_and_mul:
 +            raise NotImplementedError(
 +                "sym_int4 MoE only supports act-and-mul activations "
 +                "(is_act_and_mul=True); got is_act_and_mul=False."
 +            )
 +
-+        # Legacy path: full BF16 buffers on CPU. device_loading_context moves
-+        # them onto XPU prior to process_weights_after_loading. w13 is
-+        # [E, 2I, H]; w2 is [E, H, I].
++        if VLLM_OFFLOAD_WEIGHTS_BEFORE_QUANT:
++            # Legacy path: full BF16 buffers on CPU. device_loading_context
++            # moves them onto XPU prior to process_weights_after_loading. w13
++            # is [E, 2I, H]; w2 is [E, H, I].
++            w13_weight = torch.nn.Parameter(
++                torch.empty(
++                    num_experts,
++                    2 * intermediate_size_per_partition,
++                    hidden_size,
++                    dtype=params_dtype,
++                    device="cpu",
++                ),
++                requires_grad=False,
++            )
++            layer.register_parameter("w13_weight", w13_weight)
++            set_weight_attrs(w13_weight, extra_weight_attrs)
++
++            w2_weight = torch.nn.Parameter(
++                torch.empty(
++                    num_experts,
++                    hidden_size,
++                    intermediate_size_per_partition,
++                    dtype=params_dtype,
++                    device="cpu",
++                ),
++                requires_grad=False,
++            )
++            layer.register_parameter("w2_weight", w2_weight)
++            set_weight_attrs(w2_weight, extra_weight_attrs)
++            return
++
++        # Streaming path (VLLM_OFFLOAD_WEIGHTS_BEFORE_QUANT=0): allocate w13 /
++        # w2 on the meta device and install a patched weight_loader that
++        # materializes each side on the target device on its first shard,
++        # counts loaded elements per side independently, and quantizes each
++        # side in place the moment it is fully loaded -- releasing the BF16
++        # intermediate before the next layer starts loading.
++        layer._load_device = torch.get_default_device()
++        orig_weight_loader = extra_weight_attrs.get("weight_loader")
++
 +        w13_weight = torch.nn.Parameter(
 +            torch.empty(
 +                num_experts,
 +                2 * intermediate_size_per_partition,
 +                hidden_size,
 +                dtype=params_dtype,
-+                device="cpu",
++                device="meta",
 +            ),
 +            requires_grad=False,
 +        )
 +        layer.register_parameter("w13_weight", w13_weight)
-+        set_weight_attrs(w13_weight, extra_weight_attrs)
 +
 +        w2_weight = torch.nn.Parameter(
 +            torch.empty(
@@ -1496,24 +3539,115 @@ index 000000000..18aa39706
 +                hidden_size,
 +                intermediate_size_per_partition,
 +                dtype=params_dtype,
-+                device="cpu",
++                device="meta",
 +            ),
 +            requires_grad=False,
 +        )
 +        layer.register_parameter("w2_weight", w2_weight)
-+        set_weight_attrs(w2_weight, extra_weight_attrs)
++
++        def patched_moe_weight_loader(param, loaded_weight, *args, **kwargs):
++            shard_id = kwargs.get("shard_id")
++            if shard_id is None and len(args) >= 2:
++                shard_id = args[1]
++            is_w13 = shard_id in ("w1", "w3")
++
++            if is_w13 and not hasattr(layer, "_w13_materialized"):
++                layer._w13_materialized = True
++                layer._w13_loaded_numel = 0
++                new_w13 = torch.nn.Parameter(
++                    torch.empty_like(
++                        layer.w13_weight, device=layer._load_device,
++                    ),
++                    requires_grad=False,
++                )
++                new_attrs = dict(extra_weight_attrs)
++                new_attrs["weight_loader"] = patched_moe_weight_loader
++                set_weight_attrs(new_w13, new_attrs)
++                layer.register_parameter("w13_weight", new_w13)
++
++            if (not is_w13) and not hasattr(layer, "_w2_materialized"):
++                layer._w2_materialized = True
++                layer._w2_loaded_numel = 0
++                new_w2 = torch.nn.Parameter(
++                    torch.empty_like(
++                        layer.w2_weight, device=layer._load_device,
++                    ),
++                    requires_grad=False,
++                )
++                new_attrs = dict(extra_weight_attrs)
++                new_attrs["weight_loader"] = patched_moe_weight_loader
++                set_weight_attrs(new_w2, new_attrs)
++                layer.register_parameter("w2_weight", new_w2)
++
++            if (hasattr(layer, "_w13_materialized")
++                    and hasattr(layer, "_w2_materialized")
++                    and hasattr(layer, "_load_device")):
++                del layer._load_device
++
++            param = layer.w13_weight if is_w13 else layer.w2_weight
++
++            copy_numel_counter = CopyNumelCounter()
++            with copy_numel_counter:
++                res = orig_weight_loader(
++                    param, loaded_weight, *args, **kwargs,
++                )
++
++            if is_w13:
++                layer._w13_loaded_numel += copy_numel_counter.copied_numel
++                if layer._w13_loaded_numel >= layer.w13_weight.numel():
++                    _quantize_moe_int4_side_inplace(layer, "w13")
++                    del layer._w13_loaded_numel
++            else:
++                layer._w2_loaded_numel += copy_numel_counter.copied_numel
++                if layer._w2_loaded_numel >= layer.w2_weight.numel():
++                    _quantize_moe_int4_side_inplace(layer, "w2")
++                    del layer._w2_loaded_numel
++
++            # Both sides quantized: XpuFusedMoe is built lazily on first apply
++            # (release version), so we just clear the cached impl and mark this
++            # layer done so process_weights_after_loading short-circuits.
++            if (not hasattr(layer, "_w13_loaded_numel")
++                    and not hasattr(layer, "_w2_loaded_numel")
++                    and getattr(layer, "_w13_materialized", False)
++                    and getattr(layer, "_w2_materialized", False)):
++                self._fused_moe_impl = None
++                layer._already_called_process_weights_after_loading = True
++
++            return res
++
++        patched_attrs = dict(extra_weight_attrs)
++        patched_attrs["weight_loader"] = patched_moe_weight_loader
++        set_weight_attrs(w13_weight, patched_attrs)
++        set_weight_attrs(w2_weight, patched_attrs)
 +
 +    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
 +        if getattr(
 +            layer, "_already_called_process_weights_after_loading", False
 +        ):
 +            return
++        # hidden_size is the reduction dim for w13 and must be a group multiple
++        # (not padded here -- all current targets satisfy it). The intermediate
++        # dim is zero-padded to a group multiple inside the quantize helper
++        # (see _quantize_moe_int4_side_inplace), so it no longer needs to be a
++        # multiple up front.
 +        assert layer._int4_hidden_size % QK4_GROUP_SIZE == 0, (
-+            f"sym_int4 MoE requires hidden_size % {QK4_GROUP_SIZE} == 0"
++            f"sym_int4 MoE requires hidden_size % {QK4_GROUP_SIZE} == 0 "
++            f"(got {layer._int4_hidden_size}); the intermediate dim is "
++            f"zero-padded to a multiple automatically."
 +        )
-+        assert (
-+            layer._int4_intermediate_size % QK4_GROUP_SIZE == 0
-+        ), f"sym_int4 MoE requires intermediate_size % {QK4_GROUP_SIZE} == 0"
++
++        # Meta fallback for sides whose streaming weight_loader never fired
++        # (skipped / tied branches). Materialize zeros so the quantizer does
++        # not read meta storage. No-op on the legacy CPU path.
++        for _name in ("w13_weight", "w2_weight"):
++            _p = getattr(layer, _name, None)
++            if _p is not None and _p.device == torch.device("meta"):
++                _dev = getattr(layer, "_load_device", torch.device("xpu"))
++                setattr(layer, _name, torch.nn.Parameter(
++                    torch.zeros_like(_p, device=_dev), requires_grad=False,
++                ))
++        if hasattr(layer, "_load_device"):
++            del layer._load_device
 +
 +        _quantize_moe_int4_side_inplace(layer, "w13")
 +        _quantize_moe_int4_side_inplace(layer, "w2")
@@ -1577,6 +3711,3309 @@ index 000000000..18aa39706
 +            topk_ids=topk_ids,
 +        )
 +        return out
+diff --git a/vllm/model_executor/models/config.py b/vllm/model_executor/models/config.py
+index 459c16f8e..c10e588c7 100644
+--- a/vllm/model_executor/models/config.py
++++ b/vllm/model_executor/models/config.py
+@@ -86,12 +86,17 @@ class Gemma4Config(VerifyAndUpdateConfig):
+         # the config carries global_head_dim but all layers can still use
+         # the same FA backend.
+         max_head_dim = max(head_dim or 0, global_head_dim or 0)
++        # On XPU, FlashAttention backend handles heterogeneous head_dim:
++        # head_size=256 layers use esimd page_attn, head_size=512 layers
++        # fallback to triton unified_attention within the same backend.
++        from vllm.platforms import current_platform
+         if (
+             head_dim is not None
+             and global_head_dim is not None
+             and head_dim != global_head_dim
+             and max_head_dim > 256
+             and vllm_config.attention_config.backend is None
++            and not current_platform.is_xpu()
+         ):
+             from vllm.v1.attention.backends.registry import (
+                 AttentionBackendEnum,
+@@ -107,6 +112,75 @@ class Gemma4Config(VerifyAndUpdateConfig):
+             )
+ 
+ 
++class DiffusionGemmaModelForBlockDiffusionConfig(VerifyAndUpdateConfig):
++    @classmethod
++    def verify_and_update_config(cls, vllm_config: "VllmConfig") -> None:
++        """Set up the diffusion config and defaults for DiffusionGemma.
++
++        Auto-creates DiffusionConfig from the HF config when the user
++        didn't pass ``--diffusion-config``. Diffusion sampling params are
++        read straight from generation_config.json at sampler-build time
++        (see DiffusionGemma's custom_sampler), not injected here.
++        """
++        # Inherit Gemma4's attention backend selection (FA4 on Hopper,
++        # TRITON_ATTN fallback for heterogeneous head dims).
++        Gemma4Config.verify_and_update_config(vllm_config)
++
++        from vllm.v1.attention.backends.registry import AttentionBackendEnum
++
++        attention_config = vllm_config.attention_config
++        if attention_config.backend == AttentionBackendEnum.FLASHINFER:
++            raise ValueError(
++                "FlashInfer does not support DiffusionGemma's mixed "
++                "causal/bidirectional attention. Use --attention-backend "
++                "FLASH_ATTN or TRITON_ATTN instead."
++            )
++        if attention_config.backend is None and not attention_config.use_non_causal:
++            attention_config.use_non_causal = True
++            logger.info(
++                "DiffusionGemma uses mixed causal/bidirectional attention "
++                "within a batch; setting use_non_causal=True to exclude "
++                "FlashInfer from auto-selection."
++            )
++
++        # On XPU, default DiffusionGemma to TRITON_ATTN when the user hasn't
++        # picked a backend. TRITON has native per-request causal masking
++        # (per_seq_causal), so it serves the mixed causal/bidirectional batch
++        # in a single kernel instead of the FLASH_ATTN split helper's two
++        # varlen_fwd passes. FLASH_ATTN still works (split helper retained);
++        # set --attention-backend FLASH_ATTN to override.
++        from vllm.platforms import current_platform
++        if attention_config.backend is None and current_platform.is_xpu():
++            attention_config.backend = AttentionBackendEnum.TRITON_ATTN
++            logger.info(
++                "DiffusionGemma on XPU defaults to TRITON_ATTN "
++                "(native per-request causal). Override with "
++                "--attention-backend FLASH_ATTN if needed."
++            )
++
++        # Auto-create DiffusionConfig from HF config if not provided.
++        if vllm_config.diffusion_config is None:
++            from vllm.config.diffusion import DiffusionConfig
++
++            hf_config = vllm_config.model_config.hf_config
++            canvas_length = getattr(hf_config, "canvas_length", 256)
++            vllm_config.diffusion_config = DiffusionConfig(
++                canvas_length=canvas_length,
++            )
++
++        # The diffusion sampler materializes [num_seqs, canvas_length, vocab]
++        # fp32 transients, so concurrency is memory-bound (>8 OOMs a single H200).
++        # Default to 8 when the user didn't pass --max-num-seqs.
++        # We can't see the original None here (the engine already filled a generic
++        # default), so use >= DEFAULT_MAX_NUM_SEQS as a proxy, (the default is much
++        # larger than any deliberate value for this model)
++        from vllm.config.scheduler import SchedulerConfig
++
++        sc = vllm_config.scheduler_config
++        if sc is not None and sc.max_num_seqs >= SchedulerConfig.DEFAULT_MAX_NUM_SEQS:
++            sc.max_num_seqs = 8
++
++
+ class DeepseekV4ForCausalLMConfig(VerifyAndUpdateConfig):
+     @staticmethod
+     def verify_and_update_model_config(model_config: "ModelConfig") -> None:
+@@ -662,6 +736,7 @@ MODELS_CONFIG_MAP: dict[str, type[VerifyAndUpdateConfig]] = {
+     "ColQwen3_5": Qwen3_5ForConditionalGenerationConfig,
+     "DeepseekV4ForCausalLM": DeepseekV4ForCausalLMConfig,
+     "DeepseekV32ForCausalLM": DeepseekV32ForCausalLM,
++    "DiffusionGemmaForBlockDiffusion": DiffusionGemmaModelForBlockDiffusionConfig,  # noqa: E501
+     "Ernie4_5_VLMoeForConditionalGeneration": Ernie4_5_VLMoeForConditionalGenerationConfig,  # noqa: E501
+     "FalconMambaForCausalLM": MambaModelConfig,
+     "Gemma3TextModel": Gemma3TextModelConfig,
+diff --git a/vllm/model_executor/models/diffusion_gemma.py b/vllm/model_executor/models/diffusion_gemma.py
+new file mode 100644
+index 000000000..f53c2f445
+--- /dev/null
++++ b/vllm/model_executor/models/diffusion_gemma.py
+@@ -0,0 +1,1525 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++"""DiffusionGemma model, ModelState, and Sampler for vLLM.
++
++Single Gemma4 backbone run in two modes (like YOCO):
++- encoder mode: causal attention, writes KV cache
++- decoder mode: bidirectional attention, reads encoder KV, doesn't write
++
++Same weights, same layers. The only decoder-unique component is a
++self-conditioning MLP.
++
++Multimodal support: the model always includes a vision tower (shared with Gemma4).
++Images are encoded through the vision tower and projected into the LM embedding space
++via Gemma4MultimodalEmbedder.
++"""
++
++from __future__ import annotations
++
++from collections.abc import Iterable, Mapping
++import os
++import time
++from types import SimpleNamespace
++from typing import Any
++
++import numpy as np
++import torch
++from torch import nn
++from torch.nn import functional as F
++from transformers import AutoModel
++
++from vllm.config import VllmConfig
++from vllm.config.compilation import CUDAGraphMode
++from vllm.logger import init_logger
++from vllm.model_executor.layers.layernorm import RMSNorm
++from vllm.model_executor.layers.logits_processor import LogitsProcessor
++from vllm.distributed.communication_op import (
++    tensor_model_parallel_all_reduce,
++)
++from vllm.model_executor.layers.vocab_parallel_embedding import (
++    ParallelLMHead,
++)
++from vllm.model_executor.models.gemma4 import Gemma4Model
++from vllm.model_executor.models.gemma4_mm import (
++    Gemma4DummyInputsBuilder,
++    Gemma4ForConditionalGeneration,
++    Gemma4MultimodalEmbedder,
++    Gemma4MultiModalProcessor,
++    Gemma4ProcessingInfo,
++)
++from vllm.model_executor.models.module_mapping import MultiModelKeys
++from vllm.model_executor.models.transformers.utils import recursive_replace_linear
++from vllm.model_executor.models.utils import WeightsMapper, maybe_prefix
++from vllm.multimodal import MULTIMODAL_REGISTRY
++from vllm.v1.outputs import LogprobsTensors
++from vllm.v1.worker.gpu.attn_utils import build_attn_metadata
++from vllm.v1.worker.gpu.buffer_utils import UvaBackedTensor, async_copy_to_gpu
++from vllm.v1.worker.gpu.model_states.interface import ModelState
++from vllm.v1.worker.gpu.sample.logprob import compute_topk_logprobs
++from vllm.v1.worker.gpu.sample.output import SamplerOutput
++from vllm.v1.worker.gpu.sample.penalties import use_penalty
++
++from .interfaces import (
++    SupportsMultiModal,
++    SupportsPP,
++    SupportsQuant,
++)
++
++logger = init_logger(__name__)
++
++
++class DiffusionGemmaSelfConditioning(nn.Module):
++    """Gated MLP that processes soft embeddings from the previous denoising step.
++
++    Structurally identical to Gemma4MLP but with self_conditioning_size
++    and post_norm without learned scale.
++    """
++
++    def __init__(
++        self, hidden_size: int, self_conditioning_size: int, eps: float = 1e-6
++    ):
++        super().__init__()
++        self.pre_norm = RMSNorm(hidden_size, eps=eps)
++        self.post_norm = RMSNorm(hidden_size, eps=eps, has_weight=False)
++        self.gate_proj = nn.Linear(hidden_size, self_conditioning_size, bias=False)
++        self.up_proj = nn.Linear(hidden_size, self_conditioning_size, bias=False)
++        self.down_proj = nn.Linear(self_conditioning_size, hidden_size, bias=False)
++
++    def forward(
++        self,
++        inputs_embeds: torch.Tensor,
++        soft_embeds: torch.Tensor,
++    ) -> torch.Tensor:
++        x = self.pre_norm(soft_embeds)
++        sc_signal = self.down_proj(
++            F.gelu(self.gate_proj(x), approximate="tanh") * self.up_proj(x)
++        )
++        return self.post_norm(inputs_embeds + sc_signal)
++
++
++# ---------------------------------------------------------------------------
++# Multimodal processing info (overrides Gemma4 config type check)
++# ---------------------------------------------------------------------------
++
++
++class DiffusionGemmaProcessingInfo(Gemma4ProcessingInfo):
++    """Processing info for DiffusionGemma.
++
++    Overrides ``get_hf_config`` to accept ``DiffusionGemmaConfig``
++    (which inherits from ``PretrainedConfig``, not ``Gemma4Config``).
++    Supports image and video modalities.
++    """
++
++    def get_hf_config(self):
++        # DiffusionGemmaConfig doesn't inherit from Gemma4Config, so we
++        # accept any PretrainedConfig here.
++        return self.ctx.get_hf_config()
++
++    def get_supported_mm_limits(self) -> Mapping[str, int | None]:
++        # DiffusionGemma supports image and video inputs.
++        return {"image": None, "video": None}
++
++    def get_mm_max_tokens_per_item(
++        self, seq_len: int, mm_counts: Mapping[str, int]
++    ) -> Mapping[str, int] | None:
++        config = self.get_hf_config()
++        vision_config = getattr(config, "vision_config", None)
++        if vision_config is None:
++            # TODO(diffusion): backward-compat for the pre-RC0.1
++            # architecture name. Remove once old checkpoints are gone.
++            return {"image": 0, "video": 0}
++
++        return super().get_mm_max_tokens_per_item(seq_len, mm_counts)
++
++
++# NOTE(xpu-port): torch.compile disabled on XPU. Under enforce_eager +
++# multiproc TP with a 262k vocab, the inductor-generated triton kernel
++# fails to launch (UR_RESULT_ERROR_OUT_OF_RESOURCES). These are simple
++# elementwise/index ops; eager is correct and the perf delta is negligible.
++def _sc_soft_embed(probs, embed_weight, normalizer, sc_vocab_start):
++    """Self-conditioning soft embedding: ``probs @ embed_weight``.
++
++    NOTE(xpu-port): ``probs`` spans the full vocab (logits are all-gathered
++    across TP ranks before sampling), but ``embed_tokens`` is a
++    VocabParallelEmbedding whose weight holds only this rank's vocab shard.
++    Do the matmul as a TP-distributed reduction: multiply this rank's vocab
++    columns of ``probs`` by the local ``embed_weight`` shard, then all-reduce
++    the partial sums. With TP=1 this is a plain full matmul (all-reduce is a
++    no-op, sc_vocab_start=0, shard == full vocab).
++    """
++    shard = embed_weight.shape[0]
++    probs_shard = probs[..., sc_vocab_start : sc_vocab_start + shard]
++    # The output feeds an fp32 buffer (index_put), so keep the result fp32.
++    # PERF: embed_weight is a constant parameter; casting it fp16->fp32 every
++    # denoise step is ~4.5ms of pure redundant work. Cache the fp32 view on the
++    # weight object once. The matmul stays fp32 (probs is fp32) so numerics are
++    # identical to the original. (env DISABLE_DG_SAMPLER_OPT=1 -> per-call cast.)
++    if os.environ.get("DISABLE_DG_SAMPLER_OPT", "0") == "1":
++        ew = embed_weight.float()
++    else:
++        ew = getattr(embed_weight, "_dg_fp32", None)
++        if ew is None or ew.shape != embed_weight.shape:
++            ew = embed_weight.float()
++            embed_weight._dg_fp32 = ew
++    soft = torch.matmul(probs_shard.float(), ew)
++    soft = tensor_model_parallel_all_reduce(soft)
++    return soft * normalizer
++
++
++def _softcap_logits(logits: torch.Tensor, cap: float) -> torch.Tensor:
++    # fp32 before tanh for numerical stability (matches HF DiffusionGemma).
++    # NOTE(xpu-port): the logits are [num_decode * canvas_length, vocab] with
++    # a 262k vocab. A single elementwise kernel over the whole tensor fails to
++    # launch on Level Zero once num_decode grows (max_num_seqs>1): e.g.
++    # [4*256, 262144] tanh -> UR_RESULT_ERROR_OUT_OF_RESOURCES. Chunk the row
++    # dim so each kernel launch stays the size that already works at
++    # max_num_seqs=1 (<= canvas_length rows). Numerically identical (per-row
++    # elementwise). Skip chunking on the small / non-XPU path.
++    n_rows = logits.shape[0]
++    ROW_CHUNK = 256
++    if n_rows <= ROW_CHUNK:
++        logits = logits.float()
++        return torch.tanh(logits / cap) * cap
++    out = torch.empty_like(logits, dtype=torch.float32)
++    for lo in range(0, n_rows, ROW_CHUNK):
++        hi = min(lo + ROW_CHUNK, n_rows)
++        chunk = logits[lo:hi].float()
++        out[lo:hi] = torch.tanh(chunk / cap) * cap
++    return out
++
++
++@MULTIMODAL_REGISTRY.register_processor(
++    Gemma4MultiModalProcessor,
++    info=DiffusionGemmaProcessingInfo,
++    dummy_inputs=Gemma4DummyInputsBuilder,
++)
++class DiffusionGemmaForConditionalGeneration(
++    nn.Module,
++    SupportsMultiModal,
++    SupportsQuant,
++    SupportsPP,
++):
++    """DiffusionGemma for vLLM.
++
++    Single Gemma4 backbone that switches between encoder and decoder mode.
++    The encoder path uses standard Gemma4 layers (causal attention, KV write).
++    The decoder path uses the same weights with bidirectional attention and
++    KV read-only, plus self-conditioning.
++
++    Always includes a vision tower (same as Gemma4) for image understanding.
++
++    In practice, the model's forward() dispatches based on the `mode` kwarg
++    set by DiffusionGemmaModelState.prepare_inputs().
++    """
++
++    hf_to_vllm_mapper = WeightsMapper(
++        orig_to_new_prefix={
++            "model.decoder.": "model.",
++            "model.encoder.language_model.": "model.",
++            "model.encoder.vision_tower.": "vision_tower.",
++            "model.encoder.embed_vision.": "embed_vision.",
++        },
++        orig_to_new_substr={
++            ".experts.": ".moe.experts.",
++        },
++    )
++
++    packed_modules_mapping = {
++        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
++        "gate_up_proj": ["gate_proj", "up_proj"],
++    }
++
++    @staticmethod
++    def get_model_state_cls():
++        return DiffusionGemmaModelState
++
++    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
++        super().__init__()
++        config = vllm_config.model_config.hf_config
++        text_config = vllm_config.model_config.hf_text_config
++        self.config = config
++        self.model_dtype = vllm_config.model_config.dtype
++
++        # DiffusionGemma feeds raw (non-prenormed) input to the MoE router,
++        # matching the HF decoder which does router(residual) not
++        # router(pre_norm(residual)).
++        text_config.router_uses_prenormed_input = False
++
++        # DiffusionGemma's full-attention layers have NO v_proj — V is
++        # computed from k_proj's output (`value_states = key_states` before
++        # k_norm in `DiffusionGemmaDecoderTextAttention.forward`). This is
++        # the "k_eq_v" variant in our Gemma4 backbone. The checkpoint has no
++        # v_proj weights for full-attention layers; without this flag they
++        # would silently load with random V projections.
++        text_config.attention_k_eq_v = True
++
++        # ---- Vision tower ----
++        # NOTE(xpu-port): the downstream Gemma4 backbone uses a simplified,
++        # non-quantized Gemma4MultimodalEmbedder (signature
++        # ``(vision_config, text_config)``) and runs the vision tower in plain
++        # eager mode via AutoModel.from_config, without recursive_replace_linear.
++        # Mirror that here instead of the upstream quantize-the-tower path, so
++        # construction matches Gemma4ForConditionalGeneration in gemma4_mm.py.
++        vision_config = getattr(config, "vision_config", None)
++        if vision_config is not None:
++            with self._mark_tower_model(vllm_config, {"image", "video"}):
++                self.vision_tower = AutoModel.from_config(config=vision_config)
++                self.embed_vision = Gemma4MultimodalEmbedder(
++                    vision_config,
++                    text_config,
++                )
++        else:
++            # TODO(diffusion): backward-compat for the pre-RC0.1
++            # architecture name. Remove once old checkpoints are gone.
++            self.vision_tower = None
++            self.embed_vision = None
++
++        # ---- Language backbone (Gemma4Model) ----
++        # Use maybe_prefix to ensure correct weight name prefixes for
++        # quantization. The quantization config uses hf_to_vllm_mapper to
++        # match checkpoint weight names to model parameter names.
++        self.model = Gemma4Model(
++            vllm_config=vllm_config,
++            prefix=maybe_prefix(prefix, "model"),
++        )
++
++        self.lm_head = ParallelLMHead(
++            num_embeddings=text_config.vocab_size,
++            embedding_dim=text_config.hidden_size,
++        )
++
++        if text_config.tie_word_embeddings:
++            self.lm_head = self.lm_head.tie_weights(self.model.embed_tokens)
++
++        # HF DiffusionGemma applies the final-logit softcap in fp32, before
++        # any other processing. Do it manually in `compute_logits` so the
++        # LogitsProcessor only handles the lm_head GEMM.
++        self.final_logit_softcapping = getattr(
++            text_config, "final_logit_softcapping", None
++        )
++        self.logits_processor = LogitsProcessor(
++            text_config.vocab_size,
++            soft_cap=None,
++        )
++
++        sc_size = (
++            getattr(config, "self_conditioning_size", None)
++            or text_config.intermediate_size
++        )
++        self.self_conditioning = DiffusionGemmaSelfConditioning(
++            hidden_size=text_config.hidden_size,
++            self_conditioning_size=sc_size,
++            eps=getattr(text_config, "rms_norm_eps", 1e-6),
++        )
++
++        self.make_empty_intermediate_tensors = (
++            self.model.make_empty_intermediate_tensors
++        )
++
++    def compute_self_conditioning(
++        self,
++        inputs_embeds: torch.Tensor,
++        probs: torch.Tensor,
++    ) -> torch.Tensor:
++        embed_weight = self.model.embed_tokens.weight
++        sc_vocab_start = self.model.embed_tokens.shard_indices.org_vocab_start_index
++        soft_embeds = _sc_soft_embed(
++            probs,
++            embed_weight,
++            self.model.normalizer.float(),
++            sc_vocab_start,
++        ).to(inputs_embeds.dtype)
++        return self.self_conditioning(inputs_embeds, soft_embeds)
++
++    # ------------------------------------------------------------------ #
++    # Multimodal: reuse Gemma4's image parsing, processing & embedding
++    # ------------------------------------------------------------------ #
++    # The vision tower, pooler, embed_vision, and their processing logic
++    # are architecturally identical to Gemma4.  Delegate to avoid
++    # maintaining a duplicate copy.
++
++    _parse_and_validate_image_input = (
++        Gemma4ForConditionalGeneration._parse_and_validate_image_input
++    )
++    _parse_and_validate_video_input = (
++        Gemma4ForConditionalGeneration._parse_and_validate_video_input
++    )
++    _parse_and_validate_multimodal_inputs = (
++        Gemma4ForConditionalGeneration._parse_and_validate_multimodal_inputs
++    )
++    # NOTE(xpu-port): upstream Gemma4 exposes a vision-tower helper
++    # `_encoder_chunk`; the downstream gemma4_mm backbone does not define it
++    # and DiffusionGemma never calls it. Dropping the dead alias so import
++    # does not fail. Image features are produced via vision_tower.forward()
++    # inside _process_image_input.
++    _process_image_input = Gemma4ForConditionalGeneration._process_image_input
++    _process_video_input = Gemma4ForConditionalGeneration._process_video_input
++    embed_multimodal = Gemma4ForConditionalGeneration.embed_multimodal
++
++    def get_mm_mapping(self) -> MultiModelKeys:
++        """Get the module prefix mapping for multimodal models."""
++        return MultiModelKeys.from_string_field(
++            language_model="model",
++            connector=["embed_vision"],
++            tower_model=["vision_tower"],
++        )
++
++    # ------------------------------------------------------------------ #
++    # Forward
++    # ------------------------------------------------------------------ #
++
++    def forward(
++        self,
++        input_ids: torch.Tensor,
++        positions: torch.Tensor,
++        intermediate_tensors: Any | None = None,
++        inputs_embeds: torch.Tensor | None = None,
++        **kwargs: Any,
++    ) -> torch.Tensor:
++        if intermediate_tensors is not None:
++            inputs_embeds = None
++        # PROFILE(xpu): env-gated backbone-forward timer (zero overhead off).
++        # Times each backbone forward with an xpu sync so denoise-step latency
++        # is attributable (prefill vs per-step 256-canvas denoise).
++        if os.environ.get("DIFFUSION_PROFILE_FWD", "0") == "1":
++            n = getattr(type(self), "_dg_fwd_count", 0) + 1
++            type(self)._dg_fwd_count = n
++            ntok = input_ids.shape[0] if input_ids is not None else (
++                inputs_embeds.shape[0] if inputs_embeds is not None else -1)
++            torch.xpu.synchronize()
++            _t0 = time.perf_counter()
++            out = self.model(
++                input_ids=input_ids,
++                positions=positions,
++                intermediate_tensors=intermediate_tensors,
++                inputs_embeds=inputs_embeds,
++                **kwargs,
++            )
++            torch.xpu.synchronize()
++            logger.info("DG_FWD #%d ntokens=%d %.1fms",
++                        n, ntok, (time.perf_counter() - _t0) * 1000)
++            try:
++                from vllm.model_executor.models.gemma4 import (
++                    dg_layer_prof_dump_and_reset,
++                )
++                dg_layer_prof_dump_and_reset(logger)
++            except Exception:
++                pass
++            return out
++        return self.model(
++            input_ids=input_ids,
++            positions=positions,
++            intermediate_tensors=intermediate_tensors,
++            inputs_embeds=inputs_embeds,
++            **kwargs,
++        )
++
++    def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor | None:
++        logits = self.logits_processor(self.lm_head, hidden_states)
++        if logits is not None and self.final_logit_softcapping is not None:
++            logits = _softcap_logits(logits, self.final_logit_softcapping)
++        return logits
++
++    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
++        """Load weights from checkpoint.
++
++        Checkpoint layout (HF DiffusionGemma):
++          model.encoder.vision_tower.*            → vision tower
++          model.encoder.embed_vision.*            → vision embedder
++          model.encoder.language_model.layers.*   → backbone
++          model.decoder.layers.*                  → backbone (tied)
++          model.decoder.embed_tokens.*            → embeddings
++          model.decoder.self_conditioning.*       → self-conditioning MLP
++          lm_head.*                               → LM head (tied)
++
++        We load encoder weights into our single ``Gemma4Model`` backbone,
++        skip duplicate decoder backbone weights, handle vision tower and
++        self-conditioning separately.
++        """
++
++        sc_params = dict(
++            (n, p)
++            for n, p in self.named_parameters()
++            if n.startswith("self_conditioning.")
++        )
++
++        # Collect vision tower + embedder parameters AND buffers for manual
++        # loading.  The HF vision tower registers std_bias / std_scale as
++        # buffers (not parameters) when config.standardize is True, so we
++        # must include named_buffers() to avoid "not found in model" warnings.
++        vision_params: dict[str, torch.Tensor] = {}
++        for n, p in self.named_parameters():
++            if n.startswith(("vision_tower.", "embed_vision.")):
++                vision_params[n] = p
++        for n, b in self.named_buffers():
++            if n.startswith(("vision_tower.", "embed_vision.")):
++                vision_params[n] = b
++
++        def _remap_weights():
++            # Use full weight names (including suffixes like .weight_scale,
++            # .weight_packed) for dedup instead of just the base layer name. Critical
++            # for quantized checkpoints where each weight has multiple tensors;
++            # tracking only base names skips scales as duplicates.
++            seen_weights: set[str] = set()
++            for name, weight in weights:
++                # Self-conditioning lives under model.decoder.self_conditioning.*
++                # in the checkpoint but at self_conditioning.* in our model.
++                if "self_conditioning" in name:
++                    sc_name = name.split("self_conditioning.", 1)[1]
++                    sc_name = "self_conditioning." + sc_name
++                    if sc_name in sc_params:
++                        sc_params[sc_name].data.copy_(weight)
++                    continue
++
++                # Vision tower: model.encoder.vision_tower.* → vision_tower.*
++                # In HF, the vision tower is a sibling of language_model
++                # under the encoder module.
++                if name.startswith("model.encoder.vision_tower."):
++                    vt_name = name[len("model.encoder.") :]
++                    if vt_name in vision_params:
++                        vision_params[vt_name].data.copy_(weight)
++                    else:
++                        logger.warning(
++                            "Vision tower weight %s (mapped to %s) not found in model",
++                            name,
++                            vt_name,
++                        )
++                    continue
++
++                # Vision embedder: model.encoder.embed_vision.* → embed_vision.*
++                if name.startswith("model.encoder.embed_vision."):
++                    ev_name = name[len("model.encoder.") :]
++                    if ev_name in vision_params:
++                        vision_params[ev_name].data.copy_(weight)
++                    else:
++                        logger.warning(
++                            "Embed vision weight %s (mapped to %s) not found in model",
++                            name,
++                            ev_name,
++                        )
++                    continue
++
++                # Skip vestigial embed_vision.embedding weights.
++                if "embed_vision.embedding." in name:
++                    continue
++
++                # Encoder backbone → model.*
++                if name.startswith("model.encoder.language_model."):
++                    name = name.replace("model.encoder.language_model.", "model.")
++                # Decoder backbone → model.* (skip exact duplicates)
++                elif name.startswith("model.decoder."):
++                    name = name.replace("model.decoder.", "model.")
++
++                # Skip only if we've seen the exact same weight name (including scales)
++                if name in seen_weights:
++                    continue
++                seen_weights.add(name)
++                yield name, weight
++
++        # Delegate to Gemma4ForCausalLM.load_weights for the backbone,
++        # which handles stacked params, MoE, k_eq_v, etc.
++        # Temporarily set self.config to text_config since Gemma4's
++        # load_weights expects it (e.g. tie_word_embeddings, layer_types).
++        from vllm.model_executor.models.gemma4 import Gemma4ForCausalLM
++
++        saved_config = self.config
++        self.config = self.model.config
++        try:
++            Gemma4ForCausalLM.load_weights(self, _remap_weights())
++        finally:
++            self.config = saved_config
++
++    @classmethod
++    def get_placeholder_str(cls, modality: str, i: int) -> str | None:
++        if modality == "image":
++            return "<image_soft_token>"
++        if modality == "video":
++            return "<|video|>"
++        raise ValueError(f"Unsupported modality: {modality}")
++
++
++# NOTE(xpu-port): torch.compile disabled on XPU. Under enforce_eager +
++# multiproc TP with a 262k vocab, the inductor-generated triton kernel
++# fails to launch (UR_RESULT_ERROR_OUT_OF_RESOURCES). These are simple
++# elementwise/index ops; eager is correct and the perf delta is negligible.
++def _compute_num_rejected(
++    num_logits: torch.Tensor,
++    num_sampled: torch.Tensor,
++    query_start_loc: torch.Tensor,
++) -> torch.Tensor:
++    query_lens = query_start_loc[1:] - query_start_loc[:-1]
++    num_rejected = num_logits - num_sampled
++    is_denoise = (num_logits > 0) & (num_sampled == 0)
++    return torch.where(is_denoise, query_lens, num_rejected)
++
++
++# NOTE(xpu-port): torch.compile disabled on XPU. Under enforce_eager +
++# multiproc TP with a 262k vocab, the inductor-generated triton kernel
++# fails to launch (UR_RESULT_ERROR_OUT_OF_RESOURCES). These are simple
++# elementwise/index ops; eager is correct and the perf delta is negligible.
++def _compiled_sample_step(
++    # Logits from the model [num_decode * CL, vocab]
++    logits: torch.Tensor,
++    # Request mapping
++    decode_slots: torch.Tensor,  # [num_decode] int64 → slot indices
++    decode_idx: torch.Tensor,  # [num_decode] int64 → position in num_reqs
++    all_slots: torch.Tensor,  # [num_reqs] int64 → all slot indices
++    valid_canvas_len: torch.Tensor,  # [num_decode] int64 → real canvas length (<=CL)
++    # State tensors (modified in-place)
++    canvas: torch.Tensor,  # [max_num_reqs, CL]
++    argmax_canvas: torch.Tensor,  # [max_num_reqs, CL]
++    step_tensor: torch.Tensor,  # [max_num_reqs]
++    is_encoder_phase: torch.Tensor,  # [max_num_reqs]
++    confident_tensor: torch.Tensor,  # [max_num_reqs]
++    sc_embeds: torch.Tensor,  # [max_num_reqs, CL, hidden]
++    embed_weight: torch.Tensor,  # [vocab_shard, hidden] (TP-sharded)
++    normalizer: torch.Tensor,
++    sc_vocab_start: int,  # this rank's org vocab start index (TP shard)
++    history: torch.Tensor,  # [max_num_reqs, ST, CL]
++    history_len_tensor: torch.Tensor,  # [max_num_reqs]
++    # Output tensors (modified in-place)
++    sampled: torch.Tensor,  # [num_reqs, CL]
++    num_sampled: torch.Tensor,  # [num_reqs]
++    draft_tokens: torch.Tensor,  # [max_num_reqs, >=CL]
++    # Scalar config
++    max_denoising_steps: float,
++    t_min: float,
++    t_max: float,
++    confidence_threshold: float,
++    vocab_size: int,
++    CL: int,
++    ST: int,
++    # Sampler config
++    entropy_bound: float,
++    # When looping one decode request at a time (XPU LZ resource limit), only
++    # the first call clears the shared [num_reqs, ...] outputs; later calls
++    # must preserve earlier requests' writes.
++    zero_outputs: bool = True,
++) -> torch.Tensor:
++    """Compiled decode step: temperature → Gumbel sample → probs/confidence →
++    accept/renoise → convergence, all as vectorized PyTorch ops.
++
++    Returns the temperature-scaled logits ``[num_decode, CL, vocab]`` so the
++    caller can compute logprobs outside the compiled region."""
++    num_decode = decode_slots.shape[0]
++    device = decode_slots.device
++
++    # Clear outputs so prefill / non-decode slots report 0 (decode slots are
++    # overwritten below).
++    if zero_outputs:
++        sampled.zero_()
++        num_sampled.zero_()
++
++    # ---- Phase 1: Temperature schedule ----
++    steps_f = step_tensor[decode_slots].float()
++    remaining = (max_denoising_steps - steps_f).clamp(min=1.0)
++    temp = t_min + (t_max - t_min) * (remaining / max_denoising_steps)
++
++    # ---- Phase 2: Temperature scaling + Gumbel-max sampling ----
++    logits_3d = logits.reshape(num_decode, CL, -1).float()
++    scaled = logits_3d / temp[:, None, None].clamp(min=1e-10)
++
++    # Gumbel-max trick: argmax(logits/T + Gumbel) ~ sample from softmax(logits/T)
++    u = torch.rand_like(scaled).clamp(min=1e-20)
++    gumbel = -torch.log(-torch.log(u))
++    # Zero noise when temp==0 (greedy)
++    noisy = scaled + gumbel * (temp[:, None, None] > 0).float()
++    new_tokens = noisy.view(-1, noisy.shape[-1]).argmax(dim=-1).view(num_decode, CL)
++    argmax_tokens = (
++        scaled.view(-1, scaled.shape[-1]).argmax(dim=-1).view(num_decode, CL)
++    )
++
++    # ---- Phase 3: Probs, self-conditioning, confidence ----
++    log_probs = scaled.log_softmax(dim=-1)
++    probs = log_probs.exp()
++
++    token_entropy = -(probs * log_probs).sum(dim=-1)  # [num_decode, CL]
++    # A canvas truncated near max_model_len is zero-padded up to CL by the
++    # caller; those padded rows are uniform (max entropy, argmax 0), so they
++    # never trigger early convergence and are stable, and only the real
++    # ``valid_canvas_len`` tokens are committed (num_sampled below).
++    mean_entropy = token_entropy.mean(dim=-1)  # [num_decode]
++    confident_tensor[decode_slots] = mean_entropy < confidence_threshold
++
++    # ---- Phase 4: Entropy-bound acceptance mask ----
++    sorted_ent, sorted_idx = torch.sort(token_entropy, dim=-1)
++    cumsum_ent = torch.cumsum(sorted_ent, dim=-1)
++    cummax_ent = torch.cummax(sorted_ent, dim=-1).values
++    sorted_mask = (cumsum_ent - cummax_ent) <= entropy_bound
++    eb_mask = torch.zeros_like(sorted_mask)
++    eb_mask.scatter_(1, sorted_idx, sorted_mask)
++
++    # ---- Phase 5: Post-sample ----
++    is_commit = is_encoder_phase[decode_slots]  # [num_decode]
++    is_denoise = ~is_commit
++    cur_step = step_tensor[decode_slots].float()
++
++    # Step update: +1 for denoise, reset to 0 for commit
++    new_step_val = torch.where(
++        is_denoise,
++        (cur_step + 1).to(step_tensor.dtype),
++        step_tensor.new_zeros(num_decode),
++    )
++    step_tensor[decode_slots] = new_step_val
++
++    # Random tokens for renoise / canvas reinit
++    random_tokens = torch.randint(
++        0, vocab_size, (num_decode, CL), device=device, dtype=canvas.dtype
++    )
++
++    # Compute denoise canvas (accept/renoise)
++    denoise_canvas = torch.where(eb_mask, new_tokens, random_tokens)
++
++    # Canvas: commit → random reinit, denoise → accept/renoise result
++    canvas[decode_slots] = torch.where(
++        is_commit.unsqueeze(1), random_tokens, denoise_canvas
++    )
++
++    # History: write argmax_tokens for denoise requests at circular position
++    hist_len = history_len_tensor[decode_slots]
++    write_pos = hist_len % ST
++    for i in range(ST):
++        write_here = ((write_pos == i) & is_denoise).unsqueeze(1)
++        history[decode_slots, i] = torch.where(
++            write_here, argmax_tokens, history[decode_slots, i]
++        )
++
++    # Argmax canvas: update for denoise, preserve for commit
++    argmax_canvas[decode_slots] = torch.where(
++        is_denoise.unsqueeze(1), argmax_tokens, argmax_canvas[decode_slots]
++    )
++
++    # History length: increment for denoise, reset for commit
++    new_hist_len = torch.where(is_denoise, hist_len + 1, hist_len.new_zeros(num_decode))
++    history_len_tensor[decode_slots] = new_hist_len
++
++    # Sampled output: commit → emit argmax_canvas, denoise → 0 (pre-zeroed)
++    sampled[decode_idx] = argmax_canvas[decode_slots].to(
++        sampled.dtype
++    ) * is_commit.unsqueeze(1).to(sampled.dtype)
++    # Commit only the real canvas length (== CL except for a canvas truncated
++    # near max_model_len); the padded tail positions are never emitted.
++    num_sampled[decode_idx] = is_commit.to(num_sampled.dtype) * valid_canvas_len.to(
++        num_sampled.dtype
++    )
++
++    # ---- Phase 6: Stability + convergence ----
++    ref = history[decode_slots, 0]
++    mismatch = torch.zeros(num_decode, device=device, dtype=torch.int32)
++    for h in range(1, ST):
++        mismatch = mismatch + (ref != history[decode_slots, h]).sum(dim=-1).int()
++    stable = mismatch == 0
++
++    step_after = step_tensor[decode_slots]
++    converged = (stable & confident_tensor[decode_slots] & (new_hist_len >= ST)) | (
++        step_after >= max_denoising_steps
++    )
++    # Commit done → denoise next (False); denoise converged → commit next (True)
++    is_encoder_phase[decode_slots] = torch.where(
++        is_commit, is_commit.new_zeros(num_decode), converged
++    )
++
++    # SC soft embedding: store ``probs @ embed_weight`` (the value the next step's
++    # self-conditioning MLP consumes) only for slots that will denoise next — i.e.
++    # this step denoised AND it isn't about to commit (is_encoder_phase now False).
++    # Masking here (rather than in the consumer) lets _apply_self_conditioning read
++    # sc_embeds directly. Storing the [.., hidden] soft embed instead of the full
++    # [.., vocab] probs avoids a giant persistent buffer.
++    sc_keep = (is_denoise & ~is_encoder_phase[decode_slots])[:, None, None]
++    soft_embeds = _sc_soft_embed(probs, embed_weight, normalizer, sc_vocab_start)
++    sc_embeds[decode_slots] = soft_embeds * sc_keep
++
++    # Overwrite canvas with argmax for newly converged denoise requests
++    newly_converged = (converged & is_denoise).unsqueeze(1)
++    canvas[decode_slots] = torch.where(
++        newly_converged, argmax_canvas[decode_slots], canvas[decode_slots]
++    )
++
++    # ---- Phase 7: Copy canvas → draft_tokens for all slots ----
++    draft_tokens[all_slots, :CL] = canvas[all_slots]
++
++    return scaled
++
++
++class DiffusionGemmaRequestStates:
++    """Pre-allocated GPU tensors for DiffusionGemma per-request state.
++
++    Follows the indexed-slot pattern used by ``RequestState``.
++    """
++
++    def __init__(
++        self,
++        max_num_reqs: int,
++        canvas_length: int,
++        vocab_size: int,
++        max_denoising_steps: int,
++        device: torch.device,
++        hidden_size: int,
++        stability_threshold: int,
++    ):
++        self.max_num_reqs = max_num_reqs
++        self.canvas_length = canvas_length
++        self.vocab_size = vocab_size
++        self.max_denoising_steps = max_denoising_steps
++        self.stability_threshold = stability_threshold
++        self.device = device
++
++        self.is_encoder_phase = torch.zeros(
++            max_num_reqs, dtype=torch.bool, device=device
++        )
++        # Canvas tokens [max_num_reqs, canvas_length]
++        self.canvas = torch.zeros(
++            max_num_reqs, canvas_length, dtype=torch.int64, device=device
++        )
++        # Step counter (counts up from 0 to max_denoising_steps)
++        self.step = torch.zeros(
++            max_num_reqs,
++            dtype=torch.int32,
++            device=device,
++        )
++        # Accepted canvas history for stability check
++        self.accepted_canvas_history = torch.zeros(
++            max_num_reqs,
++            stability_threshold,
++            canvas_length,
++            dtype=torch.int64,
++            device=device,
++        )
++        self.accepted_canvas_history_len = torch.zeros(
++            max_num_reqs, dtype=torch.int32, device=device
++        )
++        # Latest argmax(processed_logits) per slot — what we COMMIT.
++        # HF reference commits `argmax_canvas` (argmax of latest step's logits),
++        # NOT `current_canvas` (which is the post-renoise stochastic input for
++        # the next denoise step). We keep this separate from `canvas` because
++        # canvas gets renoised in-place during denoise, while argmax_canvas is
++        # the deterministic best-guess we ultimately emit.
++        self.argmax_canvas = torch.zeros(
++            max_num_reqs, canvas_length, dtype=torch.int64, device=device
++        )
++
++        # Per-slot prompt length (set by add_request).
++        self.prompt_len = torch.zeros(
++            max_num_reqs,
++            dtype=torch.int32,
++            device=device,
++        )
++
++        # Per-slot confidence flag, set by the sampler each step.
++        self.confident = torch.zeros(max_num_reqs, dtype=torch.bool, device=device)
++
++        # Per-slot self-conditioning soft embedding (probs @ embed_weight) from
++        # the previous denoise step. Storing the [.., hidden] soft embed instead
++        # of the full [.., vocab] distribution shrinks this buffer by
++        # vocab/hidden (~170x) and moves the matmul to denoise time; the result
++        # is identical (SC consumes probs @ embed_weight anyway).
++        self.self_conditioning_embeds = torch.zeros(
++            max_num_reqs, canvas_length, hidden_size, dtype=torch.float32, device=device
++        )
++
++    def init_canvas(self, slot_indices_np: np.ndarray) -> None:
++        """Initialize canvas with random tokens for the given slots."""
++        n = slot_indices_np.shape[0]
++        self.canvas[slot_indices_np] = torch.randint(
++            0,
++            self.vocab_size,
++            (n, self.canvas_length),
++            dtype=torch.int64,
++            device=self.device,
++        )
++
++    def add_request(self, slot_idx: int) -> None:
++        self.is_encoder_phase[slot_idx] = True
++        self.init_canvas(torch.tensor([slot_idx], device=self.device))
++        self.step[slot_idx] = 0
++        self.accepted_canvas_history_len[slot_idx] = 0
++        self.self_conditioning_embeds[slot_idx] = 0
++
++    def remove_request(self, slot_idx: int) -> None:
++        self.is_encoder_phase[slot_idx] = False
++        self.accepted_canvas_history_len[slot_idx] = 0
++        self.self_conditioning_embeds[slot_idx] = 0
++
++
++class DiffusionGemmaModelState(ModelState):
++    """ModelState for DiffusionGemma.
++
++    Single Gemma4 backbone in two modes:
++    - encoder mode (num_draft_tokens == 0): causal attention, writes KV
++    - decoder mode (num_draft_tokens > 0): bidirectional attention, reads KV
++    """
++
++    def __init__(
++        self,
++        vllm_config: VllmConfig,
++        model: nn.Module,
++        encoder_cache: Any,
++        device: torch.device,
++    ) -> None:
++        self.vllm_config = vllm_config
++        self.model_config = vllm_config.model_config
++        self.scheduler_config = vllm_config.scheduler_config
++        self.model = model
++        self.device = device
++
++        self.supports_mm_inputs = encoder_cache is not None
++        self.max_num_reqs = self.scheduler_config.max_num_seqs
++        self.max_num_tokens = self.scheduler_config.max_num_batched_tokens
++        self.max_model_len = self.model_config.max_model_len
++        self.inputs_embeds_size = self.model_config.get_inputs_embeds_size()
++        self.dtype = self.model_config.dtype
++
++        if self.supports_mm_inputs:
++            from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
++            from vllm.v1.worker.gpu.mm.encoder_runner import EncoderRunner
++
++            assert isinstance(encoder_cache, EncoderCache)
++            self.encoder_cache = encoder_cache
++            self.encoder_runner = EncoderRunner(
++                model=self.model,
++                max_num_tokens=self.max_num_tokens,
++                hidden_size=self.inputs_embeds_size,
++                encoder_cache=encoder_cache,
++                dtype=self.dtype,
++                device=self.device,
++            )
++
++        # Per-step MM data produced by get_mm_embeddings and consumed by
++        # prepare_inputs.  Stored as raw (mm_embeds, is_mm_embed) so that
++        # prepare_inputs can call embed_input_ids directly into the
++        # persistent _inputs_embeds_buf, avoiding the intermediate copy
++        # through encoder_runner.inputs_embeds.
++        self._pending_mm_embeds: tuple[list[torch.Tensor], torch.Tensor] | None = None
++
++        diffusion_config = vllm_config.diffusion_config
++        canvas_length = diffusion_config.canvas_length if diffusion_config else 32
++
++        text_config = self.model_config.hf_text_config
++        # Diffusion sampling params come straight from generation_config.json
++        # (RC0.1 flat layout); the checkpoint is the source of truth.
++        self.gen_config = self.model_config.try_get_generation_config()
++        max_denoising_steps = (
++            diffusion_config.max_denoising_steps if diffusion_config else None
++        ) or self.gen_config.get("max_denoising_steps", 48)
++        self.diffusion_states = DiffusionGemmaRequestStates(
++            max_num_reqs=self.max_num_reqs,
++            canvas_length=canvas_length,
++            vocab_size=self.model_config.get_vocab_size(),
++            max_denoising_steps=max_denoising_steps,
++            device=device,
++            hidden_size=text_config.hidden_size,
++            stability_threshold=self.gen_config["stability_threshold"],
++        )
++        self._req_id_to_index: dict[str, int] = {}
++
++        # Persistent buffer for per-request causal flags, updated in-place
++        # so FULL CUDA graph replay sees the latest values.
++        self._causal_buf = torch.zeros(
++            self.max_num_reqs, dtype=torch.bool, device=device
++        )
++
++        # Persistent inputs_embeds buffer — required so FULL CUDA graph
++        # capture and runtime point at the SAME memory address.
++        # `prepare_dummy_inputs` (capture path) and `prepare_inputs` (runtime
++        # path) both must hand the captured graph a tensor at this address.
++        self._inputs_embeds_buf = torch.zeros(
++            self.max_num_tokens,
++            text_config.hidden_size,
++            dtype=self.model_config.dtype,
++            device=device,
++        )
++
++    def get_supported_generation_tasks(self):
++        return ("generate",)
++
++    def custom_sampler(self, sampler: Any) -> tuple[Any, Any] | None:
++        diffusion_config = self.vllm_config.diffusion_config
++        gen = self.gen_config
++        sampler_cfg = gen.get("sampler_config") or {}
++        if "EntropyBound" not in sampler_cfg.get("_cls_name", ""):
++            raise ValueError("DiffusionGemma requires an EntropyBound sampler_config")
++        entropy_bound = sampler_cfg.get("entropy_bound")
++        if entropy_bound is None or entropy_bound <= 0:
++            raise ValueError(
++                f"entropy_bound must be a positive float (got {entropy_bound})"
++            )
++        return DiffusionSampler(
++            sampler=sampler,
++            diffusion_config=diffusion_config,
++            vocab_size=self.model_config.get_vocab_size(),
++            diffusion_states=self.diffusion_states,
++            t_min=gen["t_min"],
++            t_max=gen["t_max"],
++            entropy_bound=entropy_bound,
++            confidence_threshold=gen["confidence_threshold"],
++            embed_weight=self.model.model.embed_tokens.weight,
++            normalizer=self.model.model.normalizer,
++            sc_vocab_start=(
++                self.model.model.embed_tokens.shard_indices.org_vocab_start_index
++            ),
++        ), None
++
++    def apply_staged_writes(self) -> None:
++        pass
++
++    def add_request(self, req_index: int, new_req_data: Any) -> None:
++        self._req_id_to_index[new_req_data.req_id] = req_index
++        self.diffusion_states.add_request(req_index)
++        if not new_req_data.req_id.startswith("_warmup_"):
++            prompt_len = len(new_req_data.prompt_token_ids)
++            self.diffusion_states.prompt_len[req_index] = prompt_len
++
++    def remove_request(self, req_id: str) -> None:
++        idx = self._req_id_to_index.pop(req_id, None)
++        if idx is not None:
++            self.diffusion_states.remove_request(idx)
++
++    def get_mm_embeddings(self, scheduled_encoder_inputs, input_batch, req_states=None):
++        if not self.supports_mm_inputs:
++            return None
++
++        mm_hashes, mm_kwargs = self.encoder_runner.prepare_mm_inputs(
++            scheduled_encoder_inputs
++        )
++        if mm_kwargs:
++            encoder_outputs = self.encoder_runner.execute_mm_encoder(mm_kwargs)
++            self.encoder_cache.encoder_outputs.update(zip(mm_hashes, encoder_outputs))
++
++        # NOTE(xpu-port): upstream exposes prefill_len_np /
++        # num_computed_prefill_tokens_np on InputBatch; downstream keeps these
++        # in req_states and indexes them by idx_mapping_np (see default.py
++        # ModelState.get_mm_embeddings). Mirror that here.
++        mm_embeds, is_mm_embed = self.encoder_runner.gather_mm_embeddings(
++            input_batch.req_ids,
++            input_batch.num_tokens,
++            input_batch.num_scheduled_tokens,
++            input_batch.query_start_loc_np,
++            req_states.prefill_len.np[input_batch.idx_mapping_np],
++            req_states.num_computed_prefill_tokens[input_batch.idx_mapping_np],
++        )
++
++        if not mm_embeds:
++            # No MM tokens in this batch (e.g. all-decode step).
++            # prepare_inputs will use embed_input_ids (text-only) directly.
++            self._pending_mm_embeds = None
++            return None
++
++        # Stash raw MM ingredients for prepare_inputs to merge directly
++        # into the persistent buffer, avoiding the intermediate copy
++        # through encoder_runner.inputs_embeds.
++        self._pending_mm_embeds = (mm_embeds, is_mm_embed)
++        return None
++
++    def _apply_self_conditioning(
++        self,
++        decode_slots_np: np.ndarray,
++        decode_idx_np: np.ndarray,
++        query_start_loc_np: np.ndarray,
++        inputs_embeds: torch.Tensor,
++        sc_embeds: torch.Tensor,
++    ) -> None:
++        # One self-conditioning MLP call per decode request, over that request's
++        # query span [start, end) = its canvas. The span is the full canvas (CL)
++        # or, for the final canvas truncated near max_model_len, fewer than CL
++        # positions. sc_embeds already holds probs @ embed_weight from the prior
++        # denoise step, masked to zero by the sampler for slots not denoising
++        # this step; only the MLP runs here. CPU metadata -> no GPU syncs.
++        for slot, idx in zip(decode_slots_np.tolist(), decode_idx_np.tolist()):
++            start = int(query_start_loc_np[idx])
++            end = int(query_start_loc_np[idx + 1])
++            canvas = slice(start, end)
++            soft = sc_embeds[slot, : end - start]
++            inputs_embeds[canvas] = self.model.self_conditioning(
++                inputs_embeds[canvas], soft.to(inputs_embeds.dtype)
++            )
++
++    def prepare_inputs(self, input_batch, req_states) -> dict[str, Any]:
++        states = self.diffusion_states
++        num_tokens = input_batch.num_tokens
++        num_reqs = input_batch.num_reqs
++
++        # Write into the PERSISTENT inputs_embeds buffer so FULL CUDA graph
++        # replay sees the latest values at the captured address.
++        num_tokens_padded = input_batch.num_tokens_after_padding
++        inputs_embeds = self._inputs_embeds_buf[:num_tokens_padded]
++
++        # Populate embeddings: merge MM features when available,
++        # otherwise embed input_ids as text-only.
++        input_ids = input_batch.input_ids[:num_tokens]
++        if self._pending_mm_embeds is not None:
++            mm_embeds, is_mm_embed = self._pending_mm_embeds
++            self._pending_mm_embeds = None
++            inputs_embeds[:num_tokens].copy_(
++                self.model.embed_input_ids(
++                    input_ids,
++                    multimodal_embeddings=mm_embeds,
++                    is_multimodal=is_mm_embed,
++                )
++            )
++        else:
++            inputs_embeds[:num_tokens].copy_(self.model.embed_input_ids(input_ids))
++
++        # Apply self-conditioning ONLY for denoising decode requests.
++        if input_batch.num_draft_tokens > 0 and self._req_id_to_index:
++            slots_np = input_batch.idx_mapping_np[:num_reqs]
++            num_logits_np = np.diff(input_batch.cu_num_logits_np[: num_reqs + 1])
++            is_decode_indices_np = np.where(num_logits_np > 0)[0]
++            self._apply_self_conditioning(
++                slots_np[is_decode_indices_np],
++                is_decode_indices_np,
++                input_batch.query_start_loc_np,
++                inputs_embeds,
++                states.self_conditioning_embeds,
++            )
++
++        return {"inputs_embeds": inputs_embeds}
++
++    def prepare_dummy_inputs(self, num_reqs: int, num_tokens: int) -> dict[str, Any]:
++        # CUDA graph capture path — return a slice of the SAME persistent
++        # inputs_embeds buffer that `prepare_inputs` writes to at runtime,
++        # so the captured graph and runtime point to identical addresses.
++        return {"inputs_embeds": self._inputs_embeds_buf[:num_tokens]}
++
++    def postprocess_state(self, idx_mapping, num_sampled) -> None:
++        return None
++
++    def prepare_attn(
++        self,
++        input_batch,
++        cudagraph_mode,
++        block_tables,
++        slot_mappings,
++        attn_groups,
++        kv_cache_config,
++        for_capture=False,
++    ) -> dict[str, Any]:
++        if cudagraph_mode == CUDAGraphMode.FULL:
++            num_reqs = input_batch.num_reqs_after_padding
++            num_tokens = input_batch.num_tokens_after_padding
++        else:
++            num_reqs = input_batch.num_reqs
++            num_tokens = input_batch.num_tokens
++
++        query_start_loc_cpu = torch.from_numpy(input_batch.query_start_loc_np)
++        max_query_len = input_batch.num_scheduled_tokens.max().item()
++
++        # Per-request causal mode: encoder (commit) = causal,
++        # denoise = bidirectional. Pass GPU tensor so the attention
++        # backend can handle mixed batches.
++        actual_num_reqs = input_batch.num_reqs
++        slots = input_batch.idx_mapping[:actual_num_reqs]
++        self._causal_buf[:actual_num_reqs] = self.diffusion_states.is_encoder_phase[
++            slots
++        ]
++        if actual_num_reqs < num_reqs:
++            self._causal_buf[actual_num_reqs:num_reqs] = False
++        causal: bool | torch.Tensor = self._causal_buf[:num_reqs]
++
++        return build_attn_metadata(
++            attn_groups=attn_groups,
++            num_reqs=num_reqs,
++            num_tokens=num_tokens,
++            query_start_loc_gpu=input_batch.query_start_loc,
++            query_start_loc_cpu=query_start_loc_cpu,
++            max_query_len=max_query_len,
++            seq_lens=input_batch.seq_lens,
++            max_seq_len=self.max_model_len,
++            block_tables=block_tables,
++            slot_mappings=slot_mappings,
++            kv_cache_config=kv_cache_config,
++            causal=causal,
++        )
++
++    num_new_sampled_tokens_per_step: int = 0
++
++
++# Penalty stub for the diffusion path: the runner reads
++# penalties_state.output_bin_counts, and post_update treats None as
++# "no penalty bookkeeping".
++_NO_PENALTIES_STATE = SimpleNamespace(output_bin_counts=None)
++
++
++class DiffusionSampler:
++    """Batched accept/renoise sampler for DiffusionGemma.
++
++    Follows the same structure as ``vllm.v1.worker.gpu.sample.sampler.Sampler``:
++    decomposed into named methods, all GPU state in pre-allocated buffers,
++    no GPU→CPU syncs on the hot path.
++    """
++
++    def __init__(
++        self,
++        sampler: Any,
++        diffusion_config: Any,
++        vocab_size: int,
++        diffusion_states: DiffusionGemmaRequestStates | None = None,
++        *,
++        confidence_threshold: float,
++        t_min: float,
++        t_max: float,
++        entropy_bound: float,
++        embed_weight: torch.Tensor,
++        normalizer: torch.Tensor,
++        sc_vocab_start: int = 0,
++    ):
++        self.sampling_states = sampler.sampling_states
++        self.req_states = sampler.req_states
++        # Self-conditioning soft embed = probs @ embed_weight * normalizer,
++        # computed in the sampler (see _compiled_sample_step).
++        self.embed_weight = embed_weight
++        self.normalizer = normalizer
++        self.sc_vocab_start = sc_vocab_start
++        self.canvas_length = (
++            diffusion_config.canvas_length if diffusion_config is not None else 32
++        )
++        self.t_min = t_min
++        self.t_max = t_max
++        self.confidence_threshold = confidence_threshold
++        self.vocab_size = vocab_size
++        self.diffusion_states = diffusion_states
++        self.entropy_bound = entropy_bound
++
++        max_num_reqs = diffusion_states.max_num_reqs
++        device = diffusion_states.device
++        self._sampled = torch.zeros(
++            max_num_reqs,
++            self.canvas_length,
++            dtype=torch.int32,
++            device=device,
++        )
++        self._num_sampled = torch.zeros(
++            max_num_reqs,
++            dtype=torch.int32,
++            device=device,
++        )
++        self._decode_slots = UvaBackedTensor(max_num_reqs, dtype=torch.int64)
++        self._decode_idx = UvaBackedTensor(max_num_reqs, dtype=torch.int64)
++        self._query_lens = UvaBackedTensor(max_num_reqs, dtype=torch.int32)
++        self._num_logits = UvaBackedTensor(max_num_reqs, dtype=torch.int32)
++
++        # Per-slot stash for logprobs computed on the converging denoise step.
++        # Populated after the post-sample kernel detects convergence; consumed
++        # on the subsequent commit step when num_sampled=CANVAS_LEN.
++        self._pending_logprobs: dict[int, LogprobsTensors] = {}
++
++    def add_request(self, req_idx: int, prompt_len: int, sampling_params: Any) -> None:
++        if use_penalty(sampling_params):
++            logger.warning_once(
++                "DiffusionGemma does not support repetition/frequency/presence "
++                "penalties; ignoring them for this request."
++            )
++        self.sampling_states.add_request(req_idx, sampling_params)
++
++    def apply_staged_writes(self) -> None:
++        self.sampling_states.apply_staged_writes()
++
++    @property
++    def penalties_state(self):
++        # Diffusion applies no penalties. The runner reads
++        # penalties_state.output_bin_counts, so expose a stub holding None;
++        # post_update treats None bin counts as "no penalty bookkeeping".
++        return _NO_PENALTIES_STATE
++
++    # ------------------------------------------------------------------
++    # Prefill
++    # ------------------------------------------------------------------
++
++    def _finish_prefills(
++        self, input_batch: Any, prefill_indices_np: "np.ndarray"
++    ) -> None:
++        """Transition requests whose prompt completes this step to denoising.
++
++        Initializes their canvas, seeds draft tokens, and flips
++        is_encoder_phase to False. Mid-chunk requests (prompt longer than the
++        token budget, split across multiple prefill chunks) are left untouched
++        so is_encoder_phase stays True and prepare_attn keeps causal attention
++        for their remaining chunks. (XPU port: prefill_len /
++        num_computed_prefill_tokens live on req_states, slot-indexed via
++        idx_mapping_np, rather than on InputBatch as upstream. The += this step
++        happens later in postprocess, so num_computed_prefill_tokens here is the
++        pre-step value, matching upstream's arithmetic.)
++        """
++        states = self.diffusion_states
++        CL = self.canvas_length
++        slots_np = input_batch.idx_mapping_np[prefill_indices_np]
++        done_prefill_np = (
++            self.req_states.num_computed_prefill_tokens[slots_np]
++            + input_batch.num_scheduled_tokens[prefill_indices_np]
++            >= self.req_states.prefill_len.np[slots_np]
++        )
++        ps = slots_np[done_prefill_np]
++        if len(ps) == 0:
++            return
++        states.init_canvas(ps)
++        self.req_states.draft_tokens[ps, :CL] = states.canvas[ps]
++        ps_gpu = async_copy_to_gpu(
++            ps.astype(np.int64), device=states.is_encoder_phase.device
++        )
++        states.is_encoder_phase.index_fill_(0, ps_gpu, False)
++
++    def _handle_prefill(
++        self,
++        input_batch: Any,
++        device: torch.device,
++    ) -> SamplerOutput:
++        num_reqs = input_batch.num_reqs
++        self._finish_prefills(input_batch, np.arange(num_reqs))
++        sampled = self._sampled[:num_reqs, :1]
++        sampled.zero_()
++        num_sampled = self._num_sampled[:num_reqs]
++        num_sampled.zero_()
++        return SamplerOutput(
++            sampled_token_ids=sampled,
++            logprobs_tensors=None,
++            num_nans=None,
++            num_sampled=num_sampled,
++            num_rejected=num_sampled,
++        )
++
++    # ------------------------------------------------------------------
++    # Decode helpers
++    # ------------------------------------------------------------------
++
++    def _build_output(
++        self,
++        input_batch: Any,
++        sampled: torch.Tensor,
++        num_sampled: torch.Tensor,
++        per_req_nlogits_np: np.ndarray,
++        device: torch.device,
++        logprobs_tensors: LogprobsTensors | None = None,
++    ) -> SamplerOutput:
++        """Compute num_rejected and build SamplerOutput."""
++        num_reqs = input_batch.num_reqs
++
++        self._query_lens.np[:num_reqs] = np.diff(
++            input_batch.query_start_loc_np[: num_reqs + 1]
++        )
++        self._num_logits.np[:num_reqs] = per_req_nlogits_np
++        self._query_lens.copy_to_uva()
++        self._num_logits.copy_to_uva()
++
++        num_rejected = _compute_num_rejected(
++            self._num_logits.gpu[:num_reqs],
++            num_sampled,
++            input_batch.query_start_loc[: num_reqs + 1],
++        )
++
++        return SamplerOutput(
++            sampled_token_ids=sampled,
++            logprobs_tensors=logprobs_tensors,
++            num_nans=None,
++            num_sampled=num_sampled,
++            num_rejected=num_rejected,
++        )
++
++    # ------------------------------------------------------------------
++    # Main entry point
++    # ------------------------------------------------------------------
++
++    def __call__(
++        self,
++        logits: torch.Tensor,
++        input_batch: Any,
++        draft_logits: torch.Tensor | None = None,
++    ) -> SamplerOutput:
++        num_reqs = input_batch.num_reqs
++        device = logits.device
++
++        if input_batch.num_draft_tokens == 0:
++            return self._handle_prefill(input_batch, device)
++
++        # PROFILE(xpu): time the diffusion sampler (full-vocab per-request loop)
++        # to size its share vs the backbone forward. Zero overhead when off.
++        _dg_prof = os.environ.get("DIFFUSION_PROFILE_FWD", "0") == "1"
++        if _dg_prof:
++            torch.xpu.synchronize()
++            _ts0 = time.perf_counter()
++
++        # --- CPU/NumPy setup (outside compile): split decode vs prefill, init
++        # canvas for any new prefills, and stage decode slot indices to GPU. ---
++        states = self.diffusion_states
++        CL = self.canvas_length
++        slots_np = input_batch.idx_mapping_np[:num_reqs]
++        per_req_nlogits_np = np.diff(input_batch.cu_num_logits_np[: num_reqs + 1])
++
++        decode_indices_np = np.where(per_req_nlogits_np > 0)[0]
++        prefill_indices_np = np.where(per_req_nlogits_np == 0)[0]
++        decode_slots_np = slots_np[decode_indices_np]
++
++        if len(prefill_indices_np) > 0:
++            self._finish_prefills(input_batch, prefill_indices_np)
++
++        num_decode = len(decode_indices_np)
++        self._decode_slots.np[:num_decode] = decode_slots_np
++        self._decode_idx.np[:num_decode] = decode_indices_np
++        self._decode_slots.copy_to_uva()
++        self._decode_idx.copy_to_uva()
++        decode_slots = self._decode_slots.gpu[:num_decode]
++        decode_idx = self._decode_idx.gpu[:num_decode]
++
++        # Real canvas length per decode request. Equals CL except when a canvas
++        # was truncated near max_model_len, in which case the scheduler gave us
++        # fewer than CL logits for that request.
++        valid_canvas_len_np = per_req_nlogits_np[per_req_nlogits_np > 0]
++        valid_canvas_len = async_copy_to_gpu(
++            valid_canvas_len_np.astype(np.int64), device=device
++        )
++
++        # Pad any truncated canvas back to CL so the uniform-CL sampler math
++        # holds. Phantom (padded) positions are zeroed → uniform logits → high
++        # entropy (no premature convergence) and argmax 0 (stable); they are
++        # never committed (num_sampled == real length).
++        if num_decode > 0 and valid_canvas_len_np.min() < CL:
++            ar = torch.arange(CL, device=device)
++            starts = valid_canvas_len.cumsum(0) - valid_canvas_len  # row offset per req
++            valid = ar.unsqueeze(0) < valid_canvas_len.unsqueeze(1)  # [num_decode, CL]
++            src = (starts.unsqueeze(1) + ar.unsqueeze(0)).clamp_max(logits.shape[0] - 1)
++            logits = logits[src.reshape(-1)] * valid.reshape(-1, 1).to(logits.dtype)
++
++        # Cleared inside _compiled_sample_step so prefill/non-decode slots stay 0.
++        sampled = self._sampled[:num_reqs]
++        num_sampled = self._num_sampled[:num_reqs]
++
++        all_slots = input_batch.idx_mapping[:num_reqs]
++
++        # Snapshot which slots are committing BEFORE the compiled step runs,
++        # since it mutates is_encoder_phase (commit→False, converge→True).
++        is_committing = states.is_encoder_phase[decode_slots].clone()
++
++        # --- Per-decode-request sample step ---
++        # NOTE(xpu-port): the sample step's vocab-wide ops (softcap, log_softmax,
++        # exp, argmax, sort over [num_decode*CL, 262144]) launch a single Level
++        # Zero kernel whose size scales with num_decode. At max_num_seqs>1 that
++        # tensor (e.g. [4*256, 262144]) exceeds the LZ per-launch resource limit
++        # (UR_RESULT_ERROR_OUT_OF_RESOURCES). All ops are per-request along the
++        # num_decode axis, so we loop one decode request at a time: each call
++        # sees [1*CL, vocab] — the shape already proven to launch at
++        # max_num_seqs=1 — and the in-place state writes (indexed by each
++        # request's own decode_slots) compose exactly as the batched call did.
++        # scaled parts are collected for the logprobs pass below — but ONLY
++        # when logprobs are actually requested. `scaled` (the per-request
++        # temperature-scaled full-vocab logits, [num_decode, CL, ~262k] fp32)
++        # is consumed solely by the logprobs block; with no logprobs (the
++        # common serving case, max_num_logprobs == NO_LOGPROBS) retaining every
++        # per-request scaled_d and torch.cat-ing them is pure dead work — a
++        # large fp32 transient + copy per denoise step. Skip it then.
++        # (env DISABLE_DG_SAMPLER_OPT=1 restores the always-collect behavior.)
++        _slots_np_early = input_batch.idx_mapping_np[:num_reqs]
++        _want_scaled = (
++            self.sampling_states.max_num_logprobs(_slots_np_early) >= 0
++            or os.environ.get("DISABLE_DG_SAMPLER_OPT", "0") == "1"
++        )
++        scaled_parts: list[torch.Tensor] = []
++        for d in range(num_decode):
++            sl = slice(d, d + 1)
++            scaled_d = _compiled_sample_step(
++                logits[d * CL : (d + 1) * CL],
++                decode_slots[sl],
++                decode_idx[sl],
++                all_slots,
++                valid_canvas_len[sl],
++                # State
++                states.canvas,
++                states.argmax_canvas,
++                states.step,
++                states.is_encoder_phase,
++                states.confident,
++                states.self_conditioning_embeds,
++                self.embed_weight,
++                self.normalizer,
++                self.sc_vocab_start,
++                states.accepted_canvas_history,
++                states.accepted_canvas_history_len,
++                # Output
++                sampled,
++                num_sampled,
++                self.req_states.draft_tokens,
++                # Config
++                max_denoising_steps=float(states.max_denoising_steps),
++                t_min=self.t_min,
++                t_max=self.t_max,
++                confidence_threshold=self.confidence_threshold,
++                vocab_size=self.vocab_size,
++                CL=self.canvas_length,
++                ST=states.stability_threshold,
++                entropy_bound=self.entropy_bound,
++                zero_outputs=(d == 0),
++            )
++            if _want_scaled:
++                scaled_parts.append(scaled_d)
++            # else: scaled_d is dead — drop it so the [1, CL, vocab] fp32
++            # transient is freed each iteration instead of being retained+cat.
++        # [num_decode, CL, vocab] — same layout the single batched call returned.
++        # Only materialized when logprobs need it (see _want_scaled above).
++        scaled = (
++            torch.cat(scaled_parts, dim=0)
++            if scaled_parts
++            else logits.new_empty((0, CL, logits.shape[-1]))
++        )
++
++        # --- Logprobs: stash on convergence, return on commit ---
++        slots_np = input_batch.idx_mapping_np[:num_reqs]
++        is_decode_np = per_req_nlogits_np > 0
++
++        logprobs_tensors = None
++        max_num_logprobs = self.sampling_states.max_num_logprobs(slots_np)
++        if max_num_logprobs >= 0:
++            # Denoise steps that just converged: the compiled step flipped
++            # is_encoder_phase from False→True. Detect as slots where
++            # is_encoder_phase is now True but is_committing was False.
++            converged_mask = states.is_encoder_phase[decode_slots]
++            just_converged = converged_mask & ~is_committing
++            if just_converged.any():
++                flat_logits = scaled.reshape(-1, scaled.shape[-1])
++                argmax_tokens = scaled.argmax(dim=-1)
++                for local_idx in just_converged.nonzero(as_tuple=True)[0]:
++                    li = local_idx.item()
++                    slot = decode_slots[local_idx]
++                    # Stash only the real canvas positions (== CL unless this
++                    # canvas was truncated near max_model_len); padded tail
++                    # positions are never emitted.
++                    k_i = int(valid_canvas_len_np[li])
++                    start = li * CL
++                    self._pending_logprobs[slot.item()] = compute_topk_logprobs(
++                        flat_logits[start : start + k_i],
++                        max_num_logprobs,
++                        argmax_tokens[local_idx][:k_i],
++                    )
++
++            # Commit steps: is_committing was True at entry. Reassemble
++            # previously stashed logprobs and attach to SamplerOutput.
++            if is_committing.any() and self._pending_logprobs:
++                parts_ids, parts_lp, parts_ranks = [], [], []
++                cu_gen: list[int] = []
++                flat_offset = 0
++                for i in range(num_reqs):
++                    cu_gen.append(flat_offset)
++                    slot = int(slots_np[i])
++                    if is_decode_np[i] and slot in self._pending_logprobs:
++                        lp = self._pending_logprobs.pop(slot)
++                        parts_ids.append(lp.logprob_token_ids)
++                        parts_lp.append(lp.logprobs)
++                        parts_ranks.append(lp.selected_token_ranks)
++                        flat_offset += lp.logprobs.shape[0]
++                if parts_ids:
++                    logprobs_tensors = LogprobsTensors(
++                        logprob_token_ids=torch.cat(parts_ids),
++                        logprobs=torch.cat(parts_lp),
++                        selected_token_ranks=torch.cat(parts_ranks),
++                        cu_num_generated_tokens=cu_gen,
++                    )
++
++        if _dg_prof:
++            torch.xpu.synchronize()
++            logger.info("DG_SAMPLER num_decode=%d %.1fms",
++                        num_decode, (time.perf_counter() - _ts0) * 1000)
++
++        return self._build_output(
++            input_batch,
++            sampled,
++            num_sampled,
++            per_req_nlogits_np,
++            device,
++            logprobs_tensors=logprobs_tensors,
++        )
+diff --git a/vllm/model_executor/models/gemma4.py b/vllm/model_executor/models/gemma4.py
+index 1b50db61c..1bb03ebc8 100644
+--- a/vllm/model_executor/models/gemma4.py
++++ b/vllm/model_executor/models/gemma4.py
+@@ -18,6 +18,7 @@
+ # limitations under the License.
+ """Gemma 4 model implementation for vLLM."""
+ 
++import os
+ from collections.abc import Iterable
+ from dataclasses import replace
+ from itertools import islice
+@@ -43,6 +44,76 @@ from vllm.model_executor.layers.fused_moe import (
+     fused_moe_make_expert_params_mapping,
+ )
+ from vllm.model_executor.layers.layernorm import RMSNorm
++from vllm.model_executor.layers.esimd_utils import (
++    ESIMD_AVAILABLE,
++    disable_esimd_norm,
++    esimd_fused_add_rms_norm,
++    esimd_fused_scaled_add_rms_norm,
++    esimd_rms_norm,
++)
++
++# PROFILE(xpu): env-gated per-section timing for the decoder layer.
++# DIFFUSION_PROFILE_LAYER=1 syncs around attn/mlp/moe/norm to attribute the
++# 256-canvas forward cost. The syncs distort ABSOLUTE numbers but give correct
++# RELATIVE proportions (the thing we use to pick an optimization target).
++# Zero overhead when off. Dump via _dg_layer_prof_dump().
++import time as _time
++
++_DG_LAYER_PROF = os.environ.get("DIFFUSION_PROFILE_LAYER", "0") == "1"
++_dg_layer_acc: dict[str, float] = {}
++_dg_layer_cnt: dict[str, int] = {}
++
++
++def _dg_prof_section(name: str, fn):
++    if not _DG_LAYER_PROF:
++        return fn()
++    torch.xpu.synchronize()
++    _t0 = _time.perf_counter()
++    out = fn()
++    torch.xpu.synchronize()
++    _dg_layer_acc[name] = _dg_layer_acc.get(name, 0.0) + (_time.perf_counter() - _t0)
++    _dg_layer_cnt[name] = _dg_layer_cnt.get(name, 0) + 1
++    return out
++
++
++def dg_layer_prof_dump_and_reset(logger_obj):
++    """Log accumulated per-section times (summed over all layers of one or
++    more forwards) and reset. Called from DiffusionGemma.forward when
++    DIFFUSION_PROFILE_LAYER=1."""
++    if not _DG_LAYER_PROF or not _dg_layer_acc:
++        return
++    parts = " ".join(
++        f"{k}={_dg_layer_acc[k]*1000:.1f}ms/{_dg_layer_cnt[k]}call"
++        for k in sorted(_dg_layer_acc)
++    )
++    logger_obj.info("DG_LAYER_PROF %s", parts)
++    _dg_layer_acc.clear()
++    _dg_layer_cnt.clear()
++
++
++def _esimd_rms_norm_or_fallback(
++    norm_module,
++    hidden_states: torch.Tensor,
++) -> torch.Tensor:
++    """Run an RMSNorm via esimd_rms_norm at decode (M==1) when possible;
++    fall back to the PyTorch RMSNorm module otherwise. Caches a contiguous
++    output buffer on the module."""
++    if (
++        ESIMD_AVAILABLE
++        and not disable_esimd_norm()
++        and hidden_states.shape[0] == 1
++        and hidden_states.is_contiguous()
++        and hidden_states.dtype == torch.float16
++        and norm_module.weight.dtype == torch.float16
++    ):
++        if not hasattr(norm_module, "_esimd_out_buf"):
++            norm_module._esimd_out_buf = torch.empty_like(hidden_states)
++        out = norm_module._esimd_out_buf
++        esimd_rms_norm(
++            hidden_states, out, norm_module.weight.data,
++            norm_module.variance_epsilon)
++        return out
++    return norm_module(hidden_states)
+ from vllm.model_executor.layers.linear import (
+     ColumnParallelLinear,
+     MergedColumnParallelLinear,
+@@ -160,11 +231,16 @@ def gemma4_fused_routing_kernel_triton(
+     topk: int,
+     per_expert_scale: torch.Tensor,
+     num_warps: int = 1,
++    weights_dtype: torch.dtype = torch.float32,
+ ) -> tuple[torch.Tensor, torch.Tensor]:
+     gating_output = gating_output.contiguous()
+     per_expert_scale = per_expert_scale.contiguous()
+     T, E = gating_output.shape
+-    weights = torch.empty(T, topk, dtype=torch.float32, device=gating_output.device)
++    # weights_dtype: decode (M==1) passes fp16 to skip the downstream cast;
++    # prefill keeps fp32 (the DPAS expert path is precision-sensitive — fp16
++    # routing weights drop gsm8k to 4/5). The triton kernel's tl.store casts
++    # to the buffer dtype, so all reductions still run in fp32 internally.
++    weights = torch.empty(T, topk, dtype=weights_dtype, device=gating_output.device)
+     ids = torch.empty(T, topk, dtype=torch.int32, device=gating_output.device)
+     BLOCK_E = triton.next_power_of_2(E)
+     _gemma4_routing_kernel[(T,)](
+@@ -241,7 +317,114 @@ class Gemma4MLP(nn.Module):
+         )
+         self.act_fn = get_act_and_mul_fn(hidden_activation)
+ 
++        # ESIMD FP8 dense-MLP fast path (decode / small batch).
++        # The FP8 GEMV kernel reaches only ~23% HBM bandwidth at M=1 on BMG,
++        # while esimd_gemm_fp8_pert reaches ~100% even at M=1, so route ALL
++        # M<=MAX_DECODE_BSZ (including M==1) through GEMM. Buffers are
++        # pre-allocated to avoid per-forward allocation. Gated by
++        # DISABLE_ESIMD_DENSE. fp8-weight presence is probed lazily on first
++        # forward (quant state is only set after weight load). The down_proj
++        # is RowParallel with reduce_results=True, so the fast path (which
++        # bypasses down_proj.forward) MUST all_reduce manually under TP>1.
++        _qname = quant_config.get_name() if quant_config is not None else ""
++        self._dense_quant = _qname  # "fp8" | "sym_int4" | ""
++        # fp8: default OFF (31B dense MLP already at BMG bandwidth wall, esimd
++        #   same-speed as native, A/B 32.56 vs 32.62ms). ENABLE_ESIMD_DENSE=1.
++        # sym_int4: default ON. native sym_int4 decode is NOT bandwidth-optimal
++        #   (INT4 ITL 31.5ms vs its ~16ms weight-read floor), so esimd int4
++        #   GEMM has real headroom. DISABLE_ESIMD_DENSE_INT4=1 to turn off.
++        self._dense_esimd_enabled = ESIMD_AVAILABLE and (
++            (_qname == "fp8"
++             and os.environ.get("ENABLE_ESIMD_DENSE", "0") == "1")
++            or (_qname == "sym_int4"
++                and os.environ.get("DISABLE_ESIMD_DENSE_INT4", "0") != "1")
++        )
++        self._dense_esimd_ready = None  # None = not yet probed
++        self._dense_max_bsz = int(os.environ.get("MAX_DECODE_BSZ", "64"))
++
++    def _probe_dense_esimd(self) -> bool:
++        """Verify quantized weight/scale tensors exist; allocate decode
++        buffers; pick the esimd op. Returns False (disabling) if missing."""
++        try:
++            if self._dense_quant == "fp8":
++                gu_w = self.gate_up_proj.weight
++                gu_s = self.gate_up_proj.weight_scale
++                dn_w = self.down_proj.weight
++                dn_s = self.down_proj.weight_scale
++                if gu_w.dtype not in (torch.float8_e4m3fn,
++                                      torch.float8_e5m2):
++                    return False
++                from custom_esimd_kernels_vllm import esimd_gemm_fp8_pert
++                self._dense_op = esimd_gemm_fp8_pert
++                self._dense_op_gemm = None  # fp8 uses one op for all M
++                self._dense_int4_decode_only = False
++                gu_n, dn_n = gu_w.shape[0], dn_w.shape[0]
++            elif self._dense_quant == "sym_int4":
++                gu_w = self.gate_up_proj.weight_esimd
++                gu_s = self.gate_up_proj.scale_esimd
++                dn_w = self.down_proj.weight_esimd
++                dn_s = self.down_proj.scale_esimd
++                gu_n, dn_n = gu_s.shape[0], dn_s.shape[0]
++                # M==1: esimd_gemv_int4 (GEMV). M>1: esimd_gemm_int4_pgrp
++                # (DPAS GEMM). Both group32-aware (infer group from scale dim).
++                from custom_esimd_kernels_vllm import esimd_gemv_int4
++                self._dense_op = esimd_gemv_int4
++                # M>1 GEMM (esimd_gemm_int4_pgrp) is opt-in: on gemma4-31B M=8
++                # it underperforms native sym_int4 (193 vs 236 tok/s) because
++                # the DPAS int4 GEMM is tuned for large-M prefill, not small
++                # decode batches. M=1 GEMV is the proven win. Enable the GEMM
++                # path with ENABLE_ESIMD_INT4_GEMM=1.
++                if os.environ.get("ENABLE_ESIMD_INT4_GEMM", "0") == "1":
++                    from custom_esimd_kernels_vllm import esimd_gemm_int4_pgrp
++                    self._dense_op_gemm = esimd_gemm_int4_pgrp
++                else:
++                    self._dense_op_gemm = None
++                self._dense_int4_decode_only = (self._dense_op_gemm is None)
++            else:
++                return False
++        except AttributeError:
++            return False
++        dev = gu_w.device
++        mb = self._dense_max_bsz
++        self._m_gate_up = torch.empty(
++            mb, gu_n, dtype=torch.float16, device=dev)
++        self._m_down = torch.empty(
++            mb, dn_n, dtype=torch.float16, device=dev)
++        self._gu_w, self._gu_s = gu_w, gu_s
++        self._dn_w, self._dn_s = dn_w, dn_s
++        from vllm.distributed import get_tensor_model_parallel_world_size
++        self._dense_tp = get_tensor_model_parallel_world_size()
++        return True
++
+     def forward(self, x: torch.Tensor) -> torch.Tensor:
++        if self._dense_esimd_enabled:
++            if self._dense_esimd_ready is None:
++                self._dense_esimd_ready = self._probe_dense_esimd()
++            n_tokens = x.shape[0]
++            _i4_blk = (getattr(self, "_dense_int4_decode_only", False)
++                       and n_tokens != 1)
++            if (
++                self._dense_esimd_ready
++                and not _i4_blk
++                and x.is_contiguous()
++                and x.dtype == torch.float16
++                and 1 <= n_tokens <= self._dense_max_bsz
++            ):
++                gate_up = self._m_gate_up[:n_tokens]
++                down = self._m_down[:n_tokens]
++                _gemm = getattr(self, "_dense_op_gemm", None)
++                if n_tokens == 1 or _gemm is None:
++                    _op_gu = _op_dn = self._dense_op
++                else:
++                    _op_gu = _op_dn = _gemm
++                _op_gu(x, self._gu_w, self._gu_s, gate_up)
++                act = self.act_fn(gate_up)
++                _op_dn(act, self._dn_w, self._dn_s, down)
++                if self._dense_tp > 1:
++                    from vllm.distributed import (
++                        tensor_model_parallel_all_reduce)
++                    down = tensor_model_parallel_all_reduce(down)
++                return down
+         gate_up, _ = self.gate_up_proj(x)
+         x = self.act_fn(gate_up)
+         x, _ = self.down_proj(x)
+@@ -291,6 +474,33 @@ class Gemma4Router(nn.Module):
+ 
+     def forward(self, x: torch.Tensor) -> torch.Tensor:
+         """Returns raw router logits [T, E]."""
++        # Decode-batch fast path (M==1):
++        # 1. fold the constant root_size = 1/sqrt(hidden_size) into the learnable
++        #    `scale` once → cached fp16 [hidden] tensor.
++        # 2. use esimd_gemv_fp16 for the projection — measured ~4× faster than
++        #    PyTorch F.linear on (N=128, K=2816) gemma4 router shape.
++        # The downstream consumer (gemma4_fused_routing_kernel_triton) does its
++        # own fp32 promotion, so we skip GateLinear's fp16->fp32 output cast.
++        if x.shape[0] == 1 and not getattr(self, "_disable_fast_router", False):
++            if not hasattr(self, "_scale_with_root"):
++                self._scale_with_root = (
++                    self.scale.data * self.root_size).to(x.dtype).contiguous()
++            x = self.norm(x)
++            x = x * self._scale_with_root
++            if (ESIMD_AVAILABLE
++                    and os.environ.get("DISABLE_ESIMD_ROUTER_GEMV", "0") != "1"
++                    and x.is_contiguous()
++                    and self.proj.weight.is_contiguous()
++                    and x.dtype == torch.float16
++                    and self.proj.weight.dtype == torch.float16):
++                if not hasattr(self, "_router_logits_buf"):
++                    n_experts = self.proj.weight.shape[0]
++                    self._router_logits_buf = torch.empty(
++                        1, n_experts, dtype=torch.float16, device=x.device)
++                from custom_esimd_kernels_vllm import esimd_gemv_fp16
++                esimd_gemv_fp16(x, self.proj.weight, self._router_logits_buf)
++                return self._router_logits_buf
++            return torch.nn.functional.linear(x, self.proj.weight)
+         x = self.norm(x)
+         x = x * self.root_size.to(x.dtype)
+         x = x * self.scale.to(x.dtype)
+@@ -334,9 +544,63 @@ class Gemma4MoE(nn.Module):
+             topk: int,
+             renormalize: bool,
+         ) -> tuple[torch.Tensor, torch.Tensor]:
++            _lean = os.environ.get("DISABLE_MOE_ROUTING_LEAN", "0") != "1"
++            _decode = gating_output.shape[0] == 1
++            if (current_platform.is_xpu() and _decode and _lean
++                    and os.environ.get("DISABLE_MOE_PROD_TOPK", "0") != "1"
++                    and gating_output.shape[-1] == 128 and topk == 8):
++                # Production moe_topk (fp32-internal softmax+top8+norm) replaces
++                # the per-layer triton routing launch (~130us). Verified
++                # numerically aligned with triton (200-trial id-set match, weight
++                # diff <2e-4) AND gsm8k 5/5 — the fp32-internal softmax is the key
++                # (the fp16-internal esimd_moe_topk path below drops to 4/5).
++                # Same-binary A/B: 21.45 -> 20.62ms. Then fold per_expert_scale.
++                import torch as _torch
++                pi, pw = _torch.ops.moe_ops.moe_topk(
++                    gating_output.contiguous(), topk, True)
++                w = pw * per_expert_scale[pi.long()].to(_torch.float16)
++                return w, pi
++            if (current_platform.is_xpu() and not _decode
++                    and os.environ.get("DISABLE_MOE_PROD_TOPK_BATCH", "0") != "1"
++                    and gating_output.shape[-1] == 128 and topk == 8):
++                # Batch (M>1) routing via the SAME fp32-internal moe_topk used by
++                # decode (kernel parallelizes over n_tokens; verified 5/5). Replaces
++                # gemma4_fused_routing_kernel_triton (the ~8% batch bottleneck per
++                # unitrace). fp32-internal softmax avoids the fp16-prefill accuracy
++                # loss; output weights kept fp32 to match the batch MoE consumer.
++                import torch as _torch
++                # moe_topk requires fp16 logits; gating_output is fp32 at prefill.
++                # Cast is safe — the kernel softmax is fp32-internal regardless.
++                pi, pw = _torch.ops.moe_ops.moe_topk(
++                    gating_output.to(_torch.float16).contiguous(), topk, True)
++                w = pw.to(_torch.float32) * per_expert_scale[pi.long()].to(_torch.float32)
++                return w, pi
++            if (current_platform.is_xpu() and _decode and _lean
++                    and ESIMD_AVAILABLE
++                    and os.environ.get("ENABLE_MOE_ESIMD_ROUTING", "0") == "1"
++                    and gating_output.shape[-1] == 128 and topk == 8):
++                # Decode fast routing: esimd_moe_topk (fused softmax+top8+norm,
++                # ~4us vs ~130us triton). NOTE: opt-in only (ENABLE_MOE_ESIMD_
++                # ROUTING=1) — although a single-shot unit test matched triton
++                # exactly, on real gsm8k decode it diverges on near-tie top8
++                # boundaries and drops accuracy to 4/5. Kept as future material;
++                # needs tie-break / fp32-internal alignment with triton first.
++                from custom_esimd_kernels_vllm import esimd_moe_topk
++                if not hasattr(self, "_route_tv"):
++                    self._route_tv = torch.empty(1, topk, dtype=torch.float16,
++                                                 device=gating_output.device)
++                    self._route_ti = torch.empty(1, topk, dtype=torch.int32,
++                                                  device=gating_output.device)
++                esimd_moe_topk(gating_output.contiguous(),
++                               self._route_tv, self._route_ti, 1)
++                w = self._route_tv * per_expert_scale[self._route_ti.long()].to(torch.float16)
++                return w, self._route_ti
+             if current_platform.is_cuda_alike() or current_platform.is_xpu():
++                _wdt = (torch.float16
++                        if (_decode and _lean)
++                        else torch.float32)
+                 return gemma4_fused_routing_kernel_triton(
+-                    gating_output, topk, per_expert_scale
++                    gating_output, topk, per_expert_scale, weights_dtype=_wdt
+                 )
+ 
+             return gemma4_routing_function_torch(gating_output, topk, per_expert_scale)
+@@ -358,7 +622,257 @@ class Gemma4MoE(nn.Module):
+             activation="gelu_tanh",
+         )
+ 
++        # ESIMD MoE fast path (decode batch only). Replaces Triton
++        # fused_moe_kernel for fp8 e4m3 weights at small M. Routing is
++        # computed externally so per_expert_scale is honored exactly.
++        self._esimd_routing_fn = routing_function
++        self._top_k = config.top_k_experts
++        self._n_routed_experts = config.num_experts
++        self._esimd_disabled = (
++            os.environ.get("DISABLE_ESIMD_MOE_GELU", "0") == "1"
++        )
++        # Cache for shape-validity check; set on first forward.
++        self._esimd_shape_ok: bool | None = None
++
++    def _esimd_can_run(self, x: torch.Tensor) -> bool:
++        if self._esimd_disabled or not ESIMD_AVAILABLE:
++            return False
++        if not (current_platform.is_xpu() and x.dtype == torch.float16):
++            return False
++        # Decode-batch (M==1) only. Tried extending the routed esimd MoE to
++        # M>1 for DiffusionGemma's 256-canvas: the isolated kernel matches
++        # torch ref up to T=256 (max_abs_diff 6e-5), but wired into the real
++        # model the *routed* batch path produced empty/garbage output
++        # (gsm8k 0/5, chars=0) AND ran ~28x slower than Triton fp8 fused_moe
++        # (76s vs 2.7s/prompt). The internal output-buffer ring + routed
++        # batch combination is not correct/fast at M=256. This *routed* path
++        # stays M==1; the separate expert-GROUPED path (_forward_grouped, gated
++        # in Gemma4MoE.forward) is the M>1 batch path and is verified correct.
++        if x.size(0) != 1:
++            return False
++        if self._esimd_shape_ok is False:
++            return False
++        if self._esimd_shape_ok is None:
++            self._esimd_shape_ok = self._validate_esimd_shapes()
++            if not self._esimd_shape_ok:
++                logger.warning_once(
++                    "Gemma4MoE: esimd MoE fast path disabled due to shape "
++                    "mismatch; falling back to FusedMoE."
++                )
++        return self._esimd_shape_ok
++
++    def _validate_esimd_shapes(self) -> bool:
++        e = self.experts
++        w13 = getattr(e, "w13_weight", None)
++        w2 = getattr(e, "w2_weight", None)
++        if w13 is None or w2 is None:
++            return False
++        if w13.dtype != torch.float8_e4m3fn or w2.dtype != torch.float8_e4m3fn:
++            return False
++        # Native vllm FusedMoE layout: w13 [E, 2*inter, hidden],
++        # w2 [E, hidden, inter]. Backend-specific transposes (e.g. XPUExperts)
++        # produce a different shape and must fall back.
++        E = w13.size(0)
++        if w2.size(0) != E:
++            return False
++        two_inter = w13.size(1)
++        hidden = w13.size(2)
++        if two_inter % 2 != 0:
++            return False
++        inter = two_inter // 2
++        if w2.shape != (E, hidden, inter):
++            return False
++        if hidden % 16 != 0 or inter % 16 != 0:
++            return False
++        scale_attr = "w13_weight_scale"
++        gu_s = getattr(e, scale_attr, None)
++        dn_s = getattr(e, "w2_weight_scale", None)
++        if gu_s is None or dn_s is None:
++            return False
++        # Per-tensor MoE keeps scales as [E] after process_weights; reject
++        # block-quant or unsqueezed shapes.
++        if gu_s.shape != (E,) or dn_s.shape != (E,):
++            return False
++        return True
++
++    def _esimd_batch_can_run(self, x: torch.Tensor) -> bool:
++        if self._esimd_disabled or not ESIMD_AVAILABLE:
++            return False
++        if not (current_platform.is_xpu() and x.dtype == torch.float16):
++            return False
++        m = x.size(0)
++        if m <= 1:
++            return False  # M==1 handled by the decode GEMV path
++        if os.environ.get("DISABLE_ESIMD_MOE_BATCH_GROUPED", "0") == "1":
++            return False
++        if m > int(os.environ.get("MOE_GROUPED_MAX_M", "2048")):
++            return False
++        # fp8-only: the grouped kernels (moe_up/down_fp8_grouped) dequant
++        # fp8_e4m3 weights. int4 (sym_int4, uint8-packed) must NOT use this
++        # path -- it stays on its own int4 route / Triton. (_validate_esimd_
++        # shapes also rejects non-fp8 weights, but gate it explicitly here.)
++        w13 = getattr(self.experts, "w13_weight", None)
++        if w13 is None or w13.dtype != torch.float8_e4m3fn:
++            return False
++        # Reuse the per-tensor fp8 shape validation (w13/w2 layout + [E] scales).
++        if self._esimd_shape_ok is None:
++            self._esimd_shape_ok = self._validate_esimd_shapes()
++        return bool(self._esimd_shape_ok)
++
++    def _forward_grouped(self, x: torch.Tensor,
++                         router_logits: torch.Tensor) -> torch.Tensor:
++        import custom_esimd_kernels_vllm.moe_int4_prefill_ops  # noqa: registers gather
++        e = self.experts
++        M = x.size(0)
++        # External routing (folds per_expert_scale): weights [M, top_k] fp16,
++        # indices [M, top_k] int32.
++        weights, indices = self._esimd_routing_fn(
++            x, router_logits, self._top_k, True)
++        weights = weights.to(torch.float16).contiguous()
++        indices = indices.to(torch.int32).contiguous()
++        # Gather tokens by expert (weight-dtype agnostic).
++        go = torch.ops.moe_int4_prefill_ops.moe_prefill_gather_forward_v2(
++            indices, self._n_routed_experts)
++        expert_offsets, expert_tokens = go[0], go[1]
++        # fp8 weights as uint8 view for the grouped kernels.
++        w13u = e.w13_weight.view(torch.uint8)
++        w2u = e.w2_weight.view(torch.uint8)
++        rw_flat = weights.reshape(-1).contiguous()  # [M*top_k] pair-indexed
++        inter = torch.ops.moe_ops.moe_up_fp8_grouped(
++            x.contiguous(), w13u, e.w13_weight_scale,
++            expert_offsets, expert_tokens, self._top_k, self._n_routed_experts)
++        outp = torch.ops.moe_ops.moe_down_fp8_grouped(
++            inter, w2u, e.w2_weight_scale, rw_flat,
++            expert_offsets, expert_tokens, self._top_k, self._n_routed_experts)
++        # Sum the top_k per-route rows back to per-token output.
++        out = outp.view(M, self._top_k, -1).sum(1)
++        if get_tensor_model_parallel_world_size() > 1:
++            from vllm.distributed import tensor_model_parallel_all_reduce
++            out = tensor_model_parallel_all_reduce(out)
++        return out
++
+     def forward(self, x: torch.Tensor, router_logits: torch.Tensor) -> torch.Tensor:
++        # int4 (sym_int4) ESIMD fused decode/small-batch (M <= cap). int4 MoE
++        # normally goes through cutlass xpu_fused_moe (gather/remap/count +
++        # grouped GEMM, a prefill-shaped path that adds ~90 pure data-shuffle
++        # kernels/step). This fused op (internal fp32 topk + per_expert_scale
++        # fold + gelu_tanh up + group=32 down + accumulate) indexes experts
++        # directly (no gather), reading the SAME implement_zp int4 weights
++        # cutlass uses (standard twos-complement s4 -> decode_s4_nibble matches,
++        # zero extra memory). Wins for small batch (batch=1 +20%, batch<=12 +19%,
++        # even beats fp8 grouped since int4 weights are smaller); cutlass grouped
++        # overtakes at large batch (~32, +83%) where its gather amortizes + DPAS
++        # scales -- so cap at GEMMA4_INT4_BATCH_MAX_M (default 16). Opt-in:
++        # ENABLE_GEMMA4_INT4_DECODE=1.
++        if (os.environ.get("ENABLE_GEMMA4_INT4_DECODE", "0") == "1"
++                and x.shape[0] <= int(os.environ.get("GEMMA4_INT4_BATCH_MAX_M", "16"))
++                and x.dtype == torch.float16
++                and self._n_routed_experts == 128 and self._top_k == 8):
++            _impl = getattr(getattr(self.experts, "quant_method", None),
++                            "_fused_moe_impl", None)
++            if (_impl is not None
++                    and getattr(_impl, "w13", None) is not None
++                    and getattr(_impl, "gemm1_scales", None) is not None):
++                import torch as _torch
++                _w13 = _impl.w13
++                _w2 = _impl.w2
++                if _w13.dtype != _torch.uint8:
++                    _w13 = _w13.view(_torch.uint8)
++                if _w2.dtype != _torch.uint8:
++                    _w2 = _w2.view(_torch.uint8)
++                out = _torch.ops.moe_int4_ops.moe_forward_gelu_tanh_int4_decode(
++                    x.contiguous(), router_logits.to(_torch.float16).contiguous(),
++                    _w13, _impl.gemm1_scales,
++                    _w2, _impl.gemm2_scales,
++                    self.per_expert_scale.data.float().contiguous(),
++                    self._top_k, self._n_routed_experts,
++                )
++                if get_tensor_model_parallel_world_size() > 1:
++                    from vllm.distributed import tensor_model_parallel_all_reduce
++                    out = tensor_model_parallel_all_reduce(out)
++                return out
++            # impl not built yet (first call) -> fall through to cutlass which builds it
++
++        # Batch (M>1) ESIMD path: expert-grouped fp8 DPAS GEMM. Default ON.
++        # gsm8k (gemma-4-26B, SEQS=8) holds 8/10 == Triton baseline, ITL 11-23%
++        # faster across batch 4-128; on DiffusionGemma's 256-canvas it actually
++        # *fixes* the Triton fp8 path (3/10 -> 10/10, no prompt/output mismatch).
++        # The earlier 0/5+21x in-model failure was on an older base and no longer
++        # reproduces. Disable via DISABLE_ESIMD_MOE_BATCH_GROUPED=1; cap via
++        # MOE_GROUPED_MAX_M (default covers the 256-canvas).
++        if self._esimd_batch_can_run(x):
++            return self._forward_grouped(x, router_logits)
++        if self._esimd_can_run(x):
++            # Fully-fused decode path: router logits -> (internal topk + scale
++            # fold + 1D-load gelu_tanh up/down + accumulate) in one op. Replaces
++            # the Python-side topk + torch scale-fold + separate expert dispatch.
++            # Verified gsm8k 5/5, fingerprint identical, 20.62 -> 18.72ms.
++            # Disable via DISABLE_MOE_FULL_FUSED=1.
++            if (x.shape[0] == 1
++                    and os.environ.get("DISABLE_MOE_FULL_FUSED", "0") != "1"):
++                from custom_esimd_kernels_vllm.ops import (
++                    moe_forward_full_gelu_tanh_decode,
++                )
++                e = self.experts
++                out = moe_forward_full_gelu_tanh_decode(
++                    x.contiguous(), router_logits.contiguous(),
++                    e.w13_weight, e.w13_weight_scale,
++                    e.w2_weight, e.w2_weight_scale,
++                    self.per_expert_scale.data.float().contiguous(),
++                    self._top_k, self._n_routed_experts,
++                )
++                if get_tensor_model_parallel_world_size() > 1:
++                    from vllm.distributed import tensor_model_parallel_all_reduce
++                    out = tensor_model_parallel_all_reduce(out)
++                return out
++            from custom_esimd_kernels_vllm.ops import (
++                moe_forward_full_gelu_tanh_routed,
++                moe_forward_full_gelu_tanh_routed_decode,
++            )
++            weights, indices = self._esimd_routing_fn(
++                x, router_logits, self._top_k, True)
++            # Kernel expects fp16 weights, int32 indices. The triton routing
++            # kernel emits int32 contiguous ids and (for decode) fp16 weights
++            # directly, so the lean path skips redundant .contiguous()/.to().
++            # DISABLE_MOE_ROUTING_LEAN=1 restores the full conversion guard
++            # (needed by the torch routing fallback on non-XPU/CUDA).
++            if os.environ.get("DISABLE_MOE_ROUTING_LEAN", "0") == "1":
++                weights = weights.to(torch.float16).contiguous()
++                indices = indices.to(torch.int32).contiguous()
++            else:
++                # triton routing emits int32 contiguous ids; for decode it also
++                # emits fp16 weights directly (no cast). Prefill emits fp32, so
++                # cast only when needed.
++                if weights.dtype != torch.float16:
++                    weights = weights.to(torch.float16)
++            e = self.experts
++            # Decode (M==1) fast path: 1D-load expert GEMV (~528 vs ~315 GB/s,
++            # bit-identical to DPAS). Prefill (M>1) keeps the DPAS GEMM path.
++            _use_decode_gemv = (
++                x.shape[0] == 1
++                and os.environ.get("DISABLE_MOE_DECODE_GEMV", "0") != "1"
++            )
++            _moe_fn = (
++                moe_forward_full_gelu_tanh_routed_decode
++                if _use_decode_gemv
++                else moe_forward_full_gelu_tanh_routed
++            )
++            # The kernel rotates through a small ring of output buffers
++            # internally, so the returned tensor stays valid across the
++            # next few MoE layer calls -- no .clone() needed.
++            out = _moe_fn(
++                x.contiguous(),
++                weights, indices,
++                e.w13_weight, e.w13_weight_scale,
++                e.w2_weight, e.w2_weight_scale,
++                self._top_k, self._n_routed_experts,
++            )
++            # FusedMoE's runner all-reduces partial down-proj outputs
++            # across TP ranks; we bypassed it, so do the reduce here.
++            if get_tensor_model_parallel_world_size() > 1:
++                from vllm.distributed import tensor_model_parallel_all_reduce
++                out = tensor_model_parallel_all_reduce(out)
++            return out
+         return self.experts(x, router_logits)
+ 
+ 
+@@ -499,6 +1013,96 @@ class Gemma4Attention(nn.Module):
+             prefix=f"{prefix}.attn",
+         )
+ 
++        # Fused QKV split + Q/K/V RMSNorm + RoPE (esimd) — gemma4 sliding only:
++        #   - kernel hard-codes head_dim=256 (not the head_dim=512 full layers)
++        #   - kernel does (w+1.0) RMSNorm internally (Qwen-style); we feed
++        #     (w_gemma - 1) so the kernel reproduces gemma4's standard RMSNorm
++        #   - V-Norm has_weight=False (weight=1) → pass zeros; kernel +1 = ones
++        #   - rotary_dim: gemma4 partial_rotary_factor==1.0 → full head_dim
++        #   - skipped on k_eq_v shared-KV layers (those bypass K/V norm anyway)
++        self._esimd_qkv_disabled = os.environ.get(
++            "DISABLE_ESIMD_QKV_FUSED", "0") == "1"
++        self._esimd_qkv_eligible = (
++            ESIMD_AVAILABLE
++            and not self._esimd_qkv_disabled
++            and self.head_dim == 256
++            and not self.is_kv_shared_layer
++        )
++        # Lazily caches qwen-convention norm weights and a contiguous V-zeros.
++        self._qkv_fused_cache: dict[str, torch.Tensor] | None = None
++
++        # ESIMD fp8 qkv_proj GEMM fast path (replaces the qkv_proj linear with
++        # esimd_gemm_fp8_pert). QKVParallelLinear is column-parallel (no
++        # all_reduce), so no manual reduce is needed. Default OFF (opt-in):
++        # the qkv weight read floor (~96us/layer x60 = 5.8ms) is BW-bound like
++        # the dense MLP, so this is expected to be same-speed as native; kept
++        # for A/B and for shapes where launch overhead dominates.
++        _qn = quant_config.get_name() if quant_config is not None else ""
++        self._qkv_quant = _qn
++        # fp8: opt-in (BW-bound, esimd same-speed). sym_int4: default ON
++        # (native sym_int4 decode is not BW-optimal; group32 esimd_gemv_int4
++        # has headroom). decode-only (M==1); M>1 falls back to native.
++        self._qkv_proj_esimd_enabled = ESIMD_AVAILABLE and (
++            (_qn == "fp8"
++             and os.environ.get("ENABLE_ESIMD_QKV_PROJ", "0") == "1")
++            or (_qn == "sym_int4"
++                and os.environ.get("DISABLE_ESIMD_QKV_PROJ_INT4", "0") != "1")
++        )
++        self._qkv_proj_esimd_ready = None
++        self._qkv_proj_max_bsz = int(os.environ.get("MAX_DECODE_BSZ", "64"))
++
++    def _probe_qkv_proj_esimd(self) -> bool:
++        try:
++            if self._qkv_quant == "fp8":
++                w = self.qkv_proj.weight
++                s = self.qkv_proj.weight_scale
++                if w.dtype not in (torch.float8_e4m3fn, torch.float8_e5m2):
++                    return False
++                from custom_esimd_kernels_vllm import esimd_gemm_fp8_pert
++                self._qkv_op = esimd_gemm_fp8_pert
++                self._qkv_op_gemm = None
++                self._qkv_decode_only = False
++                n = w.shape[0]
++            elif self._qkv_quant == "sym_int4":
++                w = self.qkv_proj.weight_esimd
++                s = self.qkv_proj.scale_esimd
++                from custom_esimd_kernels_vllm import esimd_gemv_int4
++                self._qkv_op = esimd_gemv_int4
++                if os.environ.get("ENABLE_ESIMD_INT4_GEMM", "0") == "1":
++                    from custom_esimd_kernels_vllm import esimd_gemm_int4_pgrp
++                    self._qkv_op_gemm = esimd_gemm_int4_pgrp
++                else:
++                    self._qkv_op_gemm = None
++                self._qkv_decode_only = (self._qkv_op_gemm is None)
++                n = s.shape[0]
++            else:
++                return False
++        except AttributeError:
++            return False
++        dev = w.device
++        self._qkv_w, self._qkv_s = w, s
++        self._m_qkv = torch.empty(
++            self._qkv_proj_max_bsz, n, dtype=torch.float16, device=dev)
++        # o_proj (RowParallel) int4 GEMV decode path. Needs manual all_reduce
++        # since the esimd path bypasses o_proj.forward (reduce_results=True).
++        self._oproj_esimd = False
++        if self._qkv_quant == "sym_int4":
++            try:
++                ow = self.o_proj.weight_esimd
++                os_ = self.o_proj.scale_esimd
++                self._o_w, self._o_s = ow, os_
++                self._m_oproj = torch.empty(
++                    self._qkv_proj_max_bsz, os_.shape[0],
++                    dtype=torch.float16, device=dev)
++                from vllm.distributed import (
++                    get_tensor_model_parallel_world_size)
++                self._oproj_tp = get_tensor_model_parallel_world_size()
++                self._oproj_esimd = (
++                    os.environ.get("DISABLE_ESIMD_OPROJ_INT4", "0") != "1")
++            except AttributeError:
++                self._oproj_esimd = False
++        return True
++
+     def forward(
+         self,
+         positions: torch.Tensor,
+@@ -508,30 +1112,105 @@ class Gemma4Attention(nn.Module):
+         # Unified QKV path (works for both k_eq_v and standard layers).
+         # For k_eq_v, K weights are loaded into both K and V slots of
+         # qkv_proj, so V == K automatically.
+-        qkv, _ = self.qkv_proj(hidden_states)
+-        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+-
+-        # Q norm (always applied)
+-        q = q.unflatten(-1, (self.num_heads, self.head_dim))
+-        q = self.q_norm(q)
+-        q = q.flatten(-2, -1)
+-
+-        if not self.is_kv_shared_layer:
+-            # Non-shared: apply K norm + RoPE, V norm
+-            k = k.unflatten(-1, (self.num_kv_heads, self.head_dim))
+-            k = self.k_norm(k)
+-            k = k.flatten(-2, -1)
+-            q, k = self.rotary_emb(positions, q, k)
+-
+-            v = v.unflatten(-1, (self.num_kv_heads, self.head_dim))
+-            v = self.v_norm(v)
+-            v = v.flatten(-2, -1)
++        if self._qkv_proj_esimd_enabled:
++            if self._qkv_proj_esimd_ready is None:
++                self._qkv_proj_esimd_ready = self._probe_qkv_proj_esimd()
++            _n = hidden_states.shape[0]
++            _qblk = getattr(self, "_qkv_decode_only", False) and _n != 1
++            if (
++                self._qkv_proj_esimd_ready
++                and not _qblk
++                and hidden_states.is_contiguous()
++                and hidden_states.dtype == torch.float16
++                and 1 <= _n <= self._qkv_proj_max_bsz
++            ):
++                qkv = self._m_qkv[:_n]
++                _qg = getattr(self, "_qkv_op_gemm", None)
++                _op = self._qkv_op if (_n == 1 or _qg is None) else _qg
++                _op(hidden_states, self._qkv_w, self._qkv_s, qkv)
++            else:
++                qkv, _ = self.qkv_proj(hidden_states)
++        else:
++            qkv, _ = self.qkv_proj(hidden_states)
++
++        if self._esimd_qkv_eligible and qkv.dtype == torch.float16:
++            # Fused esimd path: split + Q/K/V RMSNorm + Q/K RoPE in one kernel.
++            from custom_esimd_kernels_vllm.ops import (
++                esimd_qkv_split_norm_rope_v,
++            )
++            n_tok = qkv.shape[0]
++            dev = qkv.device
++            # Lazily build qwen-convention norm weights (w_gemma - 1.0) on the
++            # right device/dtype. q_norm/k_norm.weight is fp16 already.
++            cache = self._qkv_fused_cache
++            if cache is None or cache["wq"].device != dev:
++                cache = {
++                    "wq": (self.q_norm.weight.data - 1.0).contiguous(),
++                    "wk": (self.k_norm.weight.data - 1.0).contiguous(),
++                    # V-Norm has_weight=False → effective weight=1 → kernel
++                    # input zeros (kernel computes weight+1.0).
++                    "wv": torch.zeros(self.head_dim, dtype=torch.float16,
++                                      device=dev),
++                    # Empty gate buffer for kernel signature; never read.
++                    "_gate_unused": torch.empty(
++                        (1, self.q_size), dtype=torch.float16, device=dev),
++                }
++                self._qkv_fused_cache = cache
++            # Output buffers (per-call; small)
++            q = torch.empty(n_tok, self.q_size, dtype=torch.float16, device=dev)
++            k = torch.empty(n_tok, self.kv_size, dtype=torch.float16, device=dev)
++            v = torch.empty(n_tok, self.kv_size, dtype=torch.float16, device=dev)
++            # cos_sin_cache must match qkv dtype
++            cs_cache = self.rotary_emb._match_cos_sin_cache_dtype(qkv)
++            esimd_qkv_split_norm_rope_v(
++                qkv.contiguous(),
++                q, cache["_gate_unused"], k, v,
++                cache["wq"], cache["wk"], cache["wv"],
++                positions.to(torch.int32),
++                self.num_heads, self.num_kv_heads,
++                False,                     # no attn_output_gate
++                self.head_dim,             # gemma4 partial_rotary_factor=1.0
++                cs_cache,
++            )
+         else:
+-            # Shared: only apply RoPE to Q
+-            q = self.rotary_emb(positions, q, k)[0]
++            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
++
++            # Q norm (always applied)
++            q = q.unflatten(-1, (self.num_heads, self.head_dim))
++            q = self.q_norm(q)
++            q = q.flatten(-2, -1)
++
++            if not self.is_kv_shared_layer:
++                # Non-shared: apply K norm + RoPE, V norm
++                k = k.unflatten(-1, (self.num_kv_heads, self.head_dim))
++                k = self.k_norm(k)
++                k = k.flatten(-2, -1)
++                q, k = self.rotary_emb(positions, q, k)
++
++                v = v.unflatten(-1, (self.num_kv_heads, self.head_dim))
++                v = self.v_norm(v)
++                v = v.flatten(-2, -1)
++            else:
++                # Shared: only apply RoPE to Q
++                q = self.rotary_emb(positions, q, k)[0]
+ 
+         attn_output = self.attn(q, k, v)
+-        output, _ = self.o_proj(attn_output)
++        if (
++            getattr(self, "_oproj_esimd", False)
++            and self._qkv_proj_esimd_ready
++            and attn_output.shape[0] == 1
++            and attn_output.is_contiguous()
++            and attn_output.dtype == torch.float16
++        ):
++            from custom_esimd_kernels_vllm import esimd_gemv_int4
++            output = self._m_oproj[:1]
++            esimd_gemv_int4(attn_output, self._o_w, self._o_s, output)
++            if self._oproj_tp > 1:
++                from vllm.distributed import (
++                    tensor_model_parallel_all_reduce)
++                output = tensor_model_parallel_all_reduce(output)
++        else:
++            output, _ = self.o_proj(attn_output)
+ 
+         return output
+ 
+@@ -628,6 +1307,11 @@ class Gemma4DecoderLayer(nn.Module):
+         self.enable_moe_block = getattr(config, "enable_moe_block", False) or getattr(
+             config, "use_second_mlp_block", False
+         )
++        self.router_uses_prenormed_input = getattr(
++            config,
++            "router_uses_prenormed_input",
++            False,
++        )
+         if self.enable_moe_block:
+             self.router = Gemma4Router(
+                 config,
+@@ -689,6 +1373,26 @@ class Gemma4DecoderLayer(nn.Module):
+ 
+         # Layer scalar (loaded from checkpoint) — applies to ALL text layers
+         self.register_buffer("layer_scalar", torch.ones(1))
++        # Host-cached float copy of layer_scalar, consumed by the cross-layer
++        # fused-norm fast path (prev_layer_scalar). Populated lazily OUTSIDE the
++        # torch.compile/cudagraph-captured region: a `.item()` inside the
++        # captured graph does a device->host sync, which is illegal during
++        # cudagraph capture ("wait method cannot be used for an event
++        # associated with a command graph"). See _layer_scalar_host_value().
++        self._layer_scalar_host: float | None = None
++
++    def _layer_scalar_host_value(self) -> float | None:
++        """Host float copy of layer_scalar for the cross-layer fused-norm path.
++
++        Returns None while torch.compile is tracing / cudagraph is capturing,
++        so the `.item()` device->host sync never enters the compiled graph.
++        Passing None there is safe: the xfuse fast path is decode (M==1) only,
++        which is never the compiled/captured shape (canvas M==256)."""
++        if self._layer_scalar_host is None:
++            if torch.compiler.is_compiling():
++                return None
++            self._layer_scalar_host = float(self.layer_scalar.item())
++        return self._layer_scalar_host
+ 
+     def forward(
+         self,
+@@ -701,38 +1405,223 @@ class Gemma4DecoderLayer(nn.Module):
+         # Gemma4 residual pattern:
+         # 1. input_norm(x) → attn → post_attn_norm → ADD residual
+         # 2. pre_ff_norm → mlp → post_ff_norm → ADD residual
+-        residual = hidden_states
++        #
++        # Cross-layer fused norm path: when active, the previous layer
++        # returned (hidden_states=post_ff_normed, residual=residual_internal)
++        # WITHOUT applying its layer_scalar (we apply it here as part of an
++        # esimd kernel that fuses prev.scalar_mul + final_add + this.input_norm).
++        #
++        # Eligibility:
++        #   - PLE off (gemma4-12B/26B/31B all have hidden_size_per_layer_input=0)
++        #   - decode (n_tok==1)
++        #   - residual is a tensor (i.e. not the very first layer of the model)
++        #   - prev_layer_scalar provided in kwargs by _run_decoder_layers
++        prev_scalar = kwargs.pop("prev_layer_scalar", None)
++        _xfuse = (
++            ESIMD_AVAILABLE
++            and not disable_esimd_norm()
++            and per_layer_input is None
++            and self.per_layer_input_gate is None
++            and hidden_states.shape[0] == 1
++            and residual is not None
++            and prev_scalar is not None
++            and os.environ.get("DISABLE_GEMMA4_XFUSE", "0") != "1"
++        )
+ 
+-        hidden_states = self.input_layernorm(residual)
++        if _xfuse:
++            # Fuse prev.scalar_mul + final_add + this.input_layernorm in one
++            # esimd kernel call. After this:
++            #   residual ← (post_ff_normed_prev + residual_internal_prev) * prev_scalar
++            #            = original-equivalent layer-N output (entry hs_N+1)
++            #   hidden_states ← input_norm(residual)
++            esimd_fused_scaled_add_rms_norm(
++                hidden_states, residual,
++                self.input_layernorm.weight.data,
++                self.input_layernorm.variance_epsilon,
++                prev_scalar,
++            )
++        else:
++            residual = hidden_states
++            hidden_states = self.input_layernorm(residual)
+ 
+-        hidden_states = self.self_attn(
++        hidden_states = _dg_prof_section("attn", lambda: self.self_attn(
+             positions=positions,
+             hidden_states=hidden_states,
+             **kwargs,
++        ))
++
++        # Fused (post_attn_norm × w1 → add to residual → pre_ff_norm × w2) in
++        # one esimd kernel, replacing 2 launches (esimd_rms_norm +
++        # esimd_fused_add_rms_norm). Same pattern as the MoE-output
++        # esimd_norm_add_norm fuse (h2_raw → norm_w1 → add_to_h1 → norm_w2).
++        _fused_attn_out = (
++            ESIMD_AVAILABLE
++            and not disable_esimd_norm()
++            and hidden_states.shape[0] == 1
++            and hidden_states.is_contiguous()
++            and residual is not None
++            and residual.is_contiguous()
++            and hidden_states.dtype == torch.float16
++            and self.post_attention_layernorm.weight.dtype == torch.float16
++            and self.pre_feedforward_layernorm.weight.dtype == torch.float16
++            and os.environ.get("DISABLE_GEMMA4_FUSED_ATTN_OUT", "0") != "1"
+         )
+-
+-        hidden_states = self.post_attention_layernorm(hidden_states)
+-        hidden_states = hidden_states + residual
+-        residual = hidden_states
+-
+-        # MLP runs unconditionally (same inputs for MoE and non-MoE)
+-        hidden_states = self.pre_feedforward_layernorm(hidden_states)
+-        hidden_states = self.mlp(hidden_states)
++        if _fused_attn_out:
++            from custom_esimd_kernels_vllm import esimd_norm_add_norm
++            if not hasattr(self, "_fused_attn_out_buf"):
++                self._fused_attn_out_buf = torch.empty_like(hidden_states)
++            esimd_norm_add_norm(
++                hidden_states, residual,
++                self.post_attention_layernorm.weight.data,
++                self.pre_feedforward_layernorm.weight.data,
++                self._fused_attn_out_buf,
++                self.post_attention_layernorm.variance_epsilon,
++                self.pre_feedforward_layernorm.variance_epsilon,
++            )
++            # residual is now (post_attn_normed + old_residual) in-place;
++            # _fused_attn_out_buf is rms_norm(residual_new) * pre_ff_norm.w
++            hidden_states = self._fused_attn_out_buf
++        else:
++            hidden_states = _esimd_rms_norm_or_fallback(
++                self.post_attention_layernorm, hidden_states)
++            if (
++                ESIMD_AVAILABLE
++                and not disable_esimd_norm()
++                and hidden_states.shape[0] == 1
++            ):
++                esimd_fused_add_rms_norm(
++                    hidden_states, residual,
++                    self.pre_feedforward_layernorm.weight.data,
++                    self.pre_feedforward_layernorm.variance_epsilon)
++            else:
++                hidden_states = hidden_states + residual
++                residual = hidden_states
++                hidden_states = self.pre_feedforward_layernorm(hidden_states)
++        hidden_states = _dg_prof_section("mlp", lambda: self.mlp(hidden_states))
+ 
+         if self.enable_moe_block:
+-            hidden_states_1 = self.post_feedforward_layernorm_1(hidden_states)
++            hidden_states_1 = _esimd_rms_norm_or_fallback(
++                self.post_feedforward_layernorm_1, hidden_states)
+ 
+             # Router and MoE experts see the residual (pre-MLP state),
+-            # matching the HF transformers forward path
+-            router_logits = self.router(residual)
+-            hidden_states_2 = self.pre_feedforward_layernorm_2(residual)
+-            hidden_states_2 = self.moe(hidden_states_2, router_logits)
+-            hidden_states_2 = self.post_feedforward_layernorm_2(hidden_states_2)
++            # matching the HF transformers forward path.
++            #
++            # Fast path: a single esimd_norm_gemv_norm_fp16 kernel computes
++            #   - router_logits = ((residual / rms) * scale_with_root) @ proj_w^T
++            #   - hidden_states_2 = (residual / rms) * pre_feedforward_layernorm_2.weight
++            # sharing the rms reduction. This replaces 3 launches
++            # (esimd_rms_norm + esimd_gemv_fp16 + esimd_rms_norm) with one.
++            router = self.router
++            _fused_router = (
++                ESIMD_AVAILABLE
++                and not disable_esimd_norm()
++                and residual is not None
++                and residual.shape[0] == 1
++                and residual.is_contiguous()
++                and residual.dtype == torch.float16
++                and router is not None
++                and not getattr(router, "_disable_fast_router", False)
++                and router.proj.weight.dtype == torch.float16
++                and router.proj.weight.is_contiguous()
++                and self.pre_feedforward_layernorm_2.weight.dtype == torch.float16
++                and os.environ.get("DISABLE_GEMMA4_FUSED_ROUTER", "0") != "1"
++            )
++            if _fused_router:
++                if not hasattr(router, "_scale_with_root"):
++                    router._scale_with_root = (
++                        router.scale.data * router.root_size
++                    ).to(residual.dtype).contiguous()
++                if not hasattr(router, "_router_logits_buf"):
++                    n_experts = router.proj.weight.shape[0]
++                    router._router_logits_buf = torch.empty(
++                        1, n_experts, dtype=torch.float16, device=residual.device)
++                if not hasattr(self, "_moe_input_buf"):
++                    self._moe_input_buf = torch.empty(
++                        1, residual.shape[-1],
++                        dtype=torch.float16, device=residual.device)
++                from custom_esimd_kernels_vllm import esimd_norm_gemv_norm_fp16
++                esimd_norm_gemv_norm_fp16(
++                    residual,
++                    router._scale_with_root,
++                    router.proj.weight,
++                    self.pre_feedforward_layernorm_2.weight.data,
++                    router._router_logits_buf,
++                    self._moe_input_buf,
++                    self.pre_feedforward_layernorm_2.variance_epsilon,
++                )
++                router_logits = router._router_logits_buf
++                hidden_states_2 = self._moe_input_buf
++            else:
++                hidden_states_2 = _esimd_rms_norm_or_fallback(
++                    self.pre_feedforward_layernorm_2, residual)
++                # DiffusionGemma feeds the residual (router_uses_prenormed_input
++                # =False); a True variant routes the pre-normed input instead.
++                if getattr(self, "router_uses_prenormed_input", False):
++                    router_logits = self.router(hidden_states_2)
++                else:
++                    router_logits = self.router(residual)
++            hidden_states_2 = _dg_prof_section(
++                "moe", lambda: self.moe(hidden_states_2, router_logits))
++
++            # Fused (post_ff_norm_2 × w1 → add to h1 → post_ff_norm × w2) in
++            # one esimd kernel:
++            #   hidden_states_1 ← h2_normed_w1 + hidden_states_1   (in-place)
++            #   out             = rms_norm(hidden_states_1) × post_ff_norm.w
++            # Replaces 2 launches (esimd_rms_norm + esimd_fused_add_rms_norm).
++            _fused_h2_path = (
++                ESIMD_AVAILABLE
++                and not disable_esimd_norm()
++                and hidden_states_2.shape[0] == 1
++                and hidden_states_1.is_contiguous()
++                and hidden_states_2.is_contiguous()
++                and hidden_states_2.dtype == torch.float16
++                and self.post_feedforward_layernorm_2.weight.dtype == torch.float16
++                and self.post_feedforward_layernorm.weight.dtype == torch.float16
++                and os.environ.get("DISABLE_GEMMA4_FUSED_H2", "0") != "1"
++            )
++            if _fused_h2_path:
++                from custom_esimd_kernels_vllm import esimd_norm_add_norm
++                if not hasattr(self, "_fused_h2_out_buf"):
++                    self._fused_h2_out_buf = torch.empty_like(hidden_states_2)
++                esimd_norm_add_norm(
++                    hidden_states_2,
++                    hidden_states_1,
++                    self.post_feedforward_layernorm_2.weight.data,
++                    self.post_feedforward_layernorm.weight.data,
++                    self._fused_h2_out_buf,
++                    self.post_feedforward_layernorm_2.variance_epsilon,
++                    self.post_feedforward_layernorm.variance_epsilon,
++                )
++                hidden_states = self._fused_h2_out_buf
++            else:
++                hidden_states_2 = _esimd_rms_norm_or_fallback(
++                    self.post_feedforward_layernorm_2, hidden_states_2)
++                if (
++                    ESIMD_AVAILABLE
++                    and not disable_esimd_norm()
++                    and hidden_states_2.shape[0] == 1
++                    and hidden_states_1.is_contiguous()
++                    and hidden_states_2.is_contiguous()
++                ):
++                    esimd_fused_add_rms_norm(
++                        hidden_states_2, hidden_states_1,
++                        self.post_feedforward_layernorm.weight.data,
++                        self.post_feedforward_layernorm.variance_epsilon)
++                    hidden_states = hidden_states_2
++                else:
++                    hidden_states = hidden_states_1 + hidden_states_2
++                    hidden_states = self.post_feedforward_layernorm(hidden_states)
++        else:
++            hidden_states = self.post_feedforward_layernorm(hidden_states)
+ 
+-            # Combine MLP and MoE outputs
+-            hidden_states = hidden_states_1 + hidden_states_2
++        if _xfuse:
++            # Defer final_add + scalar_mul to the next layer's input_norm
++            # via esimd_fused_scaled_add_rms_norm. residual still holds the
++            # layer-internal residual (post_attn_normed + entry_hs); the next
++            # layer will compute (hidden_states + residual) * self.layer_scalar
++            # in a single kernel call.
++            return hidden_states, residual
+ 
+-        hidden_states = self.post_feedforward_layernorm(hidden_states)
+         hidden_states = hidden_states + residual
+ 
+         # Apply PLE (Per-Layer Embedding) if configured
+@@ -763,6 +1652,7 @@ def _run_decoder_layers(
+ ) -> torch.Tensor:
+     """Run a slice of decoder layers with PLE extraction."""
+     residual = None
++    prev_layer_scalar = None
+     for idx, layer in enumerate(decoder_layers):
+         layer_idx = idx + layer_idx_start
+         layer_per_input = (
+@@ -773,8 +1663,17 @@ def _run_decoder_layers(
+             hidden_states,
+             residual,
+             per_layer_input=layer_per_input,
++            prev_layer_scalar=prev_layer_scalar,
+             **kwargs,
+         )
++        prev_layer_scalar = layer._layer_scalar_host_value()
++    # After the last layer in xfuse mode, the deferred (hidden_states +
++    # residual) * last_layer_scalar must still be applied; do it here so
++    # downstream model code sees the same final hidden as the non-xfuse path.
++    if residual is not None and prev_layer_scalar is not None:
++        # The cross-layer fast path stops returning None for residual only
++        # when xfuse was active inside the layer. Apply the deferred ops.
++        hidden_states = (hidden_states + residual) * prev_layer_scalar
+     return hidden_states
+ 
+ 
+@@ -1312,6 +2211,7 @@ class Gemma4Model(nn.Module, EagleModelMixin):
+             if per_layer_inputs is not None:
+                 per_layer_inputs = intermediate_tensors["per_layer_inputs"]
+         residual = None
++        prev_layer_scalar = None
+         aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
+         for layer_idx, layer in enumerate(
+             islice(self.layers, self.start_layer, self.end_layer)
+@@ -1329,8 +2229,10 @@ class Gemma4Model(nn.Module, EagleModelMixin):
+                 hidden_states,
+                 residual,
+                 per_layer_input=layer_per_input,
++                prev_layer_scalar=prev_layer_scalar,
+                 **kwargs,
+             )
++            prev_layer_scalar = layer._layer_scalar_host_value()
+             self._maybe_add_hidden_state(
+                 aux_hidden_states, layer_idx + 1, hidden_states, residual
+             )
+@@ -1346,7 +2248,15 @@ class Gemma4Model(nn.Module, EagleModelMixin):
+         if residual is None:
+             hidden_states = self.norm(hidden_states)
+         else:
+-            hidden_states, _ = self.norm(hidden_states, residual)
++            # If the last layer ran in xfuse mode, residual is the layer-internal
++            # residual_internal and `hidden_states` is post_ff_normed (no scalar
++            # applied yet). Apply the deferred scalar_mul + final_add here so the
++            # final RMSNorm sees the same value as the non-xfuse path.
++            if prev_layer_scalar is not None:
++                hidden_states = (hidden_states + residual) * prev_layer_scalar
++                hidden_states = self.norm(hidden_states)
++            else:
++                hidden_states, _ = self.norm(hidden_states, residual)
+ 
+         if len(aux_hidden_states) > 0:
+             return hidden_states, aux_hidden_states
+diff --git a/vllm/model_executor/models/gemma4_unified.py b/vllm/model_executor/models/gemma4_unified.py
+new file mode 100644
+index 000000000..f85627bf5
+--- /dev/null
++++ b/vllm/model_executor/models/gemma4_unified.py
+@@ -0,0 +1,512 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++"""Gemma 4 Unified multimodal model (encoder-free image + audio + video).
++
++The Unified Gemma4 variant has no SigLIP vision tower and no audio tower.
++Raw pixel patches are projected directly to LM space via a Dense+LayerNorm
++pipeline with factorized 2D positional embeddings (Gemma4UnifiedVisionEmbedder),
++then routed through the same Gemma4MultimodalEmbedder used by the tower-based
++variant.  Audio inputs are raw waveform frames projected directly through the
++multimodal embedder.
++
++This module subclasses Gemma4ForConditionalGeneration from gemma4_mm rather
++than reimplementing it from scratch.  Only the multimodal pipeline differs;
++the language model, MTP integration, bidirectional attention helpers,
++embedding/forward path, and LoRA support are all inherited unchanged.
++"""
++
++import math
++from collections.abc import Iterable, Mapping
++
++import torch
++from torch import nn
++from vllm.transformers_utils.configs.gemma4_unified import Gemma4UnifiedConfig
++
++from vllm.config import VllmConfig
++from vllm.config.multimodal import VideoDummyOptions
++from vllm.model_executor.layers.linear import ColumnParallelLinear
++from vllm.model_executor.models.gemma4 import Gemma4ForCausalLM
++from vllm.model_executor.models.gemma4_mm import (
++    _SUPPORTED_SOFT_TOKENS,
++    _VIDEO_MAX_FRAMES,
++    _VIDEO_MAX_SOFT_TOKENS,
++    Gemma4AudioInputs,
++    Gemma4DummyInputsBuilder,
++    Gemma4ForConditionalGeneration,
++    Gemma4ImageInputs,
++    Gemma4ImagePixelInputs,
++    Gemma4MultimodalEmbedder,
++    Gemma4MultiModalProcessor,
++    Gemma4ProcessingInfo,
++    _get_max_soft_tokens,
++)
++from vllm.model_executor.models.module_mapping import MultiModelKeys
++from vllm.multimodal import MULTIMODAL_REGISTRY
++
++from .utils import (
++    AutoWeightsLoader,
++    WeightsMapper,
++    init_vllm_registered_model,
++    maybe_prefix,
++)
++
++# Re-export so tests/code targeting the unified variant can import from here
++# rather than reaching into gemma4_mm.
++__all__ = [
++    "Gemma4ImagePixelInputs",
++    "Gemma4UnifiedVisionEmbedder",
++    "Gemma4UnifiedProcessingInfo",
++    "Gemma4UnifiedForConditionalGeneration",
++]
++
++
++# ---------------------------------------------------------------------------
++# Encoder-free vision embedder
++# ---------------------------------------------------------------------------
++
++
++class Gemma4UnifiedVisionEmbedder(nn.Module):
++    """Encoder-free vision embedder for Gemma4 Unified variants.
++
++    Projects raw pixel patches to LM space via dense projection and
++    factorized 2D positional embeddings.  Replaces the SigLIP vision
++    tower used by the tower-based Gemma4 variant.
++
++    Pipeline: raw patches → LN₁ → Dense → LN₂ → +factorized_posemb → LN₃.
++    """
++
++    def __init__(self, config, quant_config=None):
++        super().__init__()
++        patch_dim = config.model_patch_size**2 * 3
++        mm_embed_dim = config.mm_embed_dim
++
++        self.patch_ln1 = nn.LayerNorm(patch_dim)
++        # Keep the tiny patch-embed projection unquantized: int4 here would
++        # set .weight to None (breaking the fp32 overflow-safe forward) and
++        # hurt accuracy for no throughput gain. Mirrors keeping sensitive
++        # non-MoE Linear at higher precision.
++        self.patch_dense = ColumnParallelLinear(
++            patch_dim,
++            mm_embed_dim,
++            bias=True,
++            quant_config=None,
++            gather_output=True,
++        )
++        self.patch_ln2 = nn.LayerNorm(mm_embed_dim)
++
++        self.pos_embedding = nn.Parameter(
++            torch.zeros(config.mm_posemb_size, 2, mm_embed_dim)
++        )
++        self.pos_norm = nn.LayerNorm(mm_embed_dim)
++
++    def _factorized_posemb(self, positions_xy: torch.Tensor) -> torch.Tensor:
++        clamped_pos = positions_xy.clamp(min=0).long()
++        valid_mask = positions_xy != -1
++
++        pos_embs = torch.zeros(
++            *positions_xy.shape[:-1],
++            self.pos_embedding.shape[-1],
++            device=positions_xy.device,
++            dtype=self.pos_embedding.dtype,
++        )
++        for i in range(2):
++            axis_pe = self.pos_embedding[:, i, :][clamped_pos[..., i]]
++            mask = valid_mask[..., i].unsqueeze(-1).to(axis_pe.dtype)
++            pos_embs = pos_embs + (axis_pe * mask)
++        return pos_embs
++
++    def forward(
++        self,
++        pixel_values: torch.Tensor,
++        pixel_position_ids: torch.Tensor,
++    ) -> torch.Tensor:
++        # fp16-safe: the patch_dense projection (patch_dim=6912 -> mm_embed_dim)
++        # sums thousands of products and overflows fp16 to +/-inf (then the
++        # following LayerNorm -> NaN). HF runs this in bf16; on XPU we force
++        # fp16, so compute the patch-embed pipeline in fp32 (tiny per-image op,
++        # perf-irrelevant). patch_dense is a ColumnParallelLinear shard, so do a
++        # local fp32 matmul then all-gather across TP ranks to match
++        # gather_output=True.
++        import torch.nn.functional as F
++        from vllm.distributed import (
++            get_tensor_model_parallel_world_size,
++            tensor_model_parallel_all_gather,
++        )
++
++        out_dtype = self.pos_embedding.dtype
++
++        hidden_states = F.layer_norm(
++            pixel_values.float(),
++            (pixel_values.shape[-1],),
++            self.patch_ln1.weight.float(),
++            self.patch_ln1.bias.float(),
++            self.patch_ln1.eps,
++        )
++        local = F.linear(
++            hidden_states,
++            self.patch_dense.weight.float(),
++            self.patch_dense.bias.float()
++            if self.patch_dense.bias is not None else None,
++        )
++        if get_tensor_model_parallel_world_size() > 1:
++            # column-parallel shard -> gather full mm_embed_dim along last dim
++            hidden_states = tensor_model_parallel_all_gather(local, dim=-1)
++        else:
++            hidden_states = local
++        hidden_states = F.layer_norm(
++            hidden_states,
++            (hidden_states.shape[-1],),
++            self.patch_ln2.weight.float(),
++            self.patch_ln2.bias.float(),
++            self.patch_ln2.eps,
++        )
++
++        pos_embs = self._factorized_posemb(pixel_position_ids).float()
++        hidden_states = hidden_states + pos_embs
++        hidden_states = F.layer_norm(
++            hidden_states,
++            (hidden_states.shape[-1],),
++            self.pos_norm.weight.float(),
++            self.pos_norm.bias.float(),
++            self.pos_norm.eps,
++        )
++        return hidden_states.to(out_dtype)
++
++
++# ---------------------------------------------------------------------------
++# Processing info
++# ---------------------------------------------------------------------------
++
++
++class Gemma4UnifiedProcessingInfo(Gemma4ProcessingInfo):
++    """ProcessingInfo for the Gemma4 Unified variant.
++
++    Two field-name differences from the tower-based parent:
++      * config → ``Gemma4UnifiedConfig`` (not ``Gemma4Config``)
++      * vision_config.``num_soft_tokens`` (not ``default_output_length``)
++
++    Everything else (token sequencing, audio limits, video frame budget,
++    parser construction) is inherited unchanged.
++    """
++
++    def get_hf_config(self):
++        return self.ctx.get_hf_config(Gemma4UnifiedConfig)
++
++    def get_hf_processor(self, **kwargs: object):
++        # Lazy: transformers 5.8.0 lacks gemma4_unified; vendored locally.
++        from vllm.transformers_utils.processors.gemma4_unified import (
++            Gemma4UnifiedProcessor,
++        )
++        return self.ctx.get_hf_processor(
++            Gemma4UnifiedProcessor,
++            **kwargs,
++        )
++
++    def get_mm_max_tokens_per_item(
++        self, seq_len: int, mm_counts: Mapping[str, int]
++    ) -> Mapping[str, int] | None:
++        config = self.get_hf_config()
++        # Unified field is `num_soft_tokens`.  Tower-based parent uses
++        # `default_output_length`, hence the override.
++        tokens_per_image = config.vision_config.num_soft_tokens
++        merged_kwargs = self.ctx.get_merged_mm_kwargs({})
++        val, _ = _get_max_soft_tokens(merged_kwargs)
++        if isinstance(val, int) and val in _SUPPORTED_SOFT_TOKENS:
++            tokens_per_image = val
++        tokens: dict[str, int] = {"image": tokens_per_image}
++        if config.audio_config is not None:
++            processor = self.get_hf_processor()
++            tokens["audio"] = processor.audio_seq_length
++        num_frames = _VIDEO_MAX_FRAMES
++        mm_config = self.ctx.model_config.get_multimodal_config()
++        video_opts = mm_config.limit_per_prompt.get("video")
++        if (
++            isinstance(video_opts, VideoDummyOptions)
++            and video_opts.num_frames is not None
++        ):
++            num_frames = min(num_frames, video_opts.num_frames)
++        tokens["video"] = num_frames * (_VIDEO_MAX_SOFT_TOKENS + 2 + 6)
++        return tokens
++
++    def _compute_num_soft_tokens(
++        self,
++        image_width: int,
++        image_height: int,
++        max_soft_tokens: int | None = None,
++    ) -> int:
++        vision_cfg = self.get_hf_config().vision_config
++        patch_size = vision_cfg.patch_size
++        pooling_kernel_size = vision_cfg.pooling_kernel_size
++
++        if max_soft_tokens is None:
++            max_soft_tokens = vision_cfg.num_soft_tokens
++
++        unit = patch_size * pooling_kernel_size
++        max_patches = max_soft_tokens * pooling_kernel_size**2
++        num_patches_orig = (image_height / patch_size) * (image_width / patch_size)
++        scale = math.sqrt(max_patches / num_patches_orig)
++        target_h = max(unit, int(math.floor(image_height * scale / unit)) * unit)
++        target_w = max(unit, int(math.floor(image_width * scale / unit)) * unit)
++        num_patches = (target_h // patch_size) * (target_w // patch_size)
++        num_soft_tokens = num_patches // (pooling_kernel_size**2)
++        return min(num_soft_tokens, max_soft_tokens)
++
++
++# ---------------------------------------------------------------------------
++# Main model
++# ---------------------------------------------------------------------------
++
++
++@MULTIMODAL_REGISTRY.register_processor(
++    Gemma4MultiModalProcessor,
++    info=Gemma4UnifiedProcessingInfo,
++    dummy_inputs=Gemma4DummyInputsBuilder,
++)
++class Gemma4UnifiedForConditionalGeneration(Gemma4ForConditionalGeneration):
++    """Encoder-free Gemma4 (Unified) for conditional generation.
++
++    Inherits multimodal embedding routing, PLE handling, bidirectional
++    attention helpers, language-model forward, LoRA, and pipeline-parallel
++    support from :class:`Gemma4ForConditionalGeneration`.  Overrides only:
++
++      * ``__init__`` — builds the encoder-free vision embedder instead of
++        SigLIP/audio towers (LightOnOCR-style: ``nn.Module.__init__`` +
++        full rebuild, no ``super().__init__()``).
++      * ``hf_to_vllm_mapper`` — adds the ``model.vision_embedder.`` prefix.
++      * ``_process_image_input`` / ``_process_video_input`` /
++        ``_process_audio_input`` — encoder-free projection paths.
++      * ``load_weights`` — ignore-prefix list excludes the absent towers.
++      * ``get_mm_mapping`` — no tower entries.
++    """
++
++    hf_to_vllm_mapper = WeightsMapper(
++        orig_to_new_prefix={
++            "model.embed_audio.": "embed_audio.",
++            "model.embed_vision.": "embed_vision.",
++            "model.language_model.": "language_model.model.",
++            "model.vision_embedder.": "vision_embedder.",
++            "lm_head.": "language_model.lm_head.",
++            "model": "language_model.model",
++        }
++    )
++
++    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
++        # LightOnOCR-style rebuild: do NOT call super().__init__ — that
++        # would build a SigLIP vision tower and an audio tower we don't
++        # need.  Initialize nn.Module directly and assemble the
++        # encoder-free pipeline below.
++        nn.Module.__init__(self)
++        config = vllm_config.model_config.hf_config
++        quant_config = vllm_config.quant_config
++        multimodal_config = vllm_config.model_config.multimodal_config
++        self.config = config
++        self.quant_config = quant_config
++        self.multimodal_config = multimodal_config
++
++        # No towers — set to None so inherited load_weights / get_mm_mapping
++        # and any tower-aware logic short-circuits.
++        self.vision_tower = None
++        self.audio_tower = None
++
++        # ---- Encoder-free vision embedder ----
++        self.vision_embedder = (
++            Gemma4UnifiedVisionEmbedder(
++                config.vision_config,
++                quant_config=quant_config,
++            )
++            if config.vision_config is not None
++            else None
++        )
++        self.embed_vision = (
++            Gemma4MultimodalEmbedder(
++                config.vision_config,
++                config.text_config,
++            )
++            if config.vision_config is not None
++            else None
++        )
++
++        # ---- Encoder-free audio embedder ----
++        self.embed_audio = (
++            Gemma4MultimodalEmbedder(
++                config.audio_config,
++                config.text_config,
++            )
++            if config.audio_config is not None
++            else None
++        )
++
++        # ---- Language model (vLLM optimised) ----
++        with self._mark_language_model(vllm_config):
++            self.language_model: Gemma4ForCausalLM = init_vllm_registered_model(
++                vllm_config=vllm_config,
++                hf_config=config.text_config,
++                prefix=maybe_prefix(prefix, "language_model"),
++                architectures=["Gemma4ForCausalLM"],
++            )
++
++            # PLE is disabled for the unified variant (text config defaults
++            # hidden_size_per_layer_input to 0).  Skip the buffer.
++            ple_dim = getattr(
++                config.text_config,
++                "hidden_size_per_layer_input",
++                None,
++            )
++            if ple_dim is not None and ple_dim > 0:
++                self.per_layer_embeddings = torch.zeros(
++                    vllm_config.scheduler_config.max_num_batched_tokens,
++                    config.text_config.num_hidden_layers,
++                    ple_dim,
++                    device=self.language_model.model.embed_tokens.weight.device,
++                    dtype=self.language_model.model.embed_tokens.weight.dtype,
++                )
++            else:
++                self.per_layer_embeddings = None
++
++        self.make_empty_intermediate_tensors = (
++            self.language_model.make_empty_intermediate_tensors
++        )
++
++        # --- Precompute full-attention layer indices for bidi clearing ---
++        self._full_attn_layer_idxs: frozenset[int] = frozenset()
++        text_config = config.text_config
++        if getattr(text_config, "use_bidirectional_attention", None) == "vision":
++            layer_types = getattr(text_config, "layer_types", None)
++            if layer_types:
++                self._full_attn_layer_idxs = frozenset(
++                    i for i, lt in enumerate(layer_types) if lt != "sliding_attention"
++                )
++
++        # --- MixtureOfExperts delegation to language_model ---
++        self.expert_weights = self.language_model.expert_weights
++        self.moe_layers = self.language_model.moe_layers
++        self.num_moe_layers = self.language_model.num_moe_layers
++        self.num_logical_experts = self.language_model.num_logical_experts
++        self.num_physical_experts = self.language_model.num_physical_experts
++        self.num_local_physical_experts = self.language_model.num_local_physical_experts
++        self.num_routed_experts = self.language_model.num_routed_experts
++        self.num_expert_groups = self.language_model.num_expert_groups
++        self.num_shared_experts = self.language_model.num_shared_experts
++        self.num_redundant_experts = self.language_model.num_redundant_experts
++
++        gen_cfg = vllm_config.model_config.try_get_generation_config()
++        self._suppress_token_ids = gen_cfg.get("suppress_tokens") if gen_cfg else None
++
++    # ------------------------------------------------------------------ #
++    # Multimodal processing (encoder-free overrides)
++    # ------------------------------------------------------------------ #
++
++    def _process_image_input(
++        self,
++        image_input: Gemma4ImageInputs,
++    ) -> list[torch.Tensor]:
++        """Project raw image patches directly to LM space.
++
++        No vision tower: each image's pre-patchified pixel values are
++        embedded via Gemma4UnifiedVisionEmbedder, projected through
++        Gemma4MultimodalEmbedder, and padding patches (pp == -1) are
++        stripped per image.
++        """
++        pixel_values = image_input["pixel_values"]
++        pixel_position_ids = image_input["pixel_position_ids"]
++        target_dtype = self.embed_vision.embedding_projection.weight.dtype
++
++        per_image_features: list[torch.Tensor] = []
++        for pv, pp in zip(pixel_values, pixel_position_ids, strict=True):
++            pv = pv.unsqueeze(0)
++            pp = pp.unsqueeze(0)
++            embedded = self.vision_embedder(pv, pp)
++            projected = self.embed_vision(embedded.to(target_dtype))
++            padding_mask = (pp.squeeze(0) == -1).all(dim=-1)
++            valid_features = projected.squeeze(0)[~padding_mask]
++            per_image_features.append(valid_features)
++        return per_image_features
++
++    def _process_video_input(
++        self,
++        video_input: dict[str, torch.Tensor],
++    ) -> list[torch.Tensor]:
++        """Project video frames to LM space, one frame at a time.
++
++        Frames are split per video, each frame is embedded + projected,
++        and per-frame valid embeddings are concatenated per video.
++        """
++        pixel_values = video_input["pixel_values_videos"]
++        pixel_position_ids = video_input["pixel_position_ids_videos"]
++        frame_counts = video_input["video_frame_counts"]
++        target_dtype = self.embed_vision.embedding_projection.weight.dtype
++
++        if isinstance(frame_counts, torch.Tensor):
++            fc_list = frame_counts.tolist()
++        else:
++            fc_list = list(frame_counts)
++
++        pv_per_video = torch.split(pixel_values, fc_list, dim=0)
++        pp_per_video = torch.split(pixel_position_ids, fc_list, dim=0)
++
++        per_video_embeddings: list[torch.Tensor] = []
++        for pv_chunk, pp_chunk in zip(pv_per_video, pp_per_video):
++            frame_embs: list[torch.Tensor] = []
++            for i in range(pv_chunk.shape[0]):
++                pv = pv_chunk[i].unsqueeze(0)
++                pp = pp_chunk[i].unsqueeze(0)
++                embedded = self.vision_embedder(pv, pp)
++                projected = self.embed_vision(embedded.to(target_dtype))
++                padding_mask = (pp.squeeze(0) == -1).all(dim=-1)
++                frame_embs.append(projected.squeeze(0)[~padding_mask])
++            per_video_embeddings.append(torch.cat(frame_embs, dim=0))
++        return per_video_embeddings
++
++    def _process_audio_input(
++        self,
++        audio_input: Gemma4AudioInputs,
++    ) -> list[torch.Tensor]:
++        """Project raw waveform-frame features directly to LM space.
++
++        No audio tower: the per-frame raw features are passed straight
++        through the multimodal embedder, then padding is stripped.
++        """
++        input_features = audio_input["input_features_padded"].squeeze(1)
++        input_features_mask = audio_input["input_features_mask"].squeeze(1)
++
++        target_dtype = self.embed_audio.embedding_projection.weight.dtype
++        audio_features = self.embed_audio(input_features.to(target_dtype))
++        per_audio: list[torch.Tensor] = []
++        for enc, mask in zip(audio_features, input_features_mask, strict=True):
++            per_audio.append(enc[mask])
++        return per_audio
++
++    # ------------------------------------------------------------------ #
++    # Weight loading
++    # ------------------------------------------------------------------ #
++
++    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
++        ignore_prefixes = [
++            # Vestigial Gemma3n-style embedding tables not used by
++            # Gemma4MultimodalEmbedder (which has only projection + norm).
++            "embed_vision.embedding.",
++            "embed_audio.embedding.",
++        ]
++        if self.embed_audio is None:
++            ignore_prefixes.append("embed_audio.")
++
++        loader = AutoWeightsLoader(
++            self,
++            ignore_unexpected_prefixes=ignore_prefixes,
++        )
++        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
++
++    # ------------------------------------------------------------------ #
++    # LoRA / multimodal mapping
++    # ------------------------------------------------------------------ #
++
++    def get_mm_mapping(self) -> MultiModelKeys:
++        """Module prefix mapping for the encoder-free model (no towers)."""
++        connectors = ["embed_vision"]
++        if self.embed_audio is not None:
++            connectors.append("embed_audio")
++        return MultiModelKeys.from_string_field(
++            language_model="language_model",
++            connector=connectors,
++            tower_model=[],
++        )
 diff --git a/vllm/model_executor/models/minicpmv.py b/vllm/model_executor/models/minicpmv.py
 index cda07ea29..f58f98dac 100644
 --- a/vllm/model_executor/models/minicpmv.py
@@ -1632,11 +7069,1097 @@ index cda07ea29..f58f98dac 100644
          return hf_processor
  
      def get_image_processor(self, **kwargs: object):
+diff --git a/vllm/model_executor/models/qwen3_5.py b/vllm/model_executor/models/qwen3_5.py
+index dc761e69b..4c100ed9d 100644
+--- a/vllm/model_executor/models/qwen3_5.py
++++ b/vllm/model_executor/models/qwen3_5.py
+@@ -192,6 +192,13 @@ class Qwen3_5DecoderLayer(Qwen3NextDecoderLayer):
+                 ),
+             )
+ 
++        # This subclass intentionally bypasses Qwen3NextDecoderLayer.__init__
++        # (it needs hf_text_config, gqa_interleaved_layout=False, model_type-based
++        # MLP selection, and Qwen3_5RMSNorm), so the inherited ESIMD decode
++        # fast-path wiring (incl. the sym_int4 flags) would otherwise be missing
++        # entirely. Set it up here via the shared single-source-of-truth helper.
++        self._init_esimd_flags(quant_config)
++
+ 
+ @support_torch_compile(
+     dynamic_arg_dims={
+diff --git a/vllm/model_executor/models/qwen3_next.py b/vllm/model_executor/models/qwen3_next.py
+index f4c716789..d9d41f2da 100644
+--- a/vllm/model_executor/models/qwen3_next.py
++++ b/vllm/model_executor/models/qwen3_next.py
+@@ -21,6 +21,7 @@ from vllm.distributed import (
+     get_pp_group,
+     get_tensor_model_parallel_world_size,
+     tensor_model_parallel_all_gather,
++    tensor_model_parallel_all_reduce,
+ )
+ from vllm.logger import init_logger
+ from vllm.model_executor.layers.attention import Attention
+@@ -28,6 +29,18 @@ from vllm.model_executor.layers.fused_moe import (
+     FusedMoE,
+     fused_moe_make_expert_params_mapping,
+ )
++from vllm.model_executor.layers.esimd_utils import (
++    esimd_fused_add_rms_norm,
++    esimd_fused_add_rms_norm_batched,
++    esimd_gemv_fp8_pert,
++    esimd_gemv_fp8_pert_fused2,
++    esimd_gemv_int4,
++    esimd_qkv_split_norm_rope,
++    esimd_resadd_norm_gemv_fp8_pert,
++    esimd_resadd_norm_gemv_int4_pert,
++    moe_forward_full,
++    moe_forward_full_v2,
++)
+ from vllm.model_executor.layers.layernorm import (
+     GemmaRMSNorm as Qwen3NextRMSNorm,
+ )
+@@ -124,7 +137,7 @@ class Qwen3NextSparseMoeBlock(nn.Module):
+             config.hidden_size,
+             config.num_experts,
+             bias=False,
+-            quant_config=None,
++            quant_config=quant_config,
+             prefix=f"{prefix}.gate",
+         )
+ 
+@@ -172,12 +185,162 @@ class Qwen3NextSparseMoeBlock(nn.Module):
+             else None,
+         )
+ 
++        # Eligibility for the fused ESIMD MoE decode kernel (moe_forward_full).
++        # Decided once. Requires: ESIMD available + not disabled, FP8 quant, a
++        # separate (non-None) shared expert MLP whose weights the kernel reads
++        # directly (the shared_expert-fused-into-FusedMoE layout used when
++        # shared_expert is None is not supported), and n_experts % 16 == 0 (the
++        # topk kernel loads logits in 16-wide chunks). Per-call gating to
++        # num_tokens <= 128 lives in forward(). The weight dtype check (e4m3 vs
++        # e5m2) is handled inside the kernel's host dispatch.
++        from vllm.model_executor.layers.esimd_utils import (
++            ESIMD_AVAILABLE,
++            disable_esimd_moe,
++            quant_is_fp8,
++        )
++
++        self._moe_esimd_ok = (
++            ESIMD_AVAILABLE
++            and not disable_esimd_moe()
++            and quant_is_fp8(quant_config)
++            and self.shared_expert is not None
++            and self.n_routed_experts % 16 == 0
++        )
++
++        from vllm.model_executor.layers.esimd_utils import (
++            disable_esimd_int4,
++            quant_is_sym_int4,
++        )
++
++        self._moe_int4_esimd_ok = (
++            ESIMD_AVAILABLE
++            and not disable_esimd_int4()
++            and quant_is_sym_int4(quant_config)
++            and self.shared_expert is not None
++            and self.n_routed_experts % 16 == 0
++        )
++        self._int4_moe_weights_cached = False
++
++        # Router logits the DecoderLayer may precompute when it folds the
++        # post_attention_layernorm and this gate's GEMV into one fused kernel
++        # (see fused_post_attn_router). Consumed (and cleared) in forward().
++        self._precomputed_router_logits = None
++        # Lazily-built FP8 shadow of the (fp16) gate weight, used only by the
++        # fused router GEMV kernel. The fp16 self.gate stays the source of truth
++        # for the upstream/prefill router path.
++        self._gate_fp8_weight = None
++        self._gate_fp8_scale = None
++        self._router_buf = None
++        self._normed_buf = None
++
++    def fused_post_attn_router(
++        self,
++        hidden_states: torch.Tensor,
++        residual: torch.Tensor,
++        norm_weight_fp16: torch.Tensor,
++        eps: float,
++    ) -> tuple[torch.Tensor, torch.Tensor]:
++        """Fuse residual-add + post_attn RMSNorm + router GEMV (decode, M==1).
++
++        Replaces the DecoderLayer's ``post_attention_layernorm`` (a fused
++        add+norm) plus this block's separate gate GEMV with a single ESIMD
++        kernel. Returns ``(router_logits, normed_hidden)`` — both backed by
++        reused per-layer buffers. ``residual`` is updated in place.
++
++        ``norm_weight_fp16`` is the Gemma-adjusted ``(w + 1)`` fp16 weight,
++        owned/cached by the DecoderLayer. The gate here is fp16 (unlike the
++        reference, which quantizes it), so we keep a lazily-quantized FP8
++        shadow of the gate weight for the per-tensor GEMV kernel.
++        """
++        from vllm import _custom_ops as ops
++        if self._gate_fp8_weight is None:
++            # The fused router GEMV (esimd_resadd_norm_gemv_fp8_pert) needs the
++            # gate weight as per-tensor FP8 [N, K] = [n_experts, hidden] with a
++            # scalar fp32 scale. When the gate is quantized (quant_config passed
++            # through, as upstream now does for qwen3_next), it already holds
++            # exactly that -- consume it directly, matching v0.14.0's
++            # moe_router_forward(x, gate.weight, gate.weight_scale). Only an
++            # unquantized (fp16) gate needs a lazily-quantized FP8 shadow.
++            # Re-quantizing an already-FP8 gate.weight crashes: scaled_fp8_quant
++            # dispatches on the input dtype and has no FP8 case
++            # ("not implemented for Float8_e4m3fn").
++            gw = self.gate.weight
++            gs = getattr(self.gate, "weight_scale", None)
++            if (
++                gw.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
++                and gs is not None
++                and gs.numel() == 1
++            ):
++                self._gate_fp8_weight = gw.data
++                self._gate_fp8_scale = gs.data
++            else:
++                qw, scale = ops.scaled_fp8_quant(
++                    self.gate.weight.data.contiguous(), scale=None
++                )
++                self._gate_fp8_weight = qw
++                self._gate_fp8_scale = scale
++            dev = hidden_states.device
++            self._router_buf = torch.empty(
++                1, self.n_routed_experts, dtype=torch.float16, device=dev
++            )
++            self._normed_buf = torch.empty(
++                1, hidden_states.shape[-1], dtype=torch.float16, device=dev
++            )
++
++        esimd_resadd_norm_gemv_fp8_pert(
++            hidden_states,
++            residual,
++            norm_weight_fp16,
++            self._gate_fp8_weight,
++            self._gate_fp8_scale,
++            self._router_buf,
++            self._normed_buf,
++            eps,
++        )
++        return self._router_buf, self._normed_buf
++
+     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+         # NOTE: hidden_states can have either 1D or 2D shape.
+         orig_shape = hidden_states.shape
+         num_tokens, hidden_dim = hidden_states.shape
+         hidden_states = hidden_states.view(-1, hidden_dim)
+ 
++        # Decode fast path: fuse topk + routed up/down + shared expert + finalize
++        # into one ESIMD kernel, replacing the FusedMoE dispatch + separate
++        # shared-expert MLP. FP8 is gated to num_tokens <= 128; the INT4 path is
++        # gated to num_tokens <= 64 because its grouped GEMM kernel only computes
++        # the first 64 M-rows (M_TILES=8 x M_TILE=8) and leaves rows 64.. as
++        # uninitialized garbage -> NaN/!!!! cascade for larger batches.
++        # prefill/larger batches keep the upstream path. Not under sequence
++        # parallelism (the kernel produces the full per-token output directly).
++        # A precomputed router-logits buffer (set by the DecoderLayer's fused
++        # post_attn_norm + router path) is consumed once here, then cleared so
++        # a later non-fused forward recomputes its own logits.
++        precomputed_logits = self._precomputed_router_logits
++        self._precomputed_router_logits = None
++
++        if (
++            self._moe_esimd_ok
++            and num_tokens <= 128
++            and not self.is_sequence_parallel
++        ):
++            out = self._forward_esimd_moe(
++                hidden_states, num_tokens, precomputed_logits
++            )
++            if out is not None:
++                return out.view(orig_shape)
++
++        if (
++            self._moe_int4_esimd_ok
++            and num_tokens <= 64
++            and not self.is_sequence_parallel
++        ):
++            out = self._forward_int4_esimd_moe(
++                hidden_states, num_tokens, precomputed_logits
++            )
++            if out is not None:
++                return out.view(orig_shape)
++
+         if self.is_sequence_parallel:
+             hidden_states = sequence_parallel_chunk(hidden_states)
+ 
+@@ -201,6 +364,112 @@ class Qwen3NextSparseMoeBlock(nn.Module):
+ 
+         return final_hidden_states.view(orig_shape)
+ 
++    def _forward_esimd_moe(self, hidden_states, num_tokens, precomputed_logits=None):
++        """Fused MoE decode via moe_forward_full (BSZ=1) / _v2 (BSZ>1).
++
++        Returns the [num_tokens, hidden] output, or None to fall through to the
++        upstream path (e.g. warmup before weights are FP8-quantized). The kernel
++        does topk internally, so we pass the raw gate logits. All weights are
++        consumed in their native v0.21.0 layout (no transpose; see progress doc).
++
++        ``precomputed_logits`` (when not None) are router logits the DecoderLayer
++        already produced inside its fused post_attn_norm + router GEMV kernel,
++        letting us skip this block's gate GEMV entirely.
++        """
++        experts = self.experts
++        w13 = getattr(experts, "w13_weight", None)
++        # Before process_weights_after_loading the weights are not yet FP8;
++        # bail to the upstream path (covers the profile/warmup run too).
++        if w13 is None or w13.dtype not in (
++            torch.float8_e4m3fn,
++            torch.float8_e5m2,
++        ):
++            return None
++
++        if precomputed_logits is not None:
++            router_logits = precomputed_logits
++        else:
++            router_logits, _ = self.gate(hidden_states)
++        # Route through torch.ops.moe_ops.* (dispatcher op) instead of the
++        # raw pybind binding so the MoE call appears as an fx node and the
++        # platform's splitting_ops can split it out of the captured XPU
++        # graph (the ESIMD MoE kernel does host-side alloc/sync and cannot
++        # be replayed inside a graph). Same args as the pybind signature.
++        moe_fn = (
++            torch.ops.moe_ops.moe_forward_full
++            if num_tokens == 1
++            else torch.ops.moe_ops.moe_forward_full_v2
++        )
++        out = moe_fn(
++            hidden_states,
++            router_logits,
++            experts.w13_weight,
++            experts.w13_weight_scale,
++            self.shared_expert.gate_up_proj.weight,
++            self.shared_expert.gate_up_proj.weight_scale,
++            experts.w2_weight,
++            experts.w2_weight_scale,
++            self.shared_expert.down_proj.weight,
++            self.shared_expert.down_proj.weight_scale,
++            self.shared_expert_gate.weight,
++            experts.top_k,
++            1,  # num_shared_experts
++            self.n_routed_experts,
++        )
++        if self.tp_size > 1:
++            out = tensor_model_parallel_all_reduce(out)
++        return out
++
++    def _forward_int4_esimd_moe(self, hidden_states, num_tokens, precomputed_logits=None):
++        """Fused INT4 MoE decode via moe_forward_full_cutlass_nmajor_int4.
++
++        Returns [num_tokens, hidden] output, or None to fall through (e.g.
++        before weights are ready on the first forward / profile run).
++        """
++        if not self._int4_moe_weights_cached:
++            qm = getattr(self.experts, "quant_method", None)
++            impl = getattr(qm, "_fused_moe_impl", None)
++            if impl is None:
++                return None
++            self._int4_w13 = impl.w13
++            self._int4_w13_scales = impl.gemm1_scales
++            self._int4_w2 = impl.w2
++            self._int4_w2_scales = impl.gemm2_scales
++            self._int4_shared_gu_w = self.shared_expert.gate_up_proj.weight
++            self._int4_shared_d_w = self.shared_expert.down_proj.weight
++            self._int4_shared_gate_w = self.shared_expert_gate.weight
++            from custom_esimd_kernels_vllm.ops import (
++                moe_forward_full_cutlass_nmajor_int4 as _moe_int4_bsz1_fn,
++                moe_forward_tiny_cutlass_nmajor_int4_full_fp16_shared_from_logits as _moe_int4_tiny_fn,
++            )
++            self._moe_int4_bsz1_fn = _moe_int4_bsz1_fn
++            self._moe_int4_tiny_fn = _moe_int4_tiny_fn
++            self._int4_moe_weights_cached = True
++
++        if precomputed_logits is not None:
++            router_logits = precomputed_logits
++        else:
++            router_logits, _ = self.gate(hidden_states)
++
++        _moe_fn = self._moe_int4_bsz1_fn if num_tokens == 1 else self._moe_int4_tiny_fn
++        out = _moe_fn(
++            hidden_states,
++            router_logits,
++            self._int4_w13,
++            self._int4_w13_scales,
++            self._int4_w2,
++            self._int4_w2_scales,
++            self._int4_shared_gu_w,
++            self._int4_shared_d_w,
++            self._int4_shared_gate_w,
++            self.experts.top_k,
++            1,  # num_shared_experts
++            self.n_routed_experts,
++        )
++        if self.tp_size > 1:
++            out = tensor_model_parallel_all_reduce(out)
++        return out
++
+ 
+ class Qwen3NextAttention(nn.Module):
+     def __init__(
+@@ -281,13 +550,93 @@ class Qwen3NextAttention(nn.Module):
+         self.q_norm = Qwen3NextRMSNorm(self.head_dim, eps=config.rms_norm_eps)
+         self.k_norm = Qwen3NextRMSNorm(self.head_dim, eps=config.rms_norm_eps)
+ 
++        # Eligibility for the fused ESIMD QKV split+norm+RoPE(+gate) fast path,
++        # decided once here since model/rope/quant shape is fixed. The kernel
++        # hardcodes headDim==256, q/k GemmaRMSNorm (weight+1, eps=1e-6) and
++        # NeoX-style partial RoPE reading rotary_emb.cos_sin_cache directly. The
++        # per-call positions.ndim==1 (text-only) check stays in forward(): a
++        # multimodal request passes [3, n] T/H/W positions that need the mRoPE
++        # section remap this kernel cannot express. Calibrated vs the upstream
++        # path on XPU: q/k rel_err ~2e-4, v/gate bit-exact.
++        from vllm.model_executor.layers.esimd_utils import (
++            ESIMD_AVAILABLE,
++            disable_esimd_qkv,
++        )
++
++        # ESIMD_AVAILABLE is only True on XPU with the kernel package installed,
++        # so it doubles as the platform guard (no current_platform import here).
++        self._qkv_esimd_ok = (
++            ESIMD_AVAILABLE
++            and not disable_esimd_qkv()
++            and self.head_dim == 256
++            and getattr(self.rotary_emb, "is_neox_style", False)
++            and config.rms_norm_eps == 1e-6
++        )
++        self._qkv_rotary_dim = int(
++            self.head_dim * getattr(config, "partial_rotary_factor", 1.0)
++        )
++
++        from vllm.model_executor.layers.esimd_utils import (
++            disable_esimd_int4,
++            quant_is_sym_int4,
++        )
++        from vllm.model_executor.layers.quantization.sym_int4 import (
++            QK4_GROUP_SIZE,
++        )
++
++        self._use_esimd_int4_gemv = (
++            ESIMD_AVAILABLE
++            and quant_is_sym_int4(quant_config)
++            and not disable_esimd_int4()
++            and QK4_GROUP_SIZE == 128
++        )
++        self._decode_qkv_int4_buf = None
++        self._decode_o_int4_buf = None
++
+     def forward(
+         self,
+         positions: torch.Tensor,
+         output: torch.Tensor,
+         hidden_states: torch.Tensor,
+     ):
+-        qkv, _ = self.qkv_proj(hidden_states)
++        # ntoks <= 128 cap: the kernel dispatches a 2D (totalHeads, ntoks) grid
++        # with a 1x1 work-group, which stalls the worker at prefill-scale token
++        # counts (observed to hang at ntoks~800). This is a decode / small-batch
++        # fast path; prefill falls through to the upstream split+norm+RoPE.
++        if (
++            self._qkv_esimd_ok
++            and not self._use_esimd_int4_gemv
++            and positions.ndim == 1
++            and hidden_states.shape[0] <= 128
++        ):
++            return self._forward_esimd_qkv(positions, output, hidden_states)
++
++        _ntoks = hidden_states.shape[0]
++        if _ntoks == 1 and self._use_esimd_int4_gemv:
++            if self._decode_qkv_int4_buf is None:
++                N = self.qkv_proj.weight_esimd.shape[0]
++                self._decode_qkv_int4_buf = torch.empty(
++                    1, N, dtype=torch.float16, device=hidden_states.device
++                )
++            esimd_gemv_int4(
++                hidden_states,
++                self.qkv_proj.weight_esimd,
++                self.qkv_proj.scale_esimd,
++                self._decode_qkv_int4_buf,
++            )
++            qkv = self._decode_qkv_int4_buf
++        elif _ntoks <= 64 and self._use_esimd_int4_gemv:
++            from vllm.model_executor.layers.esimd_utils import esimd_gemm_int4_pgrp
++            N = self.qkv_proj.weight_esimd.shape[0]
++            qkv = torch.empty(_ntoks, N, dtype=torch.float16, device=hidden_states.device)
++            esimd_gemm_int4_pgrp(
++                hidden_states,
++                self.qkv_proj.weight_esimd,
++                self.qkv_proj.scale_esimd,
++                qkv,
++            )
++        else:
++            qkv, _ = self.qkv_proj(hidden_states)
+ 
+         if self.attn_output_gate:
+             q_gate, k, v = qkv.split(
+@@ -316,6 +665,118 @@ class Qwen3NextAttention(nn.Module):
+             gate = torch.sigmoid(gate)
+             attn_output = attn_output * gate
+ 
++        if _ntoks == 1 and self._use_esimd_int4_gemv:
++            if self._decode_o_int4_buf is None:
++                N = self.o_proj.weight_esimd.shape[0]
++                self._decode_o_int4_buf = torch.empty(
++                    1, N, dtype=torch.float16, device=attn_output.device
++                )
++            esimd_gemv_int4(
++                attn_output,
++                self.o_proj.weight_esimd,
++                self.o_proj.scale_esimd,
++                self._decode_o_int4_buf,
++            )
++            output[:1] = tensor_model_parallel_all_reduce(
++                self._decode_o_int4_buf
++            )
++        elif _ntoks <= 64 and self._use_esimd_int4_gemv:
++            from vllm.model_executor.layers.esimd_utils import esimd_gemm_int4_pgrp
++            N = self.o_proj.weight_esimd.shape[0]
++            o_buf = torch.empty(_ntoks, N, dtype=torch.float16, device=attn_output.device)
++            esimd_gemm_int4_pgrp(
++                attn_output,
++                self.o_proj.weight_esimd,
++                self.o_proj.scale_esimd,
++                o_buf,
++            )
++            output[:_ntoks] = tensor_model_parallel_all_reduce(o_buf)
++        else:
++            output[:], _ = self.o_proj(attn_output)
++
++    def _forward_esimd_qkv(
++        self,
++        positions: torch.Tensor,
++        output: torch.Tensor,
++        hidden_states: torch.Tensor,
++    ):
++        """Text-only fast path: one ESIMD kernel does QKV split + q/k RMSNorm +
++        NeoX partial RoPE (+ sigmoid gate), replacing split/chunk/reshape, two
++        GemmaRMSNorm dispatches, the RoPE call and the gate sigmoid. Gated by
++        _qkv_esimd_ok and positions.ndim == 1 in forward()."""
++        qkv, _ = self.qkv_proj(hidden_states)
++        self._esimd_qkv_core(qkv, positions, output)
++
++    def forward_precomputed_qkv(
++        self,
++        qkv: torch.Tensor,
++        positions: torch.Tensor,
++        output: torch.Tensor,
++    ):
++        """Attention forward when the qkv projection was already computed by
++        the DecoderLayer's fused input_norm + qkv GEMV kernel. Runs only the
++        ESIMD split + q/k RMSNorm + RoPE core, attention and o_proj. Requires
++        _qkv_esimd_ok (same kernel constraints as _forward_esimd_qkv); decode
++        M==1 path."""
++        self._esimd_qkv_core(qkv, positions, output)
++
++    def _esimd_qkv_core(
++        self,
++        qkv: torch.Tensor,
++        positions: torch.Tensor,
++        output: torch.Tensor,
++    ):
++        ntoks = qkv.shape[0]
++        dev = qkv.device
++
++        # Preallocate q/k/v/gate decode buffers once (sliced to ntoks, a leading
++        # slice so contiguous); the kernel overwrites them fully. ntoks is gated
++        # <=128 by the caller. Avoids 3-4 torch.empty per full-attn layer/step.
++        if getattr(self, "_qkv_q_buf", None) is None:
++            mb = 128
++            self._qkv_q_buf = torch.empty(
++                mb, self.q_size, dtype=torch.float16, device=dev
++            )
++            self._qkv_k_buf = torch.empty(
++                mb, self.kv_size, dtype=torch.float16, device=dev
++            )
++            self._qkv_v_buf = torch.empty(
++                mb, self.kv_size, dtype=torch.float16, device=dev
++            )
++            self._qkv_gate_buf = (
++                torch.empty(mb, self.q_size, dtype=torch.float16, device=dev)
++                if self.attn_output_gate
++                else torch.empty(1, dtype=torch.float16, device=dev)
++            )
++        q = self._qkv_q_buf[:ntoks]
++        k = self._qkv_k_buf[:ntoks]
++        v = self._qkv_v_buf[:ntoks]
++        gate = self._qkv_gate_buf[:ntoks] if self.attn_output_gate else self._qkv_gate_buf
++
++        # cos_sin_cache is fp16 (model dtype) -- kernel reads it directly.
++        cos_sin_cache = self.rotary_emb.cos_sin_cache
++        esimd_qkv_split_norm_rope(
++            qkv,
++            q,
++            gate,
++            k,
++            v,
++            self.q_norm.weight,
++            self.k_norm.weight,
++            positions.to(torch.int32),
++            self.num_heads,
++            self.num_kv_heads,
++            self.attn_output_gate,
++            self._qkv_rotary_dim,
++            cos_sin_cache,
++        )
++
++        attn_output = self.attn(q, k, v)
++
++        if self.attn_output_gate:
++            # gate already has sigmoid applied inside the kernel.
++            attn_output = attn_output * gate
++
+         output[:], _ = self.o_proj(attn_output)
+ 
+ 
+@@ -398,6 +859,239 @@ class Qwen3NextDecoderLayer(nn.Module):
+                 ),
+             )
+ 
++        self._init_esimd_flags(quant_config)
++
++    def _init_esimd_flags(self, quant_config) -> None:
++        """Decide the ESIMD decode fast-path eligibility flags + buffer slots.
++
++        Reads only attributes every DecoderLayer __init__ sets before calling
++        this (``layer_type``, ``layer_scale``, ``mlp``, ``linear_attn`` /
++        ``self_attn``) plus the ``quant_config`` (passed in, used to gate fp8 vs
++        sym_int4 paths), so subclasses that intentionally bypass
++        ``Qwen3NextDecoderLayer.__init__`` (e.g. ``Qwen3_5DecoderLayer``, which
++        needs hf_text_config / a different GDN layout / RMSNorm class) can build
++        their own submodules and then call this once to get the same ESIMD
++        wiring -- instead of silently missing every flag (which disables the
++        decode fast paths and AttributeErrors on the lazy-ready checks).
++        """
++        # Eligibility for folding post_attention_layernorm + the MoE router
++        # GEMV into one ESIMD kernel at decode (M==1). Requires an FP8 MoE block
++        # that itself runs the fused-MoE decode kernel, no layer_scale (the
++        # scale multiply happens after the norm and the kernel can't express
++        # it), and the kernel available + not disabled. Decided once.
++        from vllm.model_executor.layers.esimd_utils import (
++            ESIMD_AVAILABLE,
++            disable_esimd_attn_input_norm,
++            disable_esimd_gdn_input_norm,
++            disable_esimd_moe_norm,
++            quant_is_fp8,
++        )
++
++        from vllm.model_executor.layers.esimd_utils import (
++            disable_esimd_int4,
++            quant_is_sym_int4,
++        )
++
++        _is_fp8 = quant_is_fp8(quant_config)
++        _is_int4 = quant_is_sym_int4(quant_config)
++
++        self._moe_norm_esimd_ok = (
++            ESIMD_AVAILABLE
++            and _is_fp8
++            and not disable_esimd_moe_norm()
++            and isinstance(self.mlp, Qwen3NextSparseMoeBlock)
++            and getattr(self.mlp, "_moe_esimd_ok", False)
++            and not self.layer_scale
++        )
++
++        self._moe_norm_int4_esimd_ok = (
++            ESIMD_AVAILABLE
++            and _is_int4
++            and not disable_esimd_moe_norm()
++            and not disable_esimd_int4()
++            and isinstance(self.mlp, Qwen3NextSparseMoeBlock)
++            and not self.layer_scale
++        )
++        self._int4_router_buf = None
++        self._int4_normed_buf = None
++        # Lazily-cached fp16 (w + 1) post-attn norm weight for the fused kernel.
++        # Private clone+contiguous: the XPU cache allocator may otherwise hand
++        # this storage to another tensor mid-inference and corrupt the cached
++        # weight (same caveat as GemmaRMSNorm._gemma_w_fp16 / the spec).
++        self._post_norm_w_fp16 = None
++
++        # Eligibility for folding input_layernorm + the GDN in_proj dual-GEMV
++        # into one ESIMD kernel at decode (M==1), for linear_attention layers.
++        # Requires the GDN's own dual-GEMV fast path to be enabled (so the proj
++        # weights are FP8 per-tensor) and no layer_scale. Decided once; the
++        # weight-readiness (FP8 + scalar scale) is re-checked lazily in forward.
++        self._gdn_input_norm_esimd_ok = (
++            ESIMD_AVAILABLE
++            and _is_fp8
++            and not disable_esimd_gdn_input_norm()
++            and self.layer_type == "linear_attention"
++            and getattr(self.linear_attn, "_gdn_proj_esimd_ok", False)
++            and not self.layer_scale
++        )
++        # Lazily-cached fp16 (w + 1) input norm weight + proj output buffers.
++        self._input_norm_w_fp16 = None
++        self._gdn_fused_qkvz_buf = None
++        self._gdn_fused_ba_buf = None
++        self._gdn_input_norm_ready = None  # None=undecided; True/False once checked
++
++        # Eligibility for folding input_layernorm + the attention qkv_proj GEMV
++        # into one ESIMD kernel at decode (M==1), for full_attention layers.
++        # Requires the attention's own ESIMD qkv split+norm+rope fast path (so
++        # the rope/head shape is kernel-compatible) and no layer_scale. Decided
++        # once; FP8 weight readiness is re-checked lazily in forward.
++        self._attn_input_norm_esimd_ok = (
++            ESIMD_AVAILABLE
++            and _is_fp8
++            and not disable_esimd_attn_input_norm()
++            and self.layer_type == "full_attention"
++            and getattr(self.self_attn, "_qkv_esimd_ok", False)
++            and not self.layer_scale
++        )
++        self._attn_input_norm_w_fp16 = None
++        self._attn_fused_qkv_buf = None
++        self._attn_input_norm_ready = None  # None=undecided; True/False once checked
++        # Preallocated [1, hidden] attention-output buffer for the M==1 fused
++        # decode path, reused across steps instead of a per-step empty_like.
++        self._decode_attn_out_buf = None
++
++    def _fused_gdn_input_proj(
++        self, hidden_states: torch.Tensor, residual: torch.Tensor
++    ) -> bool:
++        """Fuse input_layernorm + GDN in_proj dual-GEMV (decode M==1).
++
++        Two-kernel path matching v0.14.0: esimd_fused_add_rms_norm_batched does
++        residual += hidden and writes normed = rmsnorm(residual)*(w+1) back into
++        hidden_states in place, then esimd_gemv_fp8_pert_fused2 does the dual
++        in_proj GEMV (qkvz + ba) off the normed hidden. This replaces the single
++        fused esimd_resadd_norm_gemv2_fp8_pert kernel: at the large in_proj
++        output dim ({3088} per rank) the folded-norm GEMV profiles slower
++        (~22.7us/call) than the split norm + plain dual-GEMV (~3.8 + 16.7us),
++        same as the attn qkv path.
++        Returns True if it ran (buffers now hold the projections), else False to
++        fall through to the standard input_layernorm + GDN forward.
++
++        Readiness (both projections FP8 per-tensor, no bias) is decided lazily on
++        the first decode -- weight_scale only exists after weight loading.
++        """
++        gdn = self.linear_attn
++        if self._gdn_input_norm_ready is None:
++            wq = gdn.in_proj_qkvz.weight
++            wb = gdn.in_proj_ba.weight
++            sq = getattr(gdn.in_proj_qkvz, "weight_scale", None)
++            sb = getattr(gdn.in_proj_ba, "weight_scale", None)
++            self._gdn_input_norm_ready = (
++                wq.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
++                and wb.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
++                and sq is not None
++                and sb is not None
++                and sq.numel() == 1
++                and sb.numel() == 1
++                and gdn.in_proj_qkvz.bias is None
++                and gdn.in_proj_ba.bias is None
++            )
++            if self._gdn_input_norm_ready:
++                dev = hidden_states.device
++                self._input_norm_w_fp16 = (
++                    (self.input_layernorm.weight.data + 1.0)
++                    .half()
++                    .clone()
++                    .contiguous()
++                )
++                self._gdn_fused_qkvz_buf = torch.empty(
++                    1, wq.shape[0], dtype=torch.float16, device=dev
++                )
++                self._gdn_fused_ba_buf = torch.empty(
++                    1, wb.shape[0], dtype=torch.float16, device=dev
++                )
++        if not self._gdn_input_norm_ready:
++            return False
++
++        # residual += hidden; hidden = rmsnorm(residual) * (input_norm.weight+1),
++        # written back into hidden_states in place (matches input_layernorm).
++        esimd_fused_add_rms_norm_batched(
++            hidden_states,
++            residual,
++            self._input_norm_w_fp16,
++            self.input_layernorm.variance_epsilon,
++        )
++        # Dual per-tensor FP8 GEMV (in_proj_qkvz + in_proj_ba) off normed hidden.
++        esimd_gemv_fp8_pert_fused2(
++            hidden_states,
++            gdn.in_proj_qkvz.weight,
++            gdn.in_proj_qkvz.weight_scale,
++            self._gdn_fused_qkvz_buf,
++            gdn.in_proj_ba.weight,
++            gdn.in_proj_ba.weight_scale,
++            self._gdn_fused_ba_buf,
++        )
++        return True
++
++    def _fused_attn_input_proj(
++        self, hidden_states: torch.Tensor, residual: torch.Tensor
++    ):
++        """Fuse input_layernorm + attention qkv_proj GEMV (decode M==1).
++
++        Two-kernel path matching v0.14.0: esimd_fused_add_rms_norm updates
++        residual += hidden and writes normed = rmsnorm(residual)*(w+1) back into
++        hidden_states in place, then esimd_gemv_fp8_pert does the plain qkv GEMV
++        off the normed hidden. This replaces the single fused
++        esimd_resadd_norm_gemv_fp8_pert kernel, which folds the RMSNorm into the
++        GEMV: that fusion regresses badly at the large qkv output dim (~2560 per
++        rank) -- profiled at ~42us/call vs ~14.5us for the plain GEMV plus a
++        cheap batched norm. The router GEMV (small {512} output) keeps the fused
++        kernel; only this large-output attn qkv path is split.
++        Returns the [1, qkv_out] projection buffer, or None to fall through.
++
++        Readiness (qkv_proj FP8 per-tensor, no bias) is decided lazily on the
++        first decode -- weight_scale only exists after weight loading.
++        """
++        attn = self.self_attn
++        if self._attn_input_norm_ready is None:
++            w = attn.qkv_proj.weight
++            ws = getattr(attn.qkv_proj, "weight_scale", None)
++            self._attn_input_norm_ready = (
++                w.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
++                and ws is not None
++                and ws.numel() == 1
++                and attn.qkv_proj.bias is None
++            )
++            if self._attn_input_norm_ready:
++                dev = hidden_states.device
++                self._attn_input_norm_w_fp16 = (
++                    (self.input_layernorm.weight.data + 1.0)
++                    .half()
++                    .clone()
++                    .contiguous()
++                )
++                self._attn_fused_qkv_buf = torch.empty(
++                    1, w.shape[0], dtype=torch.float16, device=dev
++                )
++        if not self._attn_input_norm_ready:
++            return None
++
++        # residual += hidden; hidden = rmsnorm(residual) * (input_norm.weight+1),
++        # written back into hidden_states in place (matches the non-fused
++        # input_layernorm(hidden, residual) semantics the slow path uses).
++        esimd_fused_add_rms_norm_batched(
++            hidden_states,
++            residual,
++            self._attn_input_norm_w_fp16,
++            self.input_layernorm.variance_epsilon,
++        )
++        # Plain per-tensor FP8 qkv GEMV off the normed hidden.
++        esimd_gemv_fp8_pert(
++            hidden_states,
++            attn.qkv_proj.weight,
++            attn.qkv_proj.weight_scale,
++            self._attn_fused_qkv_buf,
++        )
++        return self._attn_fused_qkv_buf
++
+     def forward(
+         self,
+         hidden_states: torch.Tensor,
+@@ -405,27 +1099,100 @@ class Qwen3NextDecoderLayer(nn.Module):
+         positions: torch.Tensor = None,
+         **kwargs: object,
+     ):
+-        if residual is None:
+-            residual = hidden_states
+-            hidden_states = self.input_layernorm(hidden_states)
++        # Decode fast path (M==1, FP8): fold input_layernorm (residual-add +
++        # RMSNorm) and the attention input projection GEMV into one ESIMD
++        # kernel, then run attention off the precomputed projection. Saves a
++        # kernel launch + a normed-buffer round-trip per layer.
++        #   - linear_attention: dual-GEMV (in_proj_qkvz + in_proj_ba) ->
++        #     forward_xpu_precomputed_proj
++        #   - full_attention: single qkv_proj GEMV -> forward_precomputed_qkv
++        decode_m1 = (
++            residual is not None
++            and hidden_states.shape[0] == 1
++            and hidden_states.dtype == torch.float16
++        )
++        fused_gdn = (
++            decode_m1
++            and self._gdn_input_norm_esimd_ok
++            and self._fused_gdn_input_proj(hidden_states, residual)
++        )
++        fused_attn = False
++        if not fused_gdn and decode_m1 and self._attn_input_norm_esimd_ok:
++            qkv = self._fused_attn_input_proj(hidden_states, residual)
++            fused_attn = qkv is not None
++        if fused_gdn or fused_attn:
++            # M==1 fused decode: reuse one preallocated [1, hidden] output
++            # buffer instead of a per-step torch.empty_like. A layer is either
++            # linear_attention or full_attention, so the two branches never
++            # share a step and one buffer suffices. Safe under in-order stream
++            # execution (this step's writes/reads are enqueued before the next
++            # step reuses it), matching the reference's _m_attn_output reuse.
++            if self._decode_attn_out_buf is None:
++                self._decode_attn_out_buf = torch.empty_like(hidden_states)
++            self_attention_output = self._decode_attn_out_buf
++            if fused_gdn:
++                self.linear_attn.forward_xpu_precomputed_proj(
++                    self._gdn_fused_qkvz_buf,
++                    self._gdn_fused_ba_buf,
++                    self_attention_output,
++                )
++            else:
++                self.self_attn.forward_precomputed_qkv(
++                    qkv, positions, self_attention_output
++                )
++            hidden_states = self_attention_output
+         else:
+-            hidden_states, residual = self.input_layernorm(hidden_states, residual)
++            if residual is None:
++                residual = hidden_states
++                hidden_states = self.input_layernorm(hidden_states)
++            elif hidden_states.shape[0] == 1 and hidden_states.dtype == torch.float16:
++
++                if getattr(self, "_input_norm_w_fp16_cache", None) is None:
++                    self._input_norm_w_fp16_cache = (
++                        (self.input_layernorm.weight.data + 1.0)
++                        .half()
++                        .clone()
++                        .contiguous()
++                    )
++                esimd_fused_add_rms_norm(
++                    hidden_states,
++                    residual,
++                    self._input_norm_w_fp16_cache,
++                    self.input_layernorm.variance_epsilon,
++                )
++            else:
++                hidden_states, residual = self.input_layernorm(hidden_states, residual)
+ 
+-        self_attention_output = torch.empty_like(hidden_states)
+-        if self.layer_type == "linear_attention":
+-            self.linear_attn(
+-                hidden_states=hidden_states,
+-                output=self_attention_output,
+-            )
+-        elif self.layer_type == "full_attention":
+-            self.self_attn(
+-                hidden_states=hidden_states,
+-                output=self_attention_output,
+-                positions=positions,
+-            )
+-        else:
+-            raise ValueError("Invalid layer_type")
+-        hidden_states = self_attention_output
++            if hidden_states.shape[0] == 1:
++                if self._decode_attn_out_buf is None:
++                    self._decode_attn_out_buf = torch.empty_like(hidden_states)
++                self_attention_output = self._decode_attn_out_buf
++            else:
++                self_attention_output = torch.empty_like(hidden_states)
++            if self.layer_type == "linear_attention":
++                if hidden_states.shape[0] == 1:
++                    self.linear_attn.forward_xpu(hidden_states, self_attention_output)
++                else:
++                    self.linear_attn(
++                        hidden_states=hidden_states,
++                        output=self_attention_output,
++                    )
++            elif self.layer_type == "full_attention":
++                if hidden_states.shape[0] == 1:
++                    self.self_attn.forward(
++                        positions=positions,
++                        output=self_attention_output,
++                        hidden_states=hidden_states,
++                    )
++                else:
++                    self.self_attn(
++                        hidden_states=hidden_states,
++                        output=self_attention_output,
++                        positions=positions,
++                    )
++            else:
++                raise ValueError("Invalid layer_type")
++            hidden_states = self_attention_output
+ 
+         if self.layer_scale:
+             if len(hidden_states.shape) == 2:
+@@ -438,8 +1205,71 @@ class Qwen3NextDecoderLayer(nn.Module):
+                 )
+ 
+         # Fully Connected
+-        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+-        hidden_states = self.mlp(hidden_states)
++        # Decode fast path (M==1, FP8 MoE): one ESIMD kernel does the
++        # post_attention_layernorm residual-add + RMSNorm AND the router gate
++        # GEMV, handing the logits to the SparseMoeBlock so it skips its own
++        # gate GEMV. residual is updated in place; normed hidden is returned.
++        if (
++            self._moe_norm_esimd_ok
++            and residual is not None
++            and hidden_states.shape[0] == 1
++            and hidden_states.dtype == torch.float16
++        ):
++            if self._post_norm_w_fp16 is None:
++                self._post_norm_w_fp16 = (
++                    (self.post_attention_layernorm.weight.data + 1.0)
++                    .half()
++                    .clone()
++                    .contiguous()
++                )
++            router_logits, normed = self.mlp.fused_post_attn_router(
++                hidden_states,
++                residual,
++                self._post_norm_w_fp16,
++                self.post_attention_layernorm.variance_epsilon,
++            )
++            self.mlp._precomputed_router_logits = router_logits
++            hidden_states = self.mlp.forward(normed)
++        elif (
++            self._moe_norm_int4_esimd_ok
++            and residual is not None
++            and hidden_states.shape[0] == 1
++            and hidden_states.dtype == torch.float16
++        ):
++            if self._post_norm_w_fp16 is None:
++                self._post_norm_w_fp16 = (
++                    (self.post_attention_layernorm.weight.data + 1.0)
++                    .half()
++                    .clone()
++                    .contiguous()
++                )
++            if self._int4_router_buf is None:
++                gate = self.mlp.gate
++                n_exp = gate.weight_esimd.view(torch.int32).shape[0]
++                dev = hidden_states.device
++                self._int4_router_buf = torch.empty(
++                    1, n_exp, dtype=torch.float16, device=dev
++                )
++                self._int4_normed_buf = torch.empty(
++                    1, hidden_states.shape[-1], dtype=torch.float16, device=dev
++                )
++            esimd_resadd_norm_gemv_int4_pert(
++                hidden_states,
++                residual,
++                self._post_norm_w_fp16,
++                self.mlp.gate.weight_esimd.view(torch.int32),
++                self.mlp.gate.scale_esimd,
++                self._int4_router_buf,
++                self._int4_normed_buf,
++                self.post_attention_layernorm.variance_epsilon,
++            )
++            self.mlp._precomputed_router_logits = self._int4_router_buf
++            hidden_states = self.mlp.forward(self._int4_normed_buf)
++        else:
++            hidden_states, residual = self.post_attention_layernorm(
++                hidden_states, residual
++            )
++            hidden_states = self.mlp(hidden_states)
+ 
+         if self.layer_scale:
+             if len(hidden_states.shape) == 2:
+diff --git a/vllm/model_executor/models/registry.py b/vllm/model_executor/models/registry.py
+index 5b77da7aa..c43a023e6 100644
+--- a/vllm/model_executor/models/registry.py
++++ b/vllm/model_executor/models/registry.py
+@@ -403,7 +403,12 @@ _MULTIMODAL_MODELS = {
+         "gemma3n_mm",
+         "Gemma3nForConditionalGeneration",
+     ),
++    "DiffusionGemmaForBlockDiffusion": (
++        "diffusion_gemma",
++        "DiffusionGemmaForConditionalGeneration",
++    ),
+     "Gemma4ForConditionalGeneration": ("gemma4_mm", "Gemma4ForConditionalGeneration"),
++    "Gemma4UnifiedForConditionalGeneration": ("gemma4_unified", "Gemma4UnifiedForConditionalGeneration"),
+     "GlmAsrForConditionalGeneration": ("glmasr", "GlmAsrForConditionalGeneration"),
+     "GLM4VForCausalLM": ("glm4v", "GLM4VForCausalLM"),
+     "Glm4vForConditionalGeneration": ("glm4_1v", "Glm4vForConditionalGeneration"),
+diff --git a/vllm/model_executor/models/transformers/utils.py b/vllm/model_executor/models/transformers/utils.py
+index 04d6de28e..4c68e7519 100644
+--- a/vllm/model_executor/models/transformers/utils.py
++++ b/vllm/model_executor/models/transformers/utils.py
+@@ -25,6 +25,7 @@ from torch import nn
+ 
+ from vllm.config.utils import getattr_iter
+ from vllm.logger import init_logger
++from vllm.model_executor.models.utils import maybe_prefix
+ from vllm.model_executor.layers.conv import Conv2dLayer, Conv3dLayer
+ from vllm.model_executor.layers.layernorm import GemmaRMSNorm, RMSNorm
+ from vllm.model_executor.layers.linear import (
+@@ -263,3 +264,31 @@ def can_enable_torch_compile(vllm_config: "VllmConfig") -> bool:
+             rope_parameters = {"": rope_parameters}
+         return all(rp["rope_type"] != "dynamic" for rp in rope_parameters.values())
+     return True
++
++
++def recursive_replace_linear(
++    model: nn.Module,
++    quant_config: "QuantizationConfig | None",
++    prefix: str = "",
++):
++    """Recursively replace linear modules in the model as needed."""
++
++    def _recursive_replace(module: nn.Module, prefix: str):
++        for child_name, child_module in module.named_children():
++            new_module = child_module
++            qual_name = maybe_prefix(prefix, child_name)
++            # Replace modules as needed
++            if isinstance(child_module, nn.Linear):
++                style = "replicate"
++                new_module = replace_linear_class(
++                    child_module,
++                    style,
++                    quant_config,
++                    prefix=qual_name,
++                )
++            else:
++                _recursive_replace(child_module, prefix=qual_name)
++            if new_module is not child_module:
++                setattr(module, child_name, new_module)
++
++    _recursive_replace(model, prefix=prefix)
 diff --git a/vllm/platforms/xpu.py b/vllm/platforms/xpu.py
-index bd9006f3f..df76fa167 100644
+index bd9006f3f..9e463035d 100644
 --- a/vllm/platforms/xpu.py
 +++ b/vllm/platforms/xpu.py
-@@ -72,8 +72,17 @@ class XPUPlatform(Platform):
+@@ -61,6 +61,42 @@ class XPUPlatform(Platform):
+             "only NHD layout is supported by XPU attention kernels."
+         )
+ 
++        # Single-card large-head-size note: gemma-4 full-attention layers
++        # (head_dim=512, GQA up to 16:1) used to crash the FlashAttention
++        # chunk_prefill / paged_decode kernels at tensor_parallel_size=1 with
++        # UR_RESULT_ERROR_OUT_OF_RESOURCES (per-workgroup SLM overflow), and the
++        # sliding-window path produced wrong output. Both are fixed in the
++        # vllm-xpu-kernels (decode V-tile cap + sliding-window mask fix), so
++        # single-card now stays on FlashAttention by default (measured ~19%
++        # faster decode TPOT than Triton on gemma-4-12B fp8). Set
++        # VLLM_XPU_SINGLECARD_TRITON=1 to force the old Triton fallback on a
++        # kernel build that predates those fixes.
++        _flash_selected = selected_backend in (
++            None,
++            AttentionBackendEnum.FLASH_ATTN,
++        )
++        if (
++            _flash_selected
++            and os.environ.get("VLLM_XPU_SINGLECARD_TRITON", "0") == "1"
++        ):
++            try:
++                from vllm.config import get_current_vllm_config
++
++                _vc = get_current_vllm_config()
++                _tp = _vc.parallel_config.tensor_parallel_size
++                _hs = _vc.model_config.get_head_size()
++            except Exception:
++                _tp = None
++                _hs = attn_selector_config.head_size
++            if _tp == 1 and _hs is not None and _hs > 256:
++                logger.warning_once(
++                    "VLLM_XPU_SINGLECARD_TRITON=1: routing single-card "
++                    "head_size=%d attention to Triton (legacy fallback for "
++                    "kernel builds without the FlashAttention SLM/window fix).",
++                    _hs,
++                )
++                return AttentionBackendEnum.TRITON_ATTN.get_path()
++
+         # TurboQuant KV cache: route directly to TQ backend
+         kv_cache_dtype = attn_selector_config.kv_cache_dtype
+         if kv_cache_dtype is not None and kv_cache_dtype.startswith("turboquant_"):
+@@ -72,8 +108,17 @@ class XPUPlatform(Platform):
              logger.info_once("Using XPU MLA Sparse backend.")
              return AttentionBackendEnum.XPU_MLA_SPARSE.get_path()
          if attn_selector_config.use_mla:
@@ -1656,7 +8179,7 @@ index bd9006f3f..df76fa167 100644
          if selected_backend == AttentionBackendEnum.TRITON_ATTN:
              logger.info_once("Using Triton backend.")
              return AttentionBackendEnum.TRITON_ATTN.get_path()
-@@ -169,6 +178,17 @@ class XPUPlatform(Platform):
+@@ -169,12 +214,23 @@ class XPUPlatform(Platform):
      def get_static_graph_wrapper_cls(cls) -> str:
          return "vllm.compilation.cuda_graph.CUDAGraphWrapper"
  
@@ -1674,7 +8197,77 @@ index bd9006f3f..df76fa167 100644
      @classmethod
      def check_and_update_config(cls, vllm_config: VllmConfig) -> None:
          parallel_config = vllm_config.parallel_config
-@@ -235,6 +255,12 @@ class XPUPlatform(Platform):
+ 
+         # lazy import to avoid circular import
+-        from vllm.config import CUDAGraphMode
++        from vllm.config import CompilationMode, CUDAGraphMode
+ 
+         compilation_config = vllm_config.compilation_config
+         if compilation_config.compile_sizes is None:
+@@ -195,17 +251,22 @@ class XPUPlatform(Platform):
+                 "XPU Graph is disabled by environment variable, "
+                 "please set VLLM_XPU_ENABLE_XPU_GRAPH=1 to enable it."
+             )
+-        elif parallel_config.world_size_across_dp > 1:
+-            compilation_config.cudagraph_mode = CUDAGraphMode.NONE
+-            logger.warning(
+-                "XPU Graph doesn't support capture communication ops, "
+-                "disabling cudagraph_mode."
+-            )
+         else:
++            # NOTE(gemma4-xpu-graph): multi-card (TP>1) graph capture is
++            # allowed. Under FULL_DECODE_ONLY the per-step allreduce sits
++            # inside the captured region and is replayed with the rest of the
++            # decode step (validated on Qwen3-Coder-Next TP=4, see xy ptl-poc
++            # xpu_graph_vs_eager_perf). The previous unconditional
++            # "world_size>1 -> disable" branch is removed so TP=2 gemma4 can
++            # actually benefit from the graph.
+             if (
+                 attention_config.backend == AttentionBackendEnum.FLASH_ATTN
+                 and compilation_config.cudagraph_mode
+-                not in {CUDAGraphMode.NONE, CUDAGraphMode.PIECEWISE}
++                not in {
++                    CUDAGraphMode.NONE,
++                    CUDAGraphMode.PIECEWISE,
++                    CUDAGraphMode.FULL_DECODE_ONLY,
++                }
+             ):
+                 compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
+                 logger.warning(
+@@ -213,6 +274,32 @@ class XPUPlatform(Platform):
+                     "falling back to PIECEWISE graph mode on XPU platform."
+                 )
+ 
++            # ESIMD MoE kernels do their own host-side allocation / sync and
++            # cannot live inside a captured graph. Register the moe_ops as fx
++            # split points so PIECEWISE / FULL_DECODE_ONLY captures the
++            # surrounding layers (attention / linear / rmsnorm / norm) while
++            # the MoE block runs eager. Needed even with mode=NONE because on
++            # XPU the CUDAGraphWrapper alone does the capture. (ported from
++            # xy ptl-poc 931a44faf / fbdc36597)
++            if compilation_config.cudagraph_mode in (
++                CUDAGraphMode.PIECEWISE,
++                CUDAGraphMode.FULL_DECODE_ONLY,
++            ) or compilation_config.mode == CompilationMode.VLLM_COMPILE:
++                _esimd_moe_splits = [
++                    "moe_ops::moe_router_forward",
++                    "moe_ops::moe_forward_full",
++                    "moe_ops::moe_forward_full_v2",
++                ]
++                if compilation_config.splitting_ops is None:
++                    compilation_config.splitting_ops = (
++                        list(compilation_config._attention_ops)
++                        + _esimd_moe_splits
++                    )
++                else:
++                    for _op in _esimd_moe_splits:
++                        if _op not in compilation_config.splitting_ops:
++                            compilation_config.splitting_ops.append(_op)
++
+         # Disable fusion passes not yet supported on XPU.
+         pass_config = compilation_config.pass_config
+         fusion_passes_to_disable = {
+@@ -235,6 +322,12 @@ class XPUPlatform(Platform):
  
          # check and update parallel config
          parallel_config = vllm_config.parallel_config
@@ -1687,6 +8280,1712 @@ index bd9006f3f..df76fa167 100644
          # Only override worker_cls if it's still the default "auto"
          # This allows custom workers (like vllm-omni workers) to be used on XPU
          if parallel_config.worker_cls == "auto":
+@@ -259,7 +352,6 @@ class XPUPlatform(Platform):
+         from vllm.model_executor.layers.attention_layer_base import (
+             AttentionLayerBase,
+         )
+-        from vllm.utils.math_utils import cdiv
+ 
+         cache_config = vllm_config.cache_config
+         # special fix for GDN since kernel only supports block size dividable by 64
+@@ -277,9 +369,14 @@ class XPUPlatform(Platform):
+ 
+         if kernel_block_size is None:
+             return
+-        new_block_size = (
+-            cdiv(cache_config.block_size, kernel_block_size) * kernel_block_size
+-        )
++        # Round up to a power of 2 (which is always a multiple of 64 once >= 64).
++        # The ESIMD paged-attention decode kernel asserts isPowerOf2(pageSize);
++        # the hybrid mamba-page negotiation otherwise yields e.g. 320 (=64*5),
++        # a multiple of 64 but not a power of 2, which crashes that kernel (#51).
++        # Powers of 2 satisfy both the GDN ">= 64 and divisible-by-64" need and
++        # the PA power-of-2 need.
++        bs = max(cache_config.block_size, kernel_block_size)
++        new_block_size = 1 << (bs - 1).bit_length()  # next power of 2 >= bs
+         if new_block_size == cache_config.block_size:
+             return
+ 
+diff --git a/vllm/transformers_utils/config.py b/vllm/transformers_utils/config.py
+index e6c497c0b..1c0815f4b 100644
+--- a/vllm/transformers_utils/config.py
++++ b/vllm/transformers_utils/config.py
+@@ -95,6 +95,8 @@ _CONFIG_REGISTRY: dict[str, type[PretrainedConfig]] = LazyConfigDict(
+     ops_colqwen3="OpsColQwen3Config",
+     qwen3_vl_nemotron_embed="Qwen3VLNemotronEmbedConfig",
+     deepseek_vl_v2="DeepseekVLV2Config",
++    diffusion_gemma="DiffusionGemmaConfig",
++    gemma4_unified="Gemma4UnifiedConfig",
+     deepseek_v32="DeepseekV3Config",
+     deepseek_v4="DeepseekV4Config",
+     flex_olmo="FlexOlmoConfig",
+diff --git a/vllm/transformers_utils/configs/__init__.py b/vllm/transformers_utils/configs/__init__.py
+index c3466fddd..8668dc56a 100644
+--- a/vllm/transformers_utils/configs/__init__.py
++++ b/vllm/transformers_utils/configs/__init__.py
+@@ -26,6 +26,9 @@ _CLASS_TO_MODULE: dict[str, str] = {
+     "OpsColQwen3Config": "vllm.transformers_utils.configs.colqwen3",
+     "Qwen3VLNemotronEmbedConfig": "vllm.transformers_utils.configs.colqwen3",
+     "DeepseekVLV2Config": "vllm.transformers_utils.configs.deepseek_vl2",
++    "DiffusionGemmaConfig": "vllm.transformers_utils.configs.diffusion_gemma",
++    "DiffusionGemmaTextConfig": "vllm.transformers_utils.configs.diffusion_gemma",
++    "Gemma4UnifiedConfig": "vllm.transformers_utils.configs.gemma4_unified",
+     "DeepseekV4Config": "vllm.transformers_utils.configs.deepseek_v4",
+     "DotsOCRConfig": "vllm.transformers_utils.configs.dotsocr",
+     "EAGLEConfig": "vllm.transformers_utils.configs.eagle",
+@@ -94,6 +97,9 @@ __all__ = [
+     "ColQwen3Config",
+     "OpsColQwen3Config",
+     "Qwen3VLNemotronEmbedConfig",
++    "DiffusionGemmaConfig",
++    "DiffusionGemmaTextConfig",
++    "Gemma4UnifiedConfig",
+     "DeepseekVLV2Config",
+     "DeepseekV3Config",
+     "DeepseekV4Config",
+diff --git a/vllm/transformers_utils/configs/diffusion_gemma.py b/vllm/transformers_utils/configs/diffusion_gemma.py
+new file mode 100644
+index 000000000..246a25b32
+--- /dev/null
++++ b/vllm/transformers_utils/configs/diffusion_gemma.py
+@@ -0,0 +1,44 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++from typing import Any
++
++from transformers import PretrainedConfig
++from transformers.models.gemma4.configuration_gemma4 import Gemma4VisionConfig
++
++
++def _init_text_config(self: PretrainedConfig, **kwargs: Any) -> None:
++    PretrainedConfig.__init__(self, **kwargs)
++    # DiffusionGemma always uses MoE and K=V sharing for full_attention
++    # layers. The HF reference removed these config fields entirely.
++    if getattr(self, "num_experts", None):
++        self.enable_moe_block = True
++    self.attention_k_eq_v = True
++
++
++class DiffusionGemmaTextConfig(PretrainedConfig):
++    model_type = "diffusion_gemma_text"
++
++    def __init__(self, **kwargs: Any):
++        _init_text_config(self, **kwargs)
++
++
++class DiffusionGemmaConfig(PretrainedConfig):
++    model_type = "diffusion_gemma"
++
++    def __init__(
++        self,
++        text_config: dict[str, Any] | None = None,
++        canvas_length: int = 256,
++        self_conditioning_size: int | None = None,
++        **kwargs: Any,
++    ):
++        self.text_config = DiffusionGemmaTextConfig(**(text_config or {}))
++        self.canvas_length = canvas_length
++        self.self_conditioning_size = self_conditioning_size
++        vision_config = kwargs.pop("vision_config", None)
++        if isinstance(vision_config, dict):
++            self.vision_config = Gemma4VisionConfig(**vision_config)
++        else:
++            self.vision_config = vision_config
++        self.audio_config = None
++        PretrainedConfig.__init__(self, **kwargs)
+diff --git a/vllm/transformers_utils/configs/gemma4_unified.py b/vllm/transformers_utils/configs/gemma4_unified.py
+new file mode 100644
+index 000000000..c8cb21ace
+--- /dev/null
++++ b/vllm/transformers_utils/configs/gemma4_unified.py
+@@ -0,0 +1,319 @@
++#                🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
++#           This file was automatically generated from src/transformers/models/gemma4_unified/modular_gemma4_unified.py.
++#               Do NOT edit this file manually as any edits will be overwritten by the generation of
++#             the file from the modular. If any change should be done, please apply the change to the
++#                          modular_gemma4_unified.py file directly. One of our CI enforces this.
++#                🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
++# Copyright 2026 the HuggingFace Team. All rights reserved.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++from typing import Any, Literal
++
++from huggingface_hub.dataclasses import strict
++
++from transformers.configuration_utils import PreTrainedConfig
++from transformers.utils import (
++    auto_docstring,
++    logging,
++)
++
++
++logger = logging.get_logger(__name__)
++
++
++@auto_docstring(checkpoint="google/gemma-4-12B-it")
++@strict
++class Gemma4UnifiedAudioConfig(PreTrainedConfig):
++    r"""
++    audio_embed_dim (`int`, defaults to 640):
++        Dimension of audio features input to the multimodal embedder. Each audio soft
++        token is a raw waveform frame of `audio_samples_per_token` samples, so
++        `audio_embed_dim == audio_samples_per_token`.
++    """
++
++    model_type = "gemma4_unified_audio"
++
++    audio_embed_dim: int = 640
++    rms_norm_eps: float = 1e-6
++    initializer_range: float = 0.02
++
++    @property
++    def hidden_size(self):
++        """
++        Used by the MultimodalEmbedder to determine the input projection size.
++        """
++        return self.audio_embed_dim
++
++    @property
++    def output_proj_dims(self):
++        """
++        Output projection dimension (matches `hidden_size`).
++        """
++        return self.audio_embed_dim
++
++    @property
++    def audio_samples_per_token(self):
++        """
++        Number of raw audio samples per output soft token. At 16 kHz this equals 40ms
++        of audio per token (16000 / 25 fps = 640). Same as `audio_embed_dim`
++        """
++        return self.audio_embed_dim
++
++    # Setters are setting the `audio_embed_dim` in each case as it's shared across
++    @hidden_size.setter
++    def hidden_size(self, value):
++        self.audio_embed_dim = value
++
++    @output_proj_dims.setter
++    def output_proj_dims(self, value):
++        self.audio_embed_dim = value
++
++    @audio_samples_per_token.setter
++    def audio_samples_per_token(self, value):
++        self.audio_embed_dim = value
++
++
++@auto_docstring(checkpoint="google/gemma-4-12B-it")
++@strict
++class Gemma4UnifiedTextConfig(PreTrainedConfig):
++    r"""
++    use_bidirectional_attention (`str`, *optional*):
++        Controls bidirectional attention behavior. When set to `"vision"`, vision tokens
++        attend bidirectionally while text tokens use causal attention. When set to `"all"`,
++        all tokens use bidirectional attention.
++    num_global_key_value_heads (`int`, *optional*):
++        Number of key-value heads for global (full) attention layers. If `None`, defaults
++        to `num_key_value_heads`.
++    global_head_dim (`int`, defaults to 512):
++        Dimension of each attention head in global (full) attention layers.
++    attention_k_eq_v (`bool`, defaults to `False`):
++        Whether keys and values share the same projection weights. When `True`, the key
++        projection output is reused as the value projection.
++    num_kv_shared_layers (`int`, defaults to 0):
++        Number of consecutive decoder layers that share the same key-value projections.
++        A value of 0 means no sharing (each layer has independent KV projections).
++    use_double_wide_mlp (`bool`, defaults to `False`):
++        Whether to use a double-width MLP with fused gate and up projections.
++    """
++
++    model_type = "gemma4_unified_text"
++    keys_to_ignore_at_inference = ["past_key_values"]
++    base_model_tp_plan = {
++        "layers.*.self_attn.q_proj": "colwise",
++        "layers.*.self_attn.k_proj": "colwise",
++        "layers.*.self_attn.v_proj": "colwise",
++        "layers.*.self_attn.q_norm": "replicated_with_grad_allreduce",
++        "layers.*.self_attn.k_norm": "replicated_with_grad_allreduce",
++        "layers.*.self_attn.o_proj": "rowwise",
++        "layers.*.mlp.gate_proj": "colwise",
++        "layers.*.mlp.up_proj": "colwise",
++        "layers.*.mlp.down_proj": "rowwise",
++    }
++    base_model_ep_plan = None  # No MoE
++    base_model_pp_plan = {
++        "embed_tokens": (["input_ids"], ["inputs_embeds"]),
++        "layers": (["hidden_states", "attention_mask"], ["hidden_states"]),
++        "norm": (["hidden_states"], ["hidden_states"]),
++    }
++
++    vocab_size: int = 262_144
++    hidden_size: int = 2304
++    intermediate_size: int = 9216
++    num_hidden_layers: int = 30
++    num_attention_heads: int = 8
++    num_key_value_heads: int = 4
++    head_dim: int = 256
++    hidden_activation: str = "gelu_pytorch_tanh"
++    max_position_embeddings: int = 262_144
++    initializer_range: float = 0.02
++    rms_norm_eps: float = 1e-6
++    use_cache: bool = True
++    pad_token_id: int | None = 0
++    eos_token_id: int | list[int] | None = 1
++    bos_token_id: int | None = 2
++    tie_word_embeddings: bool = True
++    rope_parameters: dict | None = None
++    attention_bias: bool = False
++    attention_dropout: int | float | None = 0.0
++
++    sliding_window: int = 1024
++    layer_types: list[str] | None = None
++    final_logit_softcapping: float | None = None
++    use_bidirectional_attention: Literal["all", "vision"] | None = "vision"
++    num_global_key_value_heads: int | None = None
++    global_head_dim: int = 512
++    attention_k_eq_v: bool = False
++    num_kv_shared_layers: int = 0
++    use_double_wide_mlp: bool = False
++
++    def __post_init__(self, **kwargs):
++        if self.use_bidirectional_attention == "all":
++            self.is_causal = False
++            self.sliding_window = (self.sliding_window // 2) + 1  # due to fa we set exclusive bounds
++
++        if self.layer_types is None:
++            sliding_window_pattern = 6  # by default 5:1
++            self.layer_types = [
++                "sliding_attention" if bool((i + 1) % sliding_window_pattern) else "full_attention"
++                for i in range(self.num_hidden_layers)
++            ]
++
++        if self.layer_types and (last_layer_type := self.layer_types[-1]) != "full_attention":
++            logger.warning(
++                f"Last layer must use `full_attention`, but got `{last_layer_type}`. Forcing last layer to `full_attention`."
++            )
++            self.layer_types[-1] = "full_attention"
++
++        default_rope_params: dict[Literal["full_attention", "sliding_attention"] : dict[str, Any]] = {
++            "sliding_attention": {"rope_type": "default", "rope_theta": 10_000.0},
++            "full_attention": {"rope_type": "proportional", "partial_rotary_factor": 0.25, "rope_theta": 1_000_000.0},
++        }
++        if self.rope_parameters is None:
++            self.rope_parameters = default_rope_params
++
++        super().__post_init__(**kwargs)
++
++    def convert_rope_params_to_dict(self, **kwargs):
++        # No need to handle BC for new models, because they have no old-format `rope_scaling`
++        return kwargs
++
++
++@auto_docstring(checkpoint="google/gemma-4-12B-it")
++@strict
++class Gemma4UnifiedVisionConfig(PreTrainedConfig):
++    r"""
++    patch_size (`int`, defaults to 16):
++        Size of the image patches in pixels. Images are first patchified at this resolution.
++    pooling_kernel_size (`int`, defaults to 3):
++        Kernel size for merging patches into model patches. A 3×3 merge produces
++        model patches of size `patch_size * pooling_kernel_size = 48` pixels.
++    mm_embed_dim (`int`, defaults to 3840):
++        Hidden dimension for the patch embedding Dense projection (matches the text model `hidden_size`).
++    mm_posemb_size (`int`, defaults to 1120):
++        Size of the factorized 2D positional embedding table. The table has shape
++        `(mm_posemb_size, 2, mm_embed_dim)` and is looked up per-axis.
++    output_proj_dims (`int`, defaults to 3840):
++        Output dimension of the multimodal embedder projection (maps to text hidden size).
++        This is set by the composite config's text_config.hidden_size at runtime.
++    """
++
++    model_type = "gemma4_unified_vision"
++
++    patch_size: int = 16
++    pooling_kernel_size: int = 3
++    mm_embed_dim: int = 3840
++    mm_posemb_size: int = 1120
++    rms_norm_eps: float = 1e-6
++    output_proj_dims: int = 3840
++    initializer_range: float = 0.02
++
++    @property
++    def model_patch_size(self):
++        """
++        Size of the merged model patches in pixels. Each merged patch has `model_patch_size² * 3`
++        raw pixel channels.
++        """
++        return self.patch_size * self.pooling_kernel_size
++
++    @model_patch_size.setter
++    def model_patch_size(self, value):
++        if value != self.patch_size * self.pooling_kernel_size:
++            raise ValueError(
++                f"`model_patch_size` needs to be equal to {self.patch_size = } * {self.pooling_kernel_size = }"
++            )
++
++
++@auto_docstring(checkpoint="google/gemma-4-12B-it")
++@strict
++class Gemma4UnifiedConfig(PreTrainedConfig):
++    r"""
++    boi_token_id (`int`, *optional*, defaults to 255999):
++        The begin-of-image token index to wrap the image prompt.
++    eoi_token_id (`int`, *optional*, defaults to 258882):
++        The end-of-image token index to wrap the image prompt.
++    boa_token_id (`int`, *optional*, defaults to 256000):
++        The begin-of-audio token index to wrap the audio prompt.
++    eoa_token_index (`int`, *optional*, defaults to 258883):
++        The end-of-audio token index to wrap the audio prompt.
++
++    Example:
++
++    ```python
++    >>> from transformers import (
++    >>>     Gemma4UnifiedAudioConfig,
++    >>>     Gemma4UnifiedConfig,
++    >>>     Gemma4UnifiedForConditionalGeneration,
++    >>>     Gemma4UnifiedTextConfig,
++    >>>     Gemma4UnifiedVisionConfig,
++    >>> )
++
++    >>> # Initializing a Gemma 4 Audio config.
++    >>> audio_config = Gemma4UnifiedAudioConfig()
++
++    >>> # Initializing a Gemma 4 Text config.
++    >>> text_config = Gemma4UnifiedTextConfig()
++
++    >>> # Initializing a Gemma 4 vision config.
++    >>> vision_config = Gemma4UnifiedVisionConfig()
++
++    >>> # Initializing a Gemma 4 config similar to google/gemma-4-e2b-it
++    >>> configuration = Gemma4UnifiedConfig(text_config, vision_config, audio_config)
++
++    >>> # Initializing a model from the google/gemma-4-e2b-it configuration
++    >>> model = Gemma4UnifiedForConditionalGeneration(configuration)
++
++    >>> # Accessing the model configuration
++    >>> configuration = model.config
++    ```"""
++
++    model_type = "gemma4_unified"
++    sub_configs = {
++        "text_config": Gemma4UnifiedTextConfig,
++        "vision_config": Gemma4UnifiedVisionConfig,
++        "audio_config": Gemma4UnifiedAudioConfig,
++    }
++
++    text_config: Gemma4UnifiedTextConfig | dict[str, Any] | None = None
++    vision_config: Gemma4UnifiedVisionConfig | dict[str, Any] | None = None
++    audio_config: Gemma4UnifiedAudioConfig | dict[str, Any] | None = None
++    boi_token_id: int | None = 255_999
++    eoi_token_id: int | None = 258_882
++    image_token_id: int | None = 258_880
++    video_token_id: int | None = 258_884
++    boa_token_id: int | None = 256_000
++    eoa_token_index: int | None = 258_883
++    audio_token_id: int | None = 258_881
++    initializer_range: float | None = 0.02
++    tie_word_embeddings: bool = True
++
++    def __post_init__(self, **kwargs):
++        if self.text_config is None:
++            self.text_config = Gemma4UnifiedTextConfig()
++            logger.info("text_config is None. Using default Gemma4UnifiedTextConfig.")
++        elif isinstance(self.text_config, dict):
++            self.text_config = Gemma4UnifiedTextConfig(**self.text_config)
++
++        if self.vision_config is None:
++            logger.info("vision_config is None. Gemma4UnifiedModel.vision_tower will not be initialized.")
++        if isinstance(self.vision_config, dict):
++            self.vision_config = Gemma4UnifiedVisionConfig(**self.vision_config)
++
++        if self.audio_config is None:
++            logger.info("audio_config is None. Gemma4UnifiedModel.audio_tower will not be initialized.")
++        if isinstance(self.audio_config, dict):
++            self.audio_config = Gemma4UnifiedAudioConfig(**self.audio_config)
++
++        super().__post_init__(**kwargs)
++
++
++__all__ = ["Gemma4UnifiedAudioConfig", "Gemma4UnifiedConfig", "Gemma4UnifiedTextConfig", "Gemma4UnifiedVisionConfig"]
+diff --git a/vllm/transformers_utils/model_arch_config_convertor.py b/vllm/transformers_utils/model_arch_config_convertor.py
+index 35fa1313d..9d994e54f 100644
+--- a/vllm/transformers_utils/model_arch_config_convertor.py
++++ b/vllm/transformers_utils/model_arch_config_convertor.py
+@@ -558,6 +558,9 @@ MODEL_ARCH_CONFIG_CONVERTORS = {
+     "RefinedWebModel": FalconModelArchConfigConvertor,
+     "nemotron-nas": NemotronNasModelArchConfigConvertor,
+     "deepseek_mtp": DeepSeekMTPModelArchConfigConvertor,
++    "diffusion_gemma_text": Gemma4ModelArchConfigConvertor,
++    "gemma4_unified": Gemma4ModelArchConfigConvertor,
++    "gemma4_unified_text": Gemma4ModelArchConfigConvertor,
+     "qwen3_next_mtp": Qwen3NextMTPModelArchConfigConvertor,
+     "qwen3_5_mtp": Qwen3_5MTPModelArchConfigConvertor,
+     "mimo_mtp": MimoMTPModelArchConfigConvertor,
+diff --git a/vllm/transformers_utils/processors/gemma4_unified/__init__.py b/vllm/transformers_utils/processors/gemma4_unified/__init__.py
+new file mode 100644
+index 000000000..f12d942ec
+--- /dev/null
++++ b/vllm/transformers_utils/processors/gemma4_unified/__init__.py
+@@ -0,0 +1,40 @@
++# Vendored from transformers main — gemma4_unified is absent in transformers
++# 5.8.0. The Gemma4UnifiedProcessor builds sub-processors (audio feature
++# extractor / image processor / video processor) by name string from the
++# weight dir""s processor_config.json, so they must be registered into
++# transformers' auto-registries before ProcessorMixin.from_pretrained runs.
++from transformers import (
++    AutoFeatureExtractor,
++    AutoImageProcessor,
++    AutoProcessor,
++    AutoVideoProcessor,
++)
++
++from .feature_extraction_gemma4_unified import Gemma4UnifiedAudioFeatureExtractor
++from .image_processing_gemma4_unified import Gemma4UnifiedImageProcessor
++from .processing_gemma4_unified import Gemma4UnifiedProcessor
++from .video_processing_gemma4_unified import Gemma4UnifiedVideoProcessor
++
++# Register by class name so AutoX.from_pretrained() resolves the *_type strings
++# in processor_config.json. exist_ok-style guard via try/except for idempotency.
++for _auto, _cls in (
++    (AutoImageProcessor, Gemma4UnifiedImageProcessor),
++    (AutoFeatureExtractor, Gemma4UnifiedAudioFeatureExtractor),
++    (AutoVideoProcessor, Gemma4UnifiedVideoProcessor),
++):
++    try:
++        _auto.register("gemma4_unified", _cls, exist_ok=True)
++    except Exception:
++        pass
++
++try:
++    AutoProcessor.register("gemma4_unified", Gemma4UnifiedProcessor, exist_ok=True)
++except Exception:
++    pass
++
++__all__ = [
++    "Gemma4UnifiedProcessor",
++    "Gemma4UnifiedImageProcessor",
++    "Gemma4UnifiedAudioFeatureExtractor",
++    "Gemma4UnifiedVideoProcessor",
++]
+diff --git a/vllm/transformers_utils/processors/gemma4_unified/feature_extraction_gemma4_unified.py b/vllm/transformers_utils/processors/gemma4_unified/feature_extraction_gemma4_unified.py
+new file mode 100644
+index 000000000..5e3fc13bd
+--- /dev/null
++++ b/vllm/transformers_utils/processors/gemma4_unified/feature_extraction_gemma4_unified.py
+@@ -0,0 +1,151 @@
++# Copyright 2026 the HuggingFace Team. All rights reserved.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++
++import numpy as np
++
++from transformers.feature_extraction_sequence_utils import SequenceFeatureExtractor
++from transformers.image_processing_utils import BatchFeature
++from transformers.utils import (
++    TensorType,
++    is_torch_available,
++)
++
++
++if is_torch_available():
++    import torch
++
++
++class Gemma4UnifiedAudioFeatureExtractor(SequenceFeatureExtractor):
++    """Encoder-free audio feature extractor that chunks raw waveform into frames.
++
++    Unlike the standard Gemma4 audio feature extractor which computes mel spectrograms,
++    this unified version simply chunks raw 16 kHz audio into fixed-length frames
++    of `audio_samples_per_token` samples each. Each frame becomes a single audio
++    soft token with the raw waveform samples as its features.
++
++    Args:
++        feature_size (`int`, *optional*, defaults to 640):
++            The feature dimension of the extracted features (samples per token).
++        sampling_rate (`int`, *optional*, defaults to 16000):
++            The sampling rate at which the audio files should be digitalized expressed in hertz (Hz).
++        padding_value (`float`, *optional*, defaults to 0.0):
++            Padding value used to pad the audio.
++        audio_samples_per_token (`int`, *optional*, defaults to 640):
++            Number of raw audio samples per output token. At 16 kHz, 640 samples = 40ms.
++    """
++
++    model_input_names = ["input_features", "input_features_mask"]
++
++    def __init__(
++        self,
++        feature_size: int = 640,
++        sampling_rate: int = 16_000,
++        padding_value: float = 0.0,
++        audio_samples_per_token: int = 640,
++        **kwargs,
++    ):
++        super().__init__(
++            feature_size=feature_size,
++            sampling_rate=sampling_rate,
++            padding_value=padding_value,
++            **kwargs,
++        )
++        self.audio_samples_per_token = audio_samples_per_token
++
++    def _extract_waveform_features(
++        self,
++        waveform: np.ndarray,
++    ) -> tuple[np.ndarray, np.ndarray]:
++        """Chunk a raw waveform into fixed-length frames.
++
++        Each frame of `audio_samples_per_token` samples becomes one audio soft token.
++        The waveform is zero-padded to be evenly divisible by the frame size.
++
++        Args:
++            waveform: 1-D array of raw audio samples.
++
++        Returns:
++            features: (num_tokens, audio_samples_per_token) array of waveform frames.
++            mask: (num_tokens,) boolean array, True for all valid tokens.
++        """
++        # Pad waveform to be evenly divisible by samples_per_token
++        pad_len = (-len(waveform)) % self.audio_samples_per_token
++        if pad_len:
++            waveform = np.pad(waveform, (0, pad_len))
++
++        num_tokens = len(waveform) // self.audio_samples_per_token
++        features = waveform.reshape(num_tokens, self.audio_samples_per_token).astype(np.float32)
++
++        # All tokens are valid (padding is within the last frame, not creating extra frames)
++        mask = np.ones(num_tokens, dtype=bool)
++        return features, mask
++
++    def __call__(
++        self,
++        raw_speech: np.ndarray | list[float] | list[np.ndarray] | list[list[float]],
++        padding: bool | str = "longest",
++        max_length: int | None = None,
++        truncation: bool = True,
++        return_tensors: str | TensorType | None = None,
++        **kwargs,
++    ) -> BatchFeature:
++        """Chunk raw audio waveforms into fixed-length frames for the unified model.
++
++        Args:
++            raw_speech:
++                The raw audio waveform(s) to process.
++            padding (`str`, *optional*, defaults to `"longest"`):
++                Padding strategy for batches with different lengths.
++            max_length (`int`, *optional*):
++                Maximum number of tokens to produce per audio.
++            truncation (`bool`, *optional*, defaults to `True`):
++                Whether to truncate audio above `max_length` tokens.
++            return_tensors (`str`, *optional*):
++                The type of tensors to return.
++        """
++        # Normalize input to list of 1-D arrays
++        if isinstance(raw_speech, np.ndarray) and raw_speech.ndim == 1:
++            raw_speech = [raw_speech]
++        elif not isinstance(raw_speech, (list, tuple)):
++            raw_speech = [np.asarray(raw_speech)]
++        else:
++            raw_speech = [np.asarray(s) for s in raw_speech]
++
++        # Extract features for each waveform
++        all_features = [{"input_features": self._extract_waveform_features(waveform)[0]} for waveform in raw_speech]
++
++        # Delegate padding and truncation to the parent class
++        padded_inputs = self.pad(
++            all_features,
++            padding=padding,
++            max_length=max_length,
++            truncation=truncation and max_length is not None,
++            return_attention_mask=True,
++            return_tensors=return_tensors,
++        )
++
++        # Rename attention_mask → input_features_mask.
++        # pad() produces int32 (0/1); downstream code expects a boolean mask for indexing.
++        mask = padded_inputs.pop("attention_mask")
++        if is_torch_available() and isinstance(mask, torch.Tensor):
++            mask = mask.bool()
++        else:
++            mask = np.asarray(mask, dtype=bool)
++        padded_inputs["input_features_mask"] = mask
++
++        return padded_inputs
++
++
++__all__ = ["Gemma4UnifiedAudioFeatureExtractor"]
+diff --git a/vllm/transformers_utils/processors/gemma4_unified/image_processing_gemma4_unified.py b/vllm/transformers_utils/processors/gemma4_unified/image_processing_gemma4_unified.py
+new file mode 100644
+index 000000000..4f032135e
+--- /dev/null
++++ b/vllm/transformers_utils/processors/gemma4_unified/image_processing_gemma4_unified.py
+@@ -0,0 +1,365 @@
++#                🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
++#           This file was automatically generated from src/transformers/models/gemma4_unified/modular_gemma4_unified.py.
++#               Do NOT edit this file manually as any edits will be overwritten by the generation of
++#             the file from the modular. If any change should be done, please apply the change to the
++#                          modular_gemma4_unified.py file directly. One of our CI enforces this.
++#                🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
++# Copyright 2026 the HuggingFace Team. All rights reserved.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++import math
++
++import torch
++from torchvision.transforms.v2 import functional as tvF
++
++from transformers.image_processing_backends import TorchvisionBackend
++from transformers.image_processing_utils import BatchFeature
++from transformers.image_utils import ImageInput, PILImageResampling
++from transformers.processing_utils import ImagesKwargs, Unpack
++from transformers.utils import (
++    TensorType,
++    auto_docstring,
++)
++
++
++class Gemma4UnifiedImageProcessorKwargs(ImagesKwargs, total=False):
++    """
++    patch_size (`int`, *optional*):
++        Size of each teacher image patch in pixels (before merging).
++    max_soft_tokens (`int`, *optional*):
++        Maximum number of soft (vision) tokens per image after patch merging.
++        Must be one of {70, 140, 280, 560, 1120}.
++    pooling_kernel_size (`int`, *optional*):
++        Kernel size for merging teacher patches into model patches.
++    """
++
++    patch_size: int
++    max_soft_tokens: int
++    pooling_kernel_size: int
++
++
++_SUPPORTED_SOFT_TOKENS = (70, 140, 280, 560, 1120)
++
++
++def get_aspect_ratio_preserving_size(
++    height: int,
++    width: int,
++    patch_size: int,
++    max_patches: int,
++    pooling_kernel_size: int,
++) -> tuple[int, int]:
++    """
++    Image is resized to preserve aspect ratio so it fits within the patch budget.
++    Target dimensions are the largest that:
++    1) Produce at most `max_patches` patches when patchified with `patch_size`
++    2) Have height and width divisible by `pooling_kernel_size * patch_size`
++    """
++    total_px = height * width
++    target_px = max_patches * (patch_size**2)
++    factor = math.sqrt(target_px / total_px)
++    ideal_height = factor * height
++    ideal_width = factor * width
++    side_mult = pooling_kernel_size * patch_size
++
++    # Round down to nearest multiple of side_mult
++    target_height = int(math.floor(ideal_height / side_mult)) * side_mult
++    target_width = int(math.floor(ideal_width / side_mult)) * side_mult
++
++    # Handle edge cases where one or both dimensions round to 0
++    if target_height == 0 and target_width == 0:
++        raise ValueError(
++            "Attempting to resize to a 0 x 0 image. Resized height should be divisble by "
++            f"`pooling_kernel_size * patch_size`={pooling_kernel_size * patch_size}."
++        )
++
++    max_side_length = (max_patches // pooling_kernel_size**2) * side_mult
++    if target_height == 0:
++        target_height = side_mult
++        target_width = min(
++            int(math.floor(width / height)) * side_mult,
++            max_side_length,
++        )
++    elif target_width == 0:
++        target_width = side_mult
++        target_height = min(
++            int(math.floor(height / width)) * side_mult,
++            max_side_length,
++        )
++
++    if target_height * target_width > target_px:
++        raise ValueError(
++            f"Resizing [{height}x{width}] to [{target_height}x{target_width}] "
++            f"but this exceeds {max_patches} patches with patch_size {patch_size}"
++        )
++
++    return target_height, target_width
++
++
++def convert_image_to_patches(image: "torch.Tensor", patch_size: int) -> "torch.Tensor":
++    """
++    Convert 3D tensor image of shape (num_channels, image_height, image_width) into 2D tensor of patches of shape
++    (num_patches_height * num_patches_width, patch_size * patch_size * num_channels).
++    """
++    num_channels, image_height, image_width = image.shape
++    num_patches_height = image_height // patch_size
++    num_patches_width = image_width // patch_size
++    patched_image = image.reshape(num_channels, num_patches_height, patch_size, num_patches_width, patch_size)
++    patched_image = patched_image.permute(1, 3, 2, 4, 0)
++    patched_image = patched_image.reshape(num_patches_height * num_patches_width, -1)
++    return patched_image
++
++
++# Adopted from Siglip2 (mask -> position ids)
++def pad_along_first_dim(
++    image: "torch.Tensor", positions: "torch.Tensor", target_length: int
++) -> tuple["torch.Tensor", "torch.Tensor"]:
++    """
++    Pad the tensor along the first dimension.
++    """
++    current_length = image.shape[0]
++    padding_length = target_length - current_length
++    if padding_length > 0:
++        padding = [0, 0] * (image.ndim - 1) + [0, padding_length]
++        pos_padding = (0, 0, 0, padding_length)
++        image = torch.nn.functional.pad(image, padding, mode="constant", value=0)
++        positions = torch.nn.functional.pad(positions, pos_padding, mode="constant", value=-1)
++    return image, positions
++
++
++def patches_merge(
++    patches: "torch.Tensor",
++    positions_xy: "torch.Tensor",
++    length: int,
++) -> tuple["torch.Tensor", "torch.Tensor"]:
++    """Merge k×k groups of small patches into larger patches.
++
++    Given `L` input patches of dimension `D = patch_size² × 3`, merge groups of
++    `k×k` spatially adjacent patches into `length` output patches of dimension
++    `(k × patch_size)² × 3`. The spatial grouping is determined by integer-dividing
++    the XY positions by `k`.
++
++    Args:
++        patches: (*, L, D) — input patches.
++        positions_xy: (*, L, 2) — integer XY positions for each patch (-1 for padding).
++        length: target number of output patches. Must satisfy L = length × k².
++
++    Returns:
++        merged_patches: (*, length, k²×D) — merged patch features.
++        merged_positions: (*, length, 2) — new XY positions for merged patches.
++    """
++    patch_size = math.isqrt(patches.shape[-1] // 3)
++    if patches.shape[-1] != patch_size * patch_size * 3:
++        raise ValueError(f"Patch dimension {patches.shape[-1]} is not a valid `patch_size * patch_size * 3`")
++
++    k = math.isqrt(patches.shape[-2] // length)
++    if k * k * length != patches.shape[-2]:
++        raise ValueError(f"Cannot merge {patches.shape} to {length}")
++
++    # Compute target ordering for reordering patches into kernel-grouped order.
++    # This ensures patches within each k×k kernel are contiguous.
++    max_x = positions_xy[..., 0].max(dim=-1, keepdim=True)[0] + 1
++    kernel_idxs = torch.div(positions_xy, k, rounding_mode="floor")
++    num_patches_from_top_left = k * k * kernel_idxs[..., 0] + k * max_x * kernel_idxs[..., 1]
++
++    position_within_kernel = torch.remainder(positions_xy, k)
++    num_patches_from_top_left_of_kernel = position_within_kernel[..., 0] + position_within_kernel[..., 1] * k
++    target_ordering = num_patches_from_top_left_of_kernel + num_patches_from_top_left
++
++    # Reorder patches by computing the inverse permutation via argsort,
++    # then gathering patches into kernel-grouped order.
++    perm = target_ordering.long().argsort(dim=-1)  # inverse permutation
++    # Expand perm indices to match patch feature dimension for gathering
++    perm_expanded = perm.unsqueeze(-1).expand_as(patches)
++    kernel_ordered_patches = patches.gather(-2, perm_expanded)
++
++    batch_shape = patches.shape[:-2]
++
++    # Reshape: (*, length*k*k, patch_size*patch_size*3) → (*, length, (k*patch_size)*(k*patch_size)*3)
++    kernel_ordered_patches = kernel_ordered_patches.reshape(*batch_shape, length, k * k, patch_size, patch_size, 3)
++    # Rearrange (l, a*b, p, q, c) → (l, a*p, b*q, c)
++    kernel_ordered_patches = kernel_ordered_patches.reshape(*batch_shape, length, k, k, patch_size, patch_size, 3)
++    kernel_ordered_patches = kernel_ordered_patches.permute(
++        *range(len(batch_shape)), -6, -5, -3, -4, -2, -1
++    )  # (..., l, k, p, k, q, c)
++    merged_patches = kernel_ordered_patches.reshape(*batch_shape, length, k * patch_size * k * patch_size * 3)
++
++    # Compute new positions for merged patches
++    perm_pos = perm.unsqueeze(-1).expand_as(positions_xy)
++    kernel_ordered_positions = positions_xy.float().gather(-2, perm_pos.long())
++
++    # Handle padding: preserve -1 positions
++    padding = (positions_xy == -1).all(dim=-1, keepdim=True)  # (..., L, 1)
++    kernel_ordered_positions = kernel_ordered_positions * (~padding).float() + positions_xy.float() * padding.float()
++
++    # Reshape positions and take min within each kernel to get the merged position
++    kernel_ordered_positions = kernel_ordered_positions.reshape(*batch_shape, length, k * k, 2)
++    new_positions = torch.div(kernel_ordered_positions, k, rounding_mode="floor")
++    # For each merged patch, take the minimum position across the kernel
++    new_positions = new_positions.min(dim=-2)[0].to(torch.long)
++
++    return merged_patches, new_positions
++
++
++@auto_docstring(custom_intro="Constructs a Gemma4 unified image processor.")
++class Gemma4UnifiedImageProcessor(TorchvisionBackend):
++    resample = PILImageResampling.BICUBIC
++    image_mean = [0.0, 0.0, 0.0]
++    image_std = [1.0, 1.0, 1.0]
++    size = None
++    default_to_square = True
++    do_convert_rgb = True
++    do_resize = True
++    do_rescale = True
++    do_normalize = False
++    patch_size = 16
++    max_soft_tokens = 280
++    pooling_kernel_size = 3
++    valid_kwargs = Gemma4UnifiedImageProcessorKwargs
++    model_input_names = ["pixel_values", "image_position_ids", "num_soft_tokens_per_image"]
++
++    def __init__(self, **kwargs: Unpack[Gemma4UnifiedImageProcessorKwargs]):
++        super().__init__(**kwargs)
++
++        if self.max_soft_tokens not in _SUPPORTED_SOFT_TOKENS:
++            raise ValueError(f"`max_soft_tokens` must be one of {_SUPPORTED_SOFT_TOKENS}, got {self.max_soft_tokens}.")
++
++    def _validate_preprocess_kwargs(self, **kwargs):
++        # Gemma4Unified uses aspect_ratio_preserving_resize driven by patch_size,
++        # max_soft_tokens, and pooling_kernel_size — not the standard `size`
++        # parameter. Temporarily disable do_resize so the base validation
++        # doesn't require `size` to be set.
++        kwargs["do_resize"] = False
++        super()._validate_preprocess_kwargs(**kwargs)
++
++    def aspect_ratio_preserving_resize(
++        self,
++        image: torch.Tensor,
++        patch_size: int,
++        max_patches: int,
++        pooling_kernel_size: int,
++        resample: tvF.InterpolationMode,
++    ) -> torch.Tensor:
++        height, width = image.shape[-2], image.shape[-1]
++        target_height, target_width = get_aspect_ratio_preserving_size(
++            height=height,
++            width=width,
++            patch_size=patch_size,
++            max_patches=max_patches,
++            pooling_kernel_size=pooling_kernel_size,
++        )
++
++        if target_height == height and target_width == width:
++            return image
++
++        return tvF.resize(
++            image,
++            size=[target_height, target_width],
++            interpolation=resample,
++            antialias=True,
++        )
++
++    def preprocess(
++        self,
++        images: ImageInput,
++        **kwargs: Unpack[Gemma4UnifiedImageProcessorKwargs],
++    ) -> BatchFeature:
++        return super().preprocess(images, **kwargs)
++
++    def _preprocess(
++        self,
++        images: list["torch.Tensor"],
++        do_resize: bool,
++        resample: "PILImageResampling | tvF.InterpolationMode | int | None",
++        do_rescale: bool,
++        rescale_factor: float,
++        do_normalize: bool,
++        image_mean: float | list[float] | None,
++        image_std: float | list[float] | None,
++        return_tensors: str | TensorType | None,
++        patch_size: int | None = None,
++        max_soft_tokens: int | None = None,
++        pooling_kernel_size: int | None = None,
++        **kwargs,
++    ) -> BatchFeature:
++        if max_soft_tokens not in _SUPPORTED_SOFT_TOKENS:
++            raise ValueError(f"`max_soft_tokens` must be one of {_SUPPORTED_SOFT_TOKENS}, got {max_soft_tokens}.")
++
++        # Compute max_patches from max_soft_tokens and pooling_kernel_size
++        max_patches = max_soft_tokens * pooling_kernel_size**2
++
++        # Process each image individually: resize, rescale/normalize, patchify, pad.
++        # Images have different aspect ratios and thus different resized dimensions,
++        # so patchification and padding must happen per-image before stacking.
++        pixel_values = []
++        position_ids = []
++        num_soft_tokens_per_image = []
++
++        for image in images:
++            # Step 1: Aspect-ratio-preserving resize
++            if do_resize:
++                image = self.aspect_ratio_preserving_resize(
++                    image=image,
++                    patch_size=patch_size,
++                    max_patches=max_patches,
++                    pooling_kernel_size=pooling_kernel_size,
++                    resample=resample,
++                )
++
++            # Step 2: Rescale pixel values (typically to [0, 1]) and optionally identity normalize
++            image = self.rescale_and_normalize(image, do_rescale, rescale_factor, do_normalize, image_mean, image_std)
++
++            # Step 3: Patchify into teacher-size patches (16px)
++            # (num_channels, height, width) → (num_teacher_patches, patch_size²*3)
++            patch_height = image.shape[-2] // patch_size
++            patch_width = image.shape[-1] // patch_size
++            teacher_patches = convert_image_to_patches(image, patch_size)
++
++            # Step 4: Compute teacher-level position IDs
++            device = image.device
++            patch_grid = torch.meshgrid(
++                torch.arange(patch_width, device=device),
++                torch.arange(patch_height, device=device),
++                indexing="xy",
++            )
++            teacher_positions = torch.stack(patch_grid, dim=-1).reshape(teacher_patches.shape[0], 2)
++
++            # Step 5: Merge k×k teacher patches into model patches via patches_merge
++            # (num_teacher_patches, 768) → (num_model_patches, 6912)
++            num_model_patches = teacher_patches.shape[0] // (pooling_kernel_size**2)
++            merged_patches, merged_positions = patches_merge(
++                teacher_patches.unsqueeze(0),  # add batch dim for patches_merge
++                teacher_positions.unsqueeze(0),
++                num_model_patches,
++            )
++            merged_patches = merged_patches.squeeze(0)  # remove batch dim
++            merged_positions = merged_positions.squeeze(0)
++            num_soft_tokens_per_image.append(merged_patches.shape[0])
++
++            # Step 6: Pad merged patches and positions to max_soft_tokens
++            merged_patches, merged_positions = pad_along_first_dim(merged_patches, merged_positions, max_soft_tokens)
++            pixel_values.append(merged_patches)
++            position_ids.append(merged_positions)
++
++        # Stack into batch tensors
++        pixel_values = torch.stack(pixel_values, dim=0)  # (batch, max_soft_tokens, model_patch_size²*3)
++        position_ids = torch.stack(position_ids, dim=0)  # (batch, max_soft_tokens, 2)
++
++        data = {
++            "pixel_values": pixel_values,
++            "image_position_ids": position_ids,
++            "num_soft_tokens_per_image": num_soft_tokens_per_image,
++        }
++        return BatchFeature(data=data, tensor_type=return_tensors)
++
++
++__all__ = ["Gemma4UnifiedImageProcessor"]
+diff --git a/vllm/transformers_utils/processors/gemma4_unified/processing_gemma4_unified.py b/vllm/transformers_utils/processors/gemma4_unified/processing_gemma4_unified.py
+new file mode 100644
+index 000000000..1f5b38331
+--- /dev/null
++++ b/vllm/transformers_utils/processors/gemma4_unified/processing_gemma4_unified.py
+@@ -0,0 +1,315 @@
++#                🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
++#           This file was automatically generated from src/transformers/models/gemma4_unified/modular_gemma4_unified.py.
++#               Do NOT edit this file manually as any edits will be overwritten by the generation of
++#             the file from the modular. If any change should be done, please apply the change to the
++#                          modular_gemma4_unified.py file directly. One of our CI enforces this.
++#                🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
++# Copyright 2026 the HuggingFace Team. All rights reserved.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++import math
++
++import numpy as np
++
++from transformers.audio_utils import AudioInput
++from transformers.image_utils import ImageInput, make_nested_list_of_images
++from transformers.processing_utils import MultiModalData, ProcessingKwargs, ProcessorMixin, Unpack, VideosKwargs
++from transformers.tokenization_utils_base import PreTokenizedInput, TextInput
++from transformers.utils import (
++    auto_docstring,
++    is_vision_available,
++    logging,
++)
++from transformers.utils.import_utils import requires
++from transformers.video_utils import VideoInput
++
++
++if is_vision_available():
++    from .image_processing_gemma4_unified import Gemma4UnifiedImageProcessorKwargs, get_aspect_ratio_preserving_size
++
++
++logger = logging.get_logger(__name__)
++
++
++class Gemma4UnifiedVideoProcessorKwargs(VideosKwargs, total=False):
++    """
++    patch_size (`int`, *optional*):
++        Size of each image patch in pixels.
++    max_soft_tokens (`int`, *optional*):
++        Maximum number of soft (vision) tokens per video frame.
++        Must be one of {70, 140, 280, 560, 1120}.
++    pooling_kernel_size (`int`, *optional*):
++        Spatial pooling kernel size applied after patchification.
++    """
++
++    patch_size: int
++    max_soft_tokens: int
++    pooling_kernel_size: int
++
++
++class Gemma4UnifiedProcessorKwargs(ProcessingKwargs, total=False):
++    images_kwargs: Gemma4UnifiedImageProcessorKwargs
++    _defaults = {
++        "text_kwargs": {
++            "padding": True,
++            "return_mm_token_type_ids": True,
++        },
++        "images_kwargs": {
++            "do_convert_rgb": True,
++        },
++        "audio_kwargs": {},
++        "videos_kwargs": {"return_metadata": True},
++    }
++
++
++@auto_docstring
++@requires(backends=("vision",))
++class Gemma4UnifiedProcessor(ProcessorMixin):
++    valid_processor_kwargs = Gemma4UnifiedProcessorKwargs
++
++    def __init__(
++        self,
++        feature_extractor,
++        image_processor,
++        tokenizer,
++        video_processor,
++        chat_template=None,
++        image_seq_length: int = 280,
++        audio_seq_length: int = 750,
++        audio_ms_per_token: int = 40,
++        **kwargs,
++    ):
++        r"""
++        image_seq_length (`int`, *optional*, defaults to 280):
++            The number of soft tokens per image used for placeholder expansion.
++        audio_seq_length (`int`, *optional*, defaults to 750):
++            The maximum number of audio soft tokens per audio segment. Serves as an
++            upper-bound cap when dynamic audio token counts are computed.
++        audio_ms_per_token (`int`, *optional*, defaults to 40):
++            Milliseconds of audio per output soft token. Used to dynamically compute
++            the number of audio placeholder tokens as ``ceil(duration_ms / audio_ms_per_token)``.
++            The default of 40 comes from the SSCP convolution's 4× time reduction on 10ms frames.
++        """
++        self.image_seq_length = image_seq_length
++        self.image_token_id = tokenizer.image_token_id
++        self.boi_token = tokenizer.boi_token
++        self.eoi_token = tokenizer.eoi_token
++        self.image_token = tokenizer.image_token
++
++        # FIXME: add the token to config and ask Ryan to re-upload
++        tokenizer.add_special_tokens({"additional_special_tokens": ["<|video|>"]})
++        self.video_token = "<|video|>"
++        self.video_token_id = tokenizer.convert_tokens_to_ids(self.video_token)
++
++        # Audio token handling, mirroring the vision pattern.
++        # audio_seq_length serves as the maximum cap on the number of audio soft tokens
++        # any single audio segment can produce. With dynamic audio tokens, the actual
++        # number of placeholders inserted per audio is computed from the audio duration.
++        self.audio_seq_length = audio_seq_length
++        # Milliseconds of audio per output soft token. The default of 40 comes from the
++        # SSCP convolution's 4× time reduction applied to 10ms mel spectrogram frames.
++        self.audio_ms_per_token = audio_ms_per_token
++        self.audio_token_id = getattr(tokenizer, "audio_token_id", None)
++        self.audio_token = getattr(tokenizer, "audio_token", None)
++        self.boa_token = getattr(tokenizer, "boa_token", None)
++        self.eoa_token = getattr(tokenizer, "eoa_token", None)
++
++        super().__init__(
++            feature_extractor=feature_extractor,
++            image_processor=image_processor,
++            tokenizer=tokenizer,
++            video_processor=video_processor,
++            chat_template=chat_template,
++            **kwargs,
++        )
++
++    def prepare_inputs_layout(
++        self,
++        images: ImageInput | None = None,
++        text: TextInput | PreTokenizedInput | list[TextInput] | list[PreTokenizedInput] = None,
++        videos: VideoInput = None,
++        audio: AudioInput = None,
++        **kwargs,
++    ):
++        images, text, videos, audio = super().prepare_inputs_layout(
++            images=images, text=text, videos=videos, audio=audio, **kwargs
++        )
++
++        # Model requires nested struct
++        if images is not None:
++            images = make_nested_list_of_images(images)
++
++        # Create empty text to be replaced with placeholders
++        if images and not text:
++            text = [" ".join([self.image_token] * len(image_list)) for image_list in images]
++        if audio and not text:
++            text = [self.audio_token] * len(audio)
++
++        return images, text, videos, audio
++
++    def validate_inputs(
++        self,
++        images: ImageInput | list[ImageInput] | None = None,
++        text: TextInput | PreTokenizedInput | list[TextInput] | list[PreTokenizedInput] = None,
++        videos: VideoInput = None,
++        audio: AudioInput = None,
++        **kwargs: Unpack[ProcessingKwargs],
++    ):
++        super().validate_inputs(images=images, text=text, **kwargs)
++
++        if text is None and images is None:
++            raise ValueError("You must provide either `text` or `images`.")
++
++        if audio is not None and self.audio_token is None or self.boa_token is None or self.eoa_token is None:
++            raise ValueError("Audio inputs were provided, but the tokenizer does not have an `audio_token` defined.")
++
++        if text is not None:
++            n_images_in_text = [sample.count(self.image_token) for sample in text]
++            if images is not None:
++                if len(images) != len(text):
++                    raise ValueError(
++                        f"Received inconsistently sized batches of images ({len(images)}) and text ({len(text)})."
++                    )
++
++                n_images_in_images = [len(sublist) for sublist in images]
++                if n_images_in_text != n_images_in_images:
++                    raise ValueError(
++                        f"The total number of {self.image_token} tokens in the prompts should be the same as the number of images passed."
++                        f" Found {n_images_in_text} {self.image_token} tokens and {n_images_in_images} images per sample."
++                    )
++            elif images is None and any(n_images_in_text):
++                raise ValueError(
++                    f"Found {sum(n_images_in_text)} {self.image_token} tokens in the text but no images were passed."
++                )
++
++    def replace_image_token(self, image_inputs: dict, image_idx: int) -> str:
++        num_soft_tokens = image_inputs["num_soft_tokens_per_image"][image_idx]
++        return f"{self.boi_token}{self.image_token * num_soft_tokens}{self.eoi_token}"
++
++    def replace_video_token(self, video_inputs: dict, video_idx: int) -> str:
++        num_soft_tokens = video_inputs["num_soft_tokens_per_video"][video_idx]
++        metadata = video_inputs["video_metadata"][video_idx]
++
++        if metadata.fps is None:
++            logger.warning_once(
++                "Gemma4Unified requires frame timestamps to construct prompts, but the `fps` of the input video could not be inferred. "
++                "Probably `video_metadata` was missing from inputs and you passed pre-sampled frames. "
++                "Defaulting to `fps=24`. Please provide `video_metadata` for more accurate results."
++            )
++        metadata.fps = 24 if metadata.fps is None else metadata.fps
++
++        # mm:ss format for timestamps
++        timestamp_str = [f"{int(seconds // 60):02d}:{int(seconds % 60):02d}" for seconds in metadata.timestamps]
++        video_replacement = " ".join(
++            [f"{t} {self.boi_token}{self.video_token * num_soft_tokens}{self.eoi_token}" for t in timestamp_str]
++        )
++        return video_replacement
++
++    def replace_audio_token(self, audio_inputs: dict, audio_idx: int) -> str:
++        """Replace the audio placeholder with the correct number of audio tokens.
++
++        Unlike standard Gemma4 which has a conformer audio encoder with two stride-2
++        convolution blocks (reducing token count ~4×), the unified model projects raw
++        waveform frames directly through RMSNorm → Linear with **no downsampling**.
++        So the number of output soft tokens equals the number of valid input frames.
++        """
++        mask = audio_inputs["input_features_mask"][audio_idx]
++        return f"{self.boa_token}{self.audio_token * int(mask.sum())}{self.eoa_token}"
++
++    def _get_num_multimodal_tokens(self, image_sizes=None, audio_lengths=None, **kwargs):
++        """
++        Computes the number of placeholder tokens needed for multimodal inputs with the given sizes.
++
++        Args:
++            image_sizes (`list[list[int]]`, *optional*):
++                The input sizes formatted as (height, width) per each image.
++            audio_lengths (`list[int]`, *optional*):
++                The lengths of audio inputs in number of samples. Used to dynamically
++                compute per-audio token counts.
++
++        Returns:
++            `MultiModalData`: A `MultiModalData` object holding number of tokens per each of the provided
++            input modalities, along with other useful data.
++        """
++
++        images_kwargs = Gemma4UnifiedProcessorKwargs._defaults.get("images_kwargs", {})
++        images_kwargs.update(kwargs)
++        patch_size = images_kwargs.get("patch_size", None) or self.image_processor.patch_size
++        pooling_kernel_size = (
++            images_kwargs.get("pooling_kernel_size", None) or self.image_processor.pooling_kernel_size
++        )
++        max_soft_tokens = images_kwargs.get("max_soft_tokens", None) or self.image_processor.max_soft_tokens
++
++        max_patches = max_soft_tokens * pooling_kernel_size**2
++
++        vision_data = {}
++        if image_sizes is not None:
++            num_image_tokens = []
++            for image_size in image_sizes:
++                target_h, target_w = get_aspect_ratio_preserving_size(
++                    height=image_size[0],
++                    width=image_size[1],
++                    patch_size=patch_size,
++                    max_patches=max_patches,
++                    pooling_kernel_size=pooling_kernel_size,
++                )
++                patch_height = target_h // patch_size
++                patch_width = target_w // patch_size
++                num_image_tokens.append(patch_height * patch_width // pooling_kernel_size**2)
++
++            num_image_patches = [1] * len(image_sizes)
++            vision_data.update({"num_image_tokens": num_image_tokens, "num_image_patches": num_image_patches})
++
++        if audio_lengths is not None:
++            # Dynamically compute per-audio token counts from sample lengths.
++            # audio_lengths are in number of samples; assume default sampling rate.
++            sampling_rate = getattr(self.feature_extractor, "sampling_rate", 16_000)
++            num_audio_tokens = [
++                self._compute_audio_num_tokens(np.zeros(length), sampling_rate) for length in audio_lengths
++            ]
++            vision_data.update({"num_audio_tokens": num_audio_tokens})
++
++        return MultiModalData(**vision_data)
++
++    def _compute_audio_num_tokens(self, audio_waveform, sampling_rate: int) -> int:
++        """Compute the number of audio soft tokens for a single waveform.
++
++        For the unified model, the audio pipeline is much simpler than the
++        standard Gemma4 model. There is no mel spectrogram or conformer encoder.
++        Raw audio samples are simply chunked into fixed-length frames of
++        `audio_samples_per_token` samples each.
++
++        The number of tokens is: ceil(num_samples / audio_samples_per_token)
++
++        Args:
++            audio_waveform: A 1-D numpy array or list containing the raw audio samples.
++            sampling_rate: The sampling rate of the audio waveform in Hz (unused, kept
++                for API compatibility with parent).
++
++        Returns:
++            The number of audio soft tokens to insert as placeholders.
++        """
++        num_samples = len(audio_waveform)
++        audio_samples_per_token = getattr(self.feature_extractor, "audio_samples_per_token", 640)
++        return math.ceil(num_samples / audio_samples_per_token)
++
++    @property
++    def model_input_names(self):
++        return super().model_input_names + ["mm_token_type_ids"]
++
++    @property
++    def unused_input_names(self) -> list[str]:
++        return ["num_soft_tokens_per_image", "num_soft_tokens_per_video"]
++
++
++__all__ = ["Gemma4UnifiedProcessor"]
+diff --git a/vllm/transformers_utils/processors/gemma4_unified/video_processing_gemma4_unified.py b/vllm/transformers_utils/processors/gemma4_unified/video_processing_gemma4_unified.py
+new file mode 100644
+index 000000000..26b1e4bdc
+--- /dev/null
++++ b/vllm/transformers_utils/processors/gemma4_unified/video_processing_gemma4_unified.py
+@@ -0,0 +1,353 @@
++#                🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
++#           This file was automatically generated from src/transformers/models/gemma4_unified/modular_gemma4_unified.py.
++#               Do NOT edit this file manually as any edits will be overwritten by the generation of
++#             the file from the modular. If any change should be done, please apply the change to the
++#                          modular_gemma4_unified.py file directly. One of our CI enforces this.
++#                🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
++# Copyright 2026 the HuggingFace Team. All rights reserved.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++import math
++
++import torch
++from torchvision.transforms.v2 import functional as tvF
++
++from transformers.image_processing_utils import BatchFeature
++from transformers.image_utils import PILImageResampling
++from transformers.processing_utils import Unpack
++from transformers.utils import (
++    TensorType,
++    add_start_docstrings,
++)
++from transformers.video_processing_utils import BASE_VIDEO_PROCESSOR_DOCSTRING, BaseVideoProcessor
++from transformers.video_utils import VideoInput
++from .processing_gemma4_unified import Gemma4UnifiedVideoProcessorKwargs
++
++
++_SUPPORTED_SOFT_TOKENS = (70, 140, 280, 560, 1120)
++
++
++def get_aspect_ratio_preserving_size(
++    height: int,
++    width: int,
++    patch_size: int,
++    max_patches: int,
++    pooling_kernel_size: int,
++) -> tuple[int, int]:
++    """
++    Image is resized to preserve aspect ratio so it fits within the patch budget.
++    Target dimensions are the largest that:
++    1) Produce at most `max_patches` patches when patchified with `patch_size`
++    2) Have height and width divisible by `pooling_kernel_size * patch_size`
++    """
++    total_px = height * width
++    target_px = max_patches * (patch_size**2)
++    factor = math.sqrt(target_px / total_px)
++    ideal_height = factor * height
++    ideal_width = factor * width
++    side_mult = pooling_kernel_size * patch_size
++
++    # Round down to nearest multiple of side_mult
++    target_height = int(math.floor(ideal_height / side_mult)) * side_mult
++    target_width = int(math.floor(ideal_width / side_mult)) * side_mult
++
++    # Handle edge cases where one or both dimensions round to 0
++    if target_height == 0 and target_width == 0:
++        raise ValueError(
++            "Attempting to resize to a 0 x 0 image. Resized height should be divisble by "
++            f"`pooling_kernel_size * patch_size`={pooling_kernel_size * patch_size}."
++        )
++
++    max_side_length = (max_patches // pooling_kernel_size**2) * side_mult
++    if target_height == 0:
++        target_height = side_mult
++        target_width = min(
++            int(math.floor(width / height)) * side_mult,
++            max_side_length,
++        )
++    elif target_width == 0:
++        target_width = side_mult
++        target_height = min(
++            int(math.floor(height / width)) * side_mult,
++            max_side_length,
++        )
++
++    if target_height * target_width > target_px:
++        raise ValueError(
++            f"Resizing [{height}x{width}] to [{target_height}x{target_width}] "
++            f"but this exceeds {max_patches} patches with patch_size {patch_size}"
++        )
++
++    return target_height, target_width
++
++
++def convert_video_to_patches(video: "torch.Tensor", patch_size: int) -> "torch.Tensor":
++    """
++    Convert 4D tensor video of shape (num_frames, num_channels, height, width) into 3D tensor of patches of shape
++    (num_frames, num_patches_height * num_patches_width, patch_size * patch_size * num_channels).
++    """
++    num_frames, num_channels, height, width = video.shape
++    num_patches_height = height // patch_size
++    num_patches_width = width // patch_size
++    patched_video = video.reshape(
++        num_frames, num_channels, num_patches_height, patch_size, num_patches_width, patch_size
++    )
++    patched_video = patched_video.permute(0, 2, 4, 3, 5, 1)
++    patched_video = patched_video.reshape(num_frames, num_patches_height * num_patches_width, -1)
++    return patched_video
++
++
++def pad_to_max_patches(
++    video: "torch.Tensor", positions: "torch.Tensor", target_length: int
++) -> tuple["torch.Tensor", "torch.Tensor"]:
++    """
++    Pad the video along to max number of patches
++    """
++    current_length = video.shape[1]
++    padding_length = target_length - current_length
++    if padding_length > 0:
++        padding = [0, 0, 0, padding_length, 0, 0]
++        pos_padding = (0, 0, 0, padding_length, 0, 0)
++        video = torch.nn.functional.pad(video, padding, mode="constant", value=0)
++        positions = torch.nn.functional.pad(positions, pos_padding, mode="constant", value=-1)
++    return video, positions
++
++
++def patches_merge(
++    patches: "torch.Tensor",
++    positions_xy: "torch.Tensor",
++    length: int,
++) -> tuple["torch.Tensor", "torch.Tensor"]:
++    """Merge k×k groups of small patches into larger patches.
++
++    Given `L` input patches of dimension `D = patch_size² × 3`, merge groups of
++    `k×k` spatially adjacent patches into `length` output patches of dimension
++    `(k × patch_size)² × 3`. The spatial grouping is determined by integer-dividing
++    the XY positions by `k`.
++
++    Args:
++        patches: (*, L, D) — input patches.
++        positions_xy: (*, L, 2) — integer XY positions for each patch (-1 for padding).
++        length: target number of output patches. Must satisfy L = length × k².
++
++    Returns:
++        merged_patches: (*, length, k²×D) — merged patch features.
++        merged_positions: (*, length, 2) — new XY positions for merged patches.
++    """
++    patch_size = math.isqrt(patches.shape[-1] // 3)
++    if patches.shape[-1] != patch_size * patch_size * 3:
++        raise ValueError(f"Patch dimension {patches.shape[-1]} is not a valid `patch_size * patch_size * 3`")
++
++    k = math.isqrt(patches.shape[-2] // length)
++    if k * k * length != patches.shape[-2]:
++        raise ValueError(f"Cannot merge {patches.shape} to {length}")
++
++    # Compute target ordering for reordering patches into kernel-grouped order.
++    # This ensures patches within each k×k kernel are contiguous.
++    max_x = positions_xy[..., 0].max(dim=-1, keepdim=True)[0] + 1
++    kernel_idxs = torch.div(positions_xy, k, rounding_mode="floor")
++    num_patches_from_top_left = k * k * kernel_idxs[..., 0] + k * max_x * kernel_idxs[..., 1]
++
++    position_within_kernel = torch.remainder(positions_xy, k)
++    num_patches_from_top_left_of_kernel = position_within_kernel[..., 0] + position_within_kernel[..., 1] * k
++    target_ordering = num_patches_from_top_left_of_kernel + num_patches_from_top_left
++
++    # Reorder patches by computing the inverse permutation via argsort,
++    # then gathering patches into kernel-grouped order.
++    perm = target_ordering.long().argsort(dim=-1)  # inverse permutation
++    # Expand perm indices to match patch feature dimension for gathering
++    perm_expanded = perm.unsqueeze(-1).expand_as(patches)
++    kernel_ordered_patches = patches.gather(-2, perm_expanded)
++
++    batch_shape = patches.shape[:-2]
++
++    # Reshape: (*, length*k*k, patch_size*patch_size*3) → (*, length, (k*patch_size)*(k*patch_size)*3)
++    kernel_ordered_patches = kernel_ordered_patches.reshape(*batch_shape, length, k * k, patch_size, patch_size, 3)
++    # Rearrange (l, a*b, p, q, c) → (l, a*p, b*q, c)
++    kernel_ordered_patches = kernel_ordered_patches.reshape(*batch_shape, length, k, k, patch_size, patch_size, 3)
++    kernel_ordered_patches = kernel_ordered_patches.permute(
++        *range(len(batch_shape)), -6, -5, -3, -4, -2, -1
++    )  # (..., l, k, p, k, q, c)
++    merged_patches = kernel_ordered_patches.reshape(*batch_shape, length, k * patch_size * k * patch_size * 3)
++
++    # Compute new positions for merged patches
++    perm_pos = perm.unsqueeze(-1).expand_as(positions_xy)
++    kernel_ordered_positions = positions_xy.float().gather(-2, perm_pos.long())
++
++    # Handle padding: preserve -1 positions
++    padding = (positions_xy == -1).all(dim=-1, keepdim=True)  # (..., L, 1)
++    kernel_ordered_positions = kernel_ordered_positions * (~padding).float() + positions_xy.float() * padding.float()
++
++    # Reshape positions and take min within each kernel to get the merged position
++    kernel_ordered_positions = kernel_ordered_positions.reshape(*batch_shape, length, k * k, 2)
++    new_positions = torch.div(kernel_ordered_positions, k, rounding_mode="floor")
++    # For each merged patch, take the minimum position across the kernel
++    new_positions = new_positions.min(dim=-2)[0].to(torch.long)
++
++    return merged_patches, new_positions
++
++
++@add_start_docstrings(
++    "Constructs a Gemma4Unified video processor that samples frames from videos for use with the Gemma4Unified model.",
++    BASE_VIDEO_PROCESSOR_DOCSTRING,
++)
++class Gemma4UnifiedVideoProcessor(BaseVideoProcessor):
++    resample = PILImageResampling.BICUBIC
++    image_mean = [0.0, 0.0, 0.0]
++    image_std = [1.0, 1.0, 1.0]
++    size = None
++    default_to_square = True
++    do_convert_rgb = True
++    do_resize = True
++    do_rescale = True
++    do_normalize = True
++    num_frames = 32
++    do_sample_frames = True
++    patch_size = 16
++    max_soft_tokens = 70
++    pooling_kernel_size = 3
++    valid_kwargs = Gemma4UnifiedVideoProcessorKwargs
++    model_input_names = ["pixel_values_videos", "video_position_ids"]
++
++    def __init__(self, **kwargs: Unpack[Gemma4UnifiedVideoProcessorKwargs]):
++        super().__init__(**kwargs)
++
++        if self.max_soft_tokens not in _SUPPORTED_SOFT_TOKENS:
++            raise ValueError(f"`max_soft_tokens` must be one of {_SUPPORTED_SOFT_TOKENS}, got {self.max_soft_tokens}.")
++
++    def _validate_preprocess_kwargs(self, **kwargs):
++        # Gemma4Unified uses aspect_ratio_preserving_resize driven by patch_size,
++        # max_soft_tokens, and pooling_kernel_size — not the standard `size`
++        # parameter. Temporarily disable do_resize so the base validation
++        # doesn't require `size` to be set.
++        kwargs["do_resize"] = False
++        super()._validate_preprocess_kwargs(**kwargs)
++
++    def aspect_ratio_preserving_resize(
++        self,
++        video: torch.Tensor,
++        patch_size: int,
++        max_patches: int,
++        pooling_kernel_size: int,
++        resample: tvF.InterpolationMode,
++    ) -> torch.Tensor:
++        height, width = video.shape[-2], video.shape[-1]
++        target_height, target_width = get_aspect_ratio_preserving_size(
++            height=height,
++            width=width,
++            patch_size=patch_size,
++            max_patches=max_patches,
++            pooling_kernel_size=pooling_kernel_size,
++        )
++
++        if target_height == height and target_width == width:
++            return video
++
++        return tvF.resize(
++            video,
++            size=[target_height, target_width],
++            interpolation=resample,
++            antialias=True,
++        )
++
++    def preprocess(
++        self,
++        videos: VideoInput,
++        **kwargs: Unpack[Gemma4UnifiedVideoProcessorKwargs],
++    ) -> BatchFeature:
++        return super().preprocess(videos, **kwargs)
++
++    def _preprocess(
++        self,
++        videos: list["torch.Tensor"],
++        do_resize: bool,
++        resample: "tvF.InterpolationMode | int | None",
++        do_rescale: bool,
++        rescale_factor: float,
++        do_normalize: bool,
++        image_mean: float | list[float] | None,
++        image_std: float | list[float] | None,
++        return_tensors: str | TensorType | None,
++        patch_size: int | None = None,
++        max_soft_tokens: int | None = None,
++        pooling_kernel_size: int | None = None,
++        **kwargs,
++    ) -> BatchFeature:
++        if max_soft_tokens not in _SUPPORTED_SOFT_TOKENS:
++            raise ValueError(f"`max_soft_tokens` must be one of {_SUPPORTED_SOFT_TOKENS}, got {max_soft_tokens}.")
++
++        # Compute max_patches from max_soft_tokens and pooling_kernel_size
++        max_patches = max_soft_tokens * pooling_kernel_size**2
++
++        # Process each image individually: resize, rescale/normalize, patchify, pad.
++        # Images have different aspect ratios and thus different resized dimensions,
++        # so patchification and padding must happen per-image before stacking.
++        pixel_values = []
++        position_ids = []
++        num_soft_tokens_per_video = []
++
++        for video in videos:
++            if do_resize:
++                # Step 1: Aspect-ratio-preserving resize
++                video = self.aspect_ratio_preserving_resize(
++                    video=video,
++                    patch_size=patch_size,
++                    max_patches=max_patches,
++                    pooling_kernel_size=pooling_kernel_size,
++                    resample=resample,
++                )
++
++            # Step 2: Rescale pixel values (typically to [0, 1]) and optionally identity normalize
++            video = self.rescale_and_normalize(video, do_rescale, rescale_factor, do_normalize, image_mean, image_std)
++
++            # Step 3: Patchify into teacher-size patches (16px)
++            num_frames = video.shape[0]
++            patch_height = video.shape[-2] // patch_size
++            patch_width = video.shape[-1] // patch_size
++            patches = convert_video_to_patches(video, patch_size)
++
++            # Step 4: Compute teacher-level position IDs
++            device = video.device
++            patch_grid = torch.meshgrid(
++                torch.arange(patch_width, device=device),
++                torch.arange(patch_height, device=device),
++                indexing="xy",
++            )
++            stacked_grid = torch.stack(patch_grid, dim=-1)
++            teacher_positions = stacked_grid.reshape(patches.shape[1], 2)
++            teacher_positions = teacher_positions[None, ...].repeat(num_frames, 1, 1)
++
++            # Step 5: Merge k×k teacher patches into model patches via patches_merge
++            # (num_frames, num_teacher_patches, 768) → (num_frames, num_model_patches, 6912)
++            num_model_patches = patches.shape[1] // (pooling_kernel_size**2)
++            merged_patches, merged_positions = patches_merge(patches, teacher_positions, num_model_patches)
++            num_soft_tokens_per_video.append(merged_patches.shape[1])
++
++            # Step 6: Pad merged patches and positions to max_soft_tokens
++            merged_patches, merged_positions = pad_to_max_patches(merged_patches, merged_positions, max_soft_tokens)
++            pixel_values.append(merged_patches)
++            position_ids.append(merged_positions)
++
++        # Stack into batch tensors
++        pixel_values = torch.stack(pixel_values, dim=0)
++        position_ids = torch.stack(position_ids, dim=0)
++
++        data = {
++            "pixel_values_videos": pixel_values,
++            "video_position_ids": position_ids,
++            "num_soft_tokens_per_video": num_soft_tokens_per_video,
++        }
++        return BatchFeature(data=data, tensor_type=return_tensors)
++
++
++__all__ = ["Gemma4UnifiedVideoProcessor"]
 diff --git a/vllm/v1/attention/backends/fa_utils.py b/vllm/v1/attention/backends/fa_utils.py
 index 1e74e4c48..89791eb42 100644
 --- a/vllm/v1/attention/backends/fa_utils.py
@@ -1700,6 +9999,411 @@ index 1e74e4c48..89791eb42 100644
      if current_platform.is_cuda():
          try:
              from vllm.vllm_flash_attn.flash_attn_interface import (
+diff --git a/vllm/v1/attention/backends/flash_attn.py b/vllm/v1/attention/backends/flash_attn.py
+index 4b8b86d86..0026d2195 100755
+--- a/vllm/v1/attention/backends/flash_attn.py
++++ b/vllm/v1/attention/backends/flash_attn.py
+@@ -3,6 +3,8 @@
+ """Attention layer with FlashAttention."""
+ 
+ import copy
++import importlib
++import os
+ from dataclasses import dataclass
+ from typing import ClassVar
+ 
+@@ -183,6 +185,10 @@ class FlashAttentionBackend(AttentionBackend):
+             return False
+         if head_size <= 256:
+             return True
++        # XPU: triton unified_attention (called via flash_attn_varlen_func)
++        # supports head_size up to 512 — needed for gemma4 full attention layers
++        if current_platform.is_xpu() and head_size <= 512:
++            return True
+         if is_fa_version_supported(4):
+             return head_size <= 512
+         return False
+@@ -259,6 +265,147 @@ class FlashAttentionMetadata:
+     causal: bool = True
+ 
+ 
++def _xpu_split_mixed_causal_varlen(
++    flash_attn_varlen_func,
++    *,
++    query,
++    key_cache,
++    value_cache,
++    output,
++    cu_seqlens_q,
++    seqused_k,
++    max_seqlen_q,
++    max_seqlen_k,
++    softmax_scale,
++    causal_per_req,
++    alibi_slopes,
++    window_size,
++    block_table,
++    softcap,
++    fa_version,
++    q_descale,
++    k_descale,
++    v_descale,
++    num_splits,
++    s_aux,
++):
++    """XPU fallback for per-request mixed causal/bidirectional attention.
++
++    The XPU FlashAttention (vllm_xpu_kernels FA2) ``is_causal`` arg is a scalar
++    bool and has no per-request causal input (unlike upstream FA4/Triton, which
++    expose a ``per_seq_causal`` tensor). DiffusionGemma needs causal masking for
++    encoder-phase requests and bidirectional attention for denoise-phase
++    requests within the same packed batch.
++
++    We split the packed batch into a causal group and a bidirectional group,
++    run each through a scalar-causal ``varlen_fwd``, and scatter the per-token
++    outputs back into ``output``. Correctness-first (no perf tuning); gated by
++    the ``DISABLE_XPU_MIXED_CAUSAL_SPLIT`` env var at the call site.
++    """
++    device = query.device
++    num_reqs = causal_per_req.shape[0]
++    num_tokens = query.shape[0]
++
++    # Fast path: a single request (the diffusion canvas case, max_num_seqs=1) is
++    # always homogeneous in causal flag, so the split/index/scatter machinery
++    # below is pure overhead (~0.3ms/layer of repeat_interleave + nonzero +
++    # index_select x5 + .any() syncs + index_copy_). Call varlen_fwd once
++    # directly into ``output``. One scalar read replaces two .any() syncs.
++    if num_reqs == 1:
++        grp = bool(causal_per_req[0])
++        group_window_size = window_size
++        if (not grp and group_window_size is not None
++                and len(group_window_size) == 2 and group_window_size[1] == 0):
++            # Non-causal (denoise): symmetric sliding window (see below).
++            group_window_size = [group_window_size[0], group_window_size[0]]
++        flash_attn_varlen_func(
++            q=query, k=key_cache, v=value_cache, out=output,
++            cu_seqlens_q=cu_seqlens_q, max_seqlen_q=max_seqlen_q,
++            seqused_k=seqused_k, max_seqlen_k=max_seqlen_k,
++            softmax_scale=softmax_scale, causal=grp, alibi_slopes=alibi_slopes,
++            window_size=group_window_size, block_table=block_table,
++            softcap=softcap, fa_version=fa_version,
++            q_descale=q_descale, k_descale=k_descale, v_descale=v_descale,
++            num_splits=num_splits, s_aux=s_aux,
++        )
++        return
++
++    # Map each query token to its request, then to that request's causal flag.
++    q_lens = cu_seqlens_q[1:] - cu_seqlens_q[:-1]
++    req_ids = torch.repeat_interleave(
++        torch.arange(num_reqs, device=device), q_lens.long()
++    )
++    causal_per_token = causal_per_req[req_ids]
++
++    # index_copy_ writes back through this view into the real output storage.
++    out_flat = output.view(num_tokens, -1)
++
++    for grp in (True, False):
++        req_mask = causal_per_req == grp
++        if not bool(req_mask.any()):
++            continue
++        req_idx = req_mask.nonzero(as_tuple=True)[0]
++        tok_idx = (causal_per_token == grp).nonzero(as_tuple=True)[0]
++
++        q_g = query.index_select(0, tok_idx)
++        q_lens_g = q_lens.index_select(0, req_idx)
++        cu_g = torch.zeros(
++            req_idx.shape[0] + 1, dtype=cu_seqlens_q.dtype, device=device
++        )
++        torch.cumsum(q_lens_g, 0, out=cu_g[1:])
++        seqused_g = seqused_k.index_select(0, req_idx)
++        block_table_g = block_table.index_select(0, req_idx)
++        out_g = q_g.new_empty(q_g.shape[:-1] + (value_cache.shape[-1],))
++
++        # q/k/v_descale are per-tensor fp8 scales broadcast to
++        # (num_reqs, num_kv_heads) via .expand() (zero-stride). The XPU kernel
++        # requires that zero-stride single-scalar view, so re-slice the first
++        # n_g rows (slicing preserves zero stride) instead of index_select,
++        # which would materialize a strided copy and break the assertion.
++        n_g = req_idx.shape[0]
++        qd = q_descale[:n_g] if q_descale is not None else None
++        kd = k_descale[:n_g] if k_descale is not None else None
++        vd = v_descale[:n_g] if v_descale is not None else None
++
++        # For denoise-phase DiffusionGemma requests, non-causal attention must
++        # use a symmetric sliding window. Decoder layers store the normal
++        # causal sliding-window shape as (left, 0); if we pass that unchanged
++        # with causal=False, each canvas token still cannot see tokens on its
++        # right, which breaks bidirectional block denoising.
++        group_window_size = window_size
++        if (
++            not grp
++            and group_window_size is not None
++            and len(group_window_size) == 2
++            and group_window_size[1] == 0
++        ):
++            group_window_size = [group_window_size[0], group_window_size[0]]
++
++        flash_attn_varlen_func(
++            q=q_g,
++            k=key_cache,
++            v=value_cache,
++            out=out_g,
++            cu_seqlens_q=cu_g,
++            max_seqlen_q=max_seqlen_q,
++            seqused_k=seqused_g,
++            max_seqlen_k=max_seqlen_k,
++            softmax_scale=softmax_scale,
++            causal=grp,
++            alibi_slopes=alibi_slopes,
++            window_size=group_window_size,
++            block_table=block_table_g,
++            softcap=softcap,
++            fa_version=fa_version,
++            q_descale=qd,
++            k_descale=kd,
++            v_descale=vd,
++            num_splits=num_splits,
++            s_aux=s_aux,
++        )
++        out_flat.index_copy_(0, tok_idx, out_g.reshape(tok_idx.shape[0], -1))
++
++
+ def _get_sliding_window_configs(
+     vllm_config: VllmConfig,
+ ) -> set[tuple[int, int] | None]:
+@@ -674,6 +821,20 @@ class FlashAttentionImpl(AttentionImpl):
+         if vllm_config is not None and self.dcp_world_size > 1:
+             self._dcp_dtype = vllm_config.model_config.dtype
+ 
++        # Opt-in (DGEMMA_FUSED_CAUSAL=1): single-launch CUTLASS-SYCL flash with
++        # a per-sequence causal tensor, replacing the 2-call split helper for
++        # DiffusionGemma's mixed causal/bidirectional batch. Resolved ONCE here
++        # (worker reads os.environ at model-load; spawn inherits it). Output is
++        # validated bit-identical to the split path.
++        self._use_fused_causal = (
++            os.environ.get("DGEMMA_FUSED_CAUSAL", "0") == "1"
++        )
++        if self._use_fused_causal and self.head_size == 256:
++            logger.info_once(
++                "DiffusionGemma: using fused per-seq-causal CUTLASS flash "
++                "(single launch) in place of the split-FA2 path."
++            )
++
+     def forward(
+         self,
+         layer: torch.nn.Module,
+@@ -685,6 +846,51 @@ class FlashAttentionImpl(AttentionImpl):
+         output: torch.Tensor,
+         output_scale: torch.Tensor | None = None,
+         output_block_scale: torch.Tensor | None = None,
++    ) -> torch.Tensor:
++        if os.environ.get("PROFILE_ATTN", "0") == "1" and attn_metadata is not None and attn_metadata.max_query_len == 1:
++            import time as _time
++            import sys as _sys
++            _nq = query.shape[1] if query.dim() >= 2 else 0
++            _nkv = kv_cache.shape[3] if kv_cache.dim() >= 4 else 0
++            _gqa = _nq // _nkv if _nkv else 0
++            _sw = self.sliding_window if hasattr(self, "sliding_window") else None
++            _is_sliding = (_sw is not None and _sw[0] != -1)
++            torch.xpu.synchronize()
++            _t0 = _time.perf_counter()
++            _ret = self._inner_forward(layer, query, key, value, kv_cache,
++                                        attn_metadata, output,
++                                        output_scale, output_block_scale)
++            torch.xpu.synchronize()
++            _dt = (_time.perf_counter() - _t0) * 1000.0
++            global _ATTN_STATS_GLOBAL
++            try:
++                _ATTN_STATS_GLOBAL
++            except NameError:
++                _ATTN_STATS_GLOBAL = {}
++            _stats = _ATTN_STATS_GLOBAL
++            _key = (_gqa, _is_sliding)
++            _e = _stats.setdefault(_key, [0, 0.0])
++            _e[0] += 1; _e[1] += _dt
++            _stats["_call_n"] = _stats.get("_call_n", 0) + 1
++            if _stats["_call_n"] % 600 == 0:
++                _to_print = dict((k, v) for k, v in _stats.items() if k != "_call_n")
++                print(f"[ATTN STATS @{_stats['_call_n']}] {_to_print}", flush=True, file=_sys.stderr)
++            return _ret
++        return self._inner_forward(layer, query, key, value, kv_cache,
++                                    attn_metadata, output,
++                                    output_scale, output_block_scale)
++
++    def _inner_forward(
++        self,
++        layer: torch.nn.Module,
++        query: torch.Tensor,
++        key: torch.Tensor,
++        value: torch.Tensor,
++        kv_cache: torch.Tensor,
++        attn_metadata: FlashAttentionMetadata,
++        output: torch.Tensor,
++        output_scale: torch.Tensor | None = None,
++        output_block_scale: torch.Tensor | None = None,
+     ) -> torch.Tensor:
+         """Forward pass with FlashAttention.
+ 
+@@ -806,6 +1012,159 @@ class FlashAttentionImpl(AttentionImpl):
+                     if self.sliding_window is not None
+                     else None
+                 )
++
++                # ---- PAGED_ATTN_ESIMD_INSERTED_v1 ----
++                # XPU paged attention decode shortcut (esimd custom kernel).
++                # Gate: head_dim==256 AND GQA>=2. The kernel now has a NATIVE
++                # GQA=2 path (no q-head padding), so gemma4 sliding (GQA=2,
++                # hd=256) computes exactly 2 q-heads instead of padding to 4.
++                # GQA in {2, 4, 8, ...} go straight to the kernel; other
++                # non-multiples-of-4 (e.g. GQA=6) still pad up to 4 below.
++                _q_check = query[:num_actual_tokens]
++                _num_q_check = _q_check.shape[1] if _q_check.dim() >= 2 else 0
++                _num_kv_check = kv_cache.shape[3] if kv_cache.dim() >= 4 else 0
++                _gqa_check = (_num_q_check // _num_kv_check) if _num_kv_check > 0 else 0
++                if (
++                    os.environ.get("DISABLE_ESIMD_PAGE_ATTN") != "1"
++                    and current_platform.is_xpu()
++                    and attn_type == AttentionType.DECODER
++                    and attn_metadata.max_query_len == 1
++                    and self.head_size == 256
++                    and _gqa_check >= 2
++                ):
++                    try:
++                        eagle_ops = importlib.import_module(
++                            "custom_esimd_kernels_vllm.eagle_ops")
++                    except ImportError:
++                        eagle_ops = None
++
++                    if eagle_ops is not None:
++                        _q = query[:num_actual_tokens]
++                        # Kernel has built-in softmax_scale = 1/sqrt(head_dim).
++                        # Gemma4 uses scale=1.0 (Q/K already normalized).
++                        # Compensate: multiply Q by (self.scale / kernel_scale)
++                        # = self.scale * sqrt(head_size)
++                        _pa_kernel_scale = 1.0 / (self.head_size ** 0.5)
++                        if abs(self.scale - _pa_kernel_scale) > 1e-6:
++                            _q = (_q * (self.scale / _pa_kernel_scale)).half()
++                        _o = output[:num_actual_tokens]
++                        _num_q = _q.shape[1]
++                        _num_kv = kv_cache.shape[3]
++                        _gqa = _num_q // _num_kv if _num_kv > 0 else 0
++                        # GQA=2 has a native kernel path; only odd / non-4k
++                        # ratios (e.g. 6) still need q-head padding to 4.
++                        _need_pad = (_gqa > 2 and _gqa % 4 != 0)
++
++                        # KV cache view: must reinterpret the [2,num_blocks,page,kv_h,hd]
++                        # tensor as the actual fp8 dtype the writer used.
++                        if self.kv_cache_dtype.startswith("fp8"):
++                            _kv_dtype = (
++                                torch.float8_e5m2
++                                if self.kv_cache_dtype == "fp8_e5m2"
++                                else torch.float8_e4m3fn)
++                            _kv_for_esimd = kv_cache.view(_kv_dtype)
++                            _k_scale = float(layer._k_scale)
++                            _v_scale = float(layer._v_scale)
++                        else:
++                            _kv_for_esimd = kv_cache
++                            _k_scale = 1.0
++                            _v_scale = 1.0
++
++                        if _need_pad:
++                            _padded_gqa = ((_gqa + 3) // 4) * 4
++                            _pad_per_kv = _padded_gqa - _gqa
++                            _bs, _, _hd = _q.shape
++                            _q_grouped = _q.reshape(_bs, _num_kv, _gqa, _hd)
++                            _q_pad = torch.nn.functional.pad(
++                                _q_grouped, (0, 0, 0, _pad_per_kv))
++                            _q_pad = _q_pad.reshape(
++                                _bs, _num_kv * _padded_gqa, _hd).contiguous()
++                            _o_pad = torch.zeros_like(_q_pad)
++                            eagle_ops.page_attn_decode(
++                                _q_pad, _kv_for_esimd, block_table, seqused_k,
++                                _o_pad, 1, attn_metadata.max_seq_len,
++                                _k_scale, _v_scale)
++                            _o_grouped = _o_pad.reshape(
++                                _bs, _num_kv, _padded_gqa, _hd)
++                            _o.copy_(_o_grouped[:, :, :_gqa, :].reshape(
++                                _bs, _num_q, _hd))
++                        elif _gqa == 2 or _gqa >= 4:
++                            eagle_ops.page_attn_decode(
++                                _q, _kv_for_esimd, block_table, seqused_k,
++                                _o, 1, attn_metadata.max_seq_len,
++                                _k_scale, _v_scale)
++                        else:
++                            eagle_ops = None  # unsupported gqa, fall through
++
++                        if eagle_ops is not None:
++                            return output
++                # ---- end PAGED_ATTN_ESIMD_INSERTED_v1 ----
++
++                # XPU: DiffusionGemma passes a per-request causal bool
++                # tensor (encoder=causal, denoise=bidirectional) within one
++                # packed batch. The XPU varlen_fwd is_causal arg is scalar, so
++                # split the batch by causal flag and run each group once.
++                if (
++                    isinstance(attn_metadata.causal, torch.Tensor)
++                    and os.environ.get("DISABLE_XPU_MIXED_CAUSAL_SPLIT", "0")
++                    != "1"
++                ):
++                    # Opt-in (DGEMMA_FUSED_CAUSAL=1): single-launch CUTLASS-SYCL
++                    # flash with a per-sequence causal tensor — handles the
++                    # mixed causal(encoder)+bidirectional(denoise) batch in ONE
++                    # call, replacing the split-into-two-FA2-calls helper. The
++                    # kernel reads per_seq_causal[seq]; bidir seqs use the full
++                    # kv range + symmetric window. Output validated bit-identical
++                    # to the split path (vs_split=0.0000, 6/6 cases).
++                    if self._use_fused_causal:
++                        flash_attn_varlen_func(
++                            q=query[:num_actual_tokens],
++                            k=key_cache,
++                            v=value_cache,
++                            out=output[:num_actual_tokens],
++                            cu_seqlens_q=cu_seqlens_q,
++                            max_seqlen_q=max_seqlen_q,
++                            seqused_k=seqused_k,
++                            max_seqlen_k=max_seqlen_k,
++                            softmax_scale=self.scale,
++                            causal=True,  # compile-time path; per-seq decides
++                            window_size=sliding_window_size,
++                            block_table=block_table,
++                            softcap=self.logits_soft_cap,
++                            fa_version=self.vllm_flash_attn_version,
++                            q_descale=q_descale,
++                            k_descale=k_descale,
++                            v_descale=v_descale,
++                            num_splits=attn_metadata.max_num_splits,
++                            s_aux=self.sinks,
++                            per_seq_causal=attn_metadata.causal,
++                        )
++                    else:
++                        _xpu_split_mixed_causal_varlen(
++                            flash_attn_varlen_func,
++                            query=query[:num_actual_tokens],
++                            key_cache=key_cache,
++                            value_cache=value_cache,
++                            output=output[:num_actual_tokens],
++                            cu_seqlens_q=cu_seqlens_q,
++                            seqused_k=seqused_k,
++                            max_seqlen_q=max_seqlen_q,
++                            max_seqlen_k=max_seqlen_k,
++                            softmax_scale=self.scale,
++                            causal_per_req=attn_metadata.causal,
++                            alibi_slopes=self.alibi_slopes,
++                            window_size=sliding_window_size,
++                            block_table=block_table,
++                            softcap=self.logits_soft_cap,
++                            fa_version=self.vllm_flash_attn_version,
++                            q_descale=q_descale,
++                            k_descale=k_descale,
++                            v_descale=v_descale,
++                            num_splits=attn_metadata.max_num_splits,
++                            s_aux=self.sinks,
++                        )
++                    return output
++
+                 flash_attn_varlen_func(
+                     q=query[:num_actual_tokens],
+                     k=key_cache,
 diff --git a/vllm/v1/attention/backends/mla/flashattn_mla.py b/vllm/v1/attention/backends/mla/flashattn_mla.py
 index bd947296e..697376069 100644
 --- a/vllm/v1/attention/backends/mla/flashattn_mla.py
@@ -1834,6 +10538,434 @@ index bd947296e..697376069 100644
          kv_c_cache = kv_c_and_k_pe_cache[..., : self.kv_lora_rank]
          k_pe_cache = kv_c_and_k_pe_cache[..., self.kv_lora_rank :]
  
+diff --git a/vllm/v1/attention/backends/triton_attn.py b/vllm/v1/attention/backends/triton_attn.py
+index 0aeb33ae6..4598d5a6e 100644
+--- a/vllm/v1/attention/backends/triton_attn.py
++++ b/vllm/v1/attention/backends/triton_attn.py
+@@ -1,3 +1,4 @@
++import importlib
+ # SPDX-License-Identifier: Apache-2.0
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ """High-Performance Triton-only Attention layer."""
+@@ -74,6 +75,8 @@ class TritonAttentionMetadata:
+     softmax_segm_max: torch.Tensor
+     softmax_segm_expsum: torch.Tensor
+ 
++    causal: bool | torch.Tensor
++
+     # For cascade attention.
+     use_cascade: bool
+     common_prefix_len: int
+@@ -247,6 +250,7 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
+             seq_lens=seq_lens,
+             block_table=block_table_tensor,
+             slot_mapping=slot_mapping,
++            causal=common_attn_metadata.causal,
+             use_cascade=use_cascade,
+             common_prefix_len=common_prefix_len,
+             cu_prefix_query_lens=cu_prefix_query_lens,
+@@ -291,6 +295,10 @@ class TritonAttentionBackend(AttentionBackend):
+ 
+     forward_includes_kv_cache_update: bool = False
+ 
++    @classmethod
++    def supports_non_causal(cls) -> bool:
++        return True
++
+     @staticmethod
+     def get_name() -> str:
+         return "TRITON_ATTN"
+@@ -606,6 +614,73 @@ class TritonAttentionImpl(AttentionImpl):
+ 
+         mm_prefix_range_tensor = attn_metadata.mm_prefix_range_tensor
+ 
++        # ---- ESIMD page_attn decode shortcut (head_size=256, M==1) ----
++        # TODO: triton_attn KV cache layout is [num_blocks, 2, page, kv_h, hd]
++        # but esimd page_attn expects [2, num_blocks, page, kv_h, hd].
++        # Need layout transpose or kernel adaptation. Disabled for now.
++        if (
++            False  # disabled: KV cache layout mismatch with esimd kernel
++            and current_platform.is_xpu()
++            and attn_metadata.max_query_len == 1
++            and self.head_size == 256
++            and kv_cache.size(2) >= 64
++        ):
++            try:
++                eagle_ops = importlib.import_module(
++                    "custom_esimd_kernels_vllm.eagle_ops")
++            except ImportError:
++                eagle_ops = None
++
++            if eagle_ops is not None:
++                _q = query[:num_actual_tokens]
++                _o = output[:num_actual_tokens]
++                _num_q = _q.shape[1]
++                _num_kv = kv_cache.shape[3]
++                _gqa = _num_q // _num_kv if _num_kv > 0 else 0
++                _need_pad = (_gqa >= 2 and _gqa % 4 != 0)
++
++                if self.kv_cache_dtype.startswith("fp8"):
++                    _kv_dtype = (
++                        torch.float8_e5m2
++                        if self.kv_cache_dtype == "fp8_e5m2"
++                        else torch.float8_e4m3fn)
++                    _kv_for_esimd = kv_cache.view(_kv_dtype)
++                    _k_scale = float(layer._k_scale)
++                    _v_scale = float(layer._v_scale)
++                else:
++                    _kv_for_esimd = kv_cache
++                    _k_scale = 1.0
++                    _v_scale = 1.0
++
++                if _need_pad:
++                    _padded_gqa = ((_gqa + 3) // 4) * 4
++                    _pad_per_kv = _padded_gqa - _gqa
++                    _bs, _, _hd = _q.shape
++                    _q_grouped = _q.reshape(_bs, _num_kv, _gqa, _hd)
++                    _q_pad = torch.nn.functional.pad(
++                        _q_grouped, (0, 0, 0, _pad_per_kv))
++                    _q_pad = _q_pad.reshape(
++                        _bs, _num_kv * _padded_gqa, _hd).contiguous()
++                    _o_pad = torch.zeros_like(_q_pad)
++                    eagle_ops.page_attn_decode(
++                        _q_pad, _kv_for_esimd, block_table, seqused_k,
++                        _o_pad, 1, attn_metadata.max_seq_len,
++                        _k_scale, _v_scale)
++                    _o_grouped = _o_pad.reshape(_bs, _num_kv, _padded_gqa, _hd)
++                    _o.copy_(_o_grouped[:, :, :_gqa, :].reshape(
++                        _bs, _num_q, _hd))
++                elif _gqa >= 4:
++                    eagle_ops.page_attn_decode(
++                        _q, _kv_for_esimd, block_table, seqused_k,
++                        _o, 1, attn_metadata.max_seq_len,
++                        _k_scale, _v_scale)
++                else:
++                    eagle_ops = None
++
++                if eagle_ops is not None:
++                    return output
++        # ---- end ESIMD page_attn decode shortcut ----
++
+         unified_attention(
+             q=query[:num_actual_tokens],
+             k=key_cache,
+@@ -616,7 +691,7 @@ class TritonAttentionImpl(AttentionImpl):
+             seqused_k=seqused_k,
+             max_seqlen_k=max_seqlen_k,
+             softmax_scale=self.scale,
+-            causal=True,
++            causal=attn_metadata.causal,
+             alibi_slopes=self.alibi_slopes,
+             use_alibi_sqrt=self.use_alibi_sqrt,
+             window_size=self.sliding_window,
+diff --git a/vllm/v1/attention/ops/triton_attention_helpers.py b/vllm/v1/attention/ops/triton_attention_helpers.py
+index 6ed50f6a2..b09f0b2e9 100644
+--- a/vllm/v1/attention/ops/triton_attention_helpers.py
++++ b/vllm/v1/attention/ops/triton_attention_helpers.py
+@@ -153,6 +153,8 @@ def compute_tile_loop_bounds(
+     SLIDING_WINDOW: tl.constexpr,
+     USE_MM_PREFIX: tl.constexpr,
+     IS_3D: tl.constexpr,
++    USE_CAUSAL: tl.constexpr = True,
++    USE_PER_SEQ_CAUSAL: tl.constexpr = False,
+     CHUNK_LOOKBACK: tl.constexpr = -1,
+     CHUNK_SIZE: tl.constexpr = -1,
+ ):
+@@ -163,10 +165,11 @@ def compute_tile_loop_bounds(
+ 
+     1. Longest prefix spanned by any query token in this q-block.
+        Clamped to ``seq_len`` (causal) or extended to it when
+-       mm_prefix is active (bidirectional ranges can reach past the
+-       causal prefix).
++       mm_prefix is active or non-causal sequences need the full
++       sequence.
+     2. Sliding-window pruning: narrows ``[tile_start, tile_end)`` to
+        only tiles that can contain an allowed key under SWA.
++       For non-causal sequences, the window extends in both directions.
+     3. 3D scoping: when ``IS_3D`` is True, further narrows to the
+        segment's slice via ``(segm_idx * tiles_per_segment,
+        (segm_idx + 1) * tiles_per_segment)``.
+@@ -179,9 +182,10 @@ def compute_tile_loop_bounds(
+         + (BLOCK_M - 1) // num_queries_per_kv
+         + 1
+     )
+-    if USE_MM_PREFIX:
+-        # image bidirectional attention ranges require a full range
+-        # including q_block padding to make sure doc mask is correct
++    if USE_MM_PREFIX or USE_PER_SEQ_CAUSAL or (not USE_CAUSAL):
++        # Non-causal or mixed batches need the full sequence range.
++        # Per-element masking in compute_kv_seq_mask handles the
++        # actual causal/non-causal boundary per sequence.
+         max_seq_prefix_len = tl.maximum(max_seq_prefix_len, seq_len)
+     else:
+         max_seq_prefix_len = tl.minimum(max_seq_prefix_len, seq_len)
+@@ -212,7 +216,14 @@ def compute_tile_loop_bounds(
+             first_allowed_key = ((q_abs // CHUNK_SIZE) - CHUNK_LOOKBACK) * CHUNK_SIZE
+         else:
+             first_allowed_key = q_abs - SLIDING_WINDOW + 1
+-        last_allowed_key = context_len + qpos_hi
++        if USE_PER_SEQ_CAUSAL or (not USE_CAUSAL):
++            # Non-causal: keys can be AHEAD of query within the window
++            last_allowed_key = tl.minimum(
++                context_len + qpos_hi + SLIDING_WINDOW - 1,
++                seq_len - 1,
++            )
++        else:
++            last_allowed_key = context_len + qpos_hi
+         # Convert to tile indices and clamp
+         tile_start = tl.maximum(0, first_allowed_key // TILE_SIZE)
+         tile_end = tl.minimum((last_allowed_key // TILE_SIZE) + 1, num_tiles)
+@@ -262,10 +273,14 @@ def compute_kv_seq_mask(
+     query_abs_pos,
+     seq_offset,
+     seq_idx,
++    seq_len,
+     mm_prefix_range_ptr,
+     SLIDING_WINDOW: tl.constexpr,
+     USE_MM_PREFIX: tl.constexpr,
+     MAX_MM_RANGES: tl.constexpr,
++    USE_CAUSAL: tl.constexpr = True,
++    USE_PER_SEQ_CAUSAL: tl.constexpr = False,
++    per_seq_causal_ptr=None,
+     CHUNK_LOOKBACK: tl.constexpr = -1,
+     CHUNK_SIZE: tl.constexpr = -1,
+ ):
+@@ -279,9 +294,24 @@ def compute_kv_seq_mask(
+     Chunked attention takes precedence over sliding window when both
+     are non-default — the launcher zeros ``CHUNK_LOOKBACK`` whenever
+     sliding window is disabled.
++
++    When ``USE_PER_SEQ_CAUSAL`` is set, each sequence carries its own
++    causal flag via ``per_seq_causal_ptr``; non-causal sequences use a
++    simple ``key < seq_len`` bound instead.  ``USE_CAUSAL=False``
++    disables causal masking entirely.
+     """
+     # Compute attention mask: causal by default (key <= query)
+-    seq_mask = seq_offset[None, :] <= query_abs_pos
++    if USE_PER_SEQ_CAUSAL:
++        is_causal = tl.load(per_seq_causal_ptr + seq_idx)
++        seq_mask = tl.where(
++            is_causal,
++            seq_offset[None, :] <= query_abs_pos,
++            seq_offset[None, :] < seq_len,
++        )
++    elif USE_CAUSAL:
++        seq_mask = seq_offset[None, :] <= query_abs_pos
++    else:
++        seq_mask = seq_offset[None, :] < seq_len
+ 
+     # Apply sliding window / chunked attention to base mask
+     # BEFORE mm_prefix OR.
+@@ -293,7 +323,15 @@ def compute_kv_seq_mask(
+             <= CHUNK_LOOKBACK
+         )
+     elif SLIDING_WINDOW > 0:
+-        seq_mask = seq_mask & ((query_abs_pos - seq_offset) < SLIDING_WINDOW)
++        sw_left = (query_abs_pos - seq_offset) < SLIDING_WINDOW
++        if USE_PER_SEQ_CAUSAL:
++            sw_right = (seq_offset[None, :] - query_abs_pos) < SLIDING_WINDOW
++            seq_mask = seq_mask & tl.where(is_causal, sw_left, sw_left & sw_right)
++        elif not USE_CAUSAL:
++            sw_right = (seq_offset[None, :] - query_abs_pos) < SLIDING_WINDOW
++            seq_mask = seq_mask & sw_left & sw_right
++        else:
++            seq_mask = seq_mask & sw_left
+ 
+     # PrefixLM: extend mask with bidirectional ranges for multimodal tokens.
+     # Applied AFTER sliding window so mm_prefix ranges override SW restriction.
+diff --git a/vllm/v1/attention/ops/triton_unified_attention.py b/vllm/v1/attention/ops/triton_unified_attention.py
+index 1774f1b30..c06c72c20 100644
+--- a/vllm/v1/attention/ops/triton_unified_attention.py
++++ b/vllm/v1/attention/ops/triton_unified_attention.py
+@@ -101,6 +101,9 @@ def kernel_unified_attention(
+     USE_SOFTCAP: tl.constexpr,  # bool
+     USE_SINKS: tl.constexpr,  # bool
+     SLIDING_WINDOW: tl.constexpr,  # int
++    USE_CAUSAL: tl.constexpr,  # bool
++    USE_PER_SEQ_CAUSAL: tl.constexpr,  # bool
++    per_seq_causal_ptr,  # [num_seqs] bool, or None
+     USE_MM_PREFIX: tl.constexpr,  # bool
+     MAX_MM_RANGES: tl.constexpr,  # int
+     mm_prefix_range_ptr,
+@@ -224,6 +227,8 @@ def kernel_unified_attention(
+         SLIDING_WINDOW,
+         USE_MM_PREFIX,
+         IS_3D,
++        USE_CAUSAL,
++        USE_PER_SEQ_CAUSAL,
+         CHUNK_LOOKBACK,
+         CHUNK_SIZE,
+     )
+@@ -288,10 +293,14 @@ def kernel_unified_attention(
+             query_abs_pos,
+             seq_offset,
+             seq_idx,
++            seq_len,
+             mm_prefix_range_ptr,
+             SLIDING_WINDOW,
+             USE_MM_PREFIX,
+             MAX_MM_RANGES,
++            USE_CAUSAL,
++            USE_PER_SEQ_CAUSAL,
++            per_seq_causal_ptr,
+             CHUNK_LOOKBACK,
+             CHUNK_SIZE,
+         )
+@@ -327,11 +336,27 @@ def kernel_unified_attention(
+ 
+         if SLIDING_WINDOW:
+             qpos_lo = q_block_local_idx * BLOCK_Q
+-            V = tl.where(
+-                (context_len + qpos_lo - seq_offset[:, None]) < SLIDING_WINDOW,
+-                V,
+-                0.0,
+-            )
++            dist = context_len + qpos_lo - seq_offset[:, None]
++            # NOTE(XPU port): this post-softmax V prune uses qpos_lo (the
++            # block's LOWEST query row). For causal that is a conservative
++            # left-only prune — it only zeros keys older than every row in
++            # the block, which the per-row S-mask already excluded, so it is
++            # redundant-but-harmless. For NON-causal (denoise) rows it is NOT
++            # safe: a qpos_lo-based right bound (dist > -SW) drops keys that
++            # are AHEAD of qpos_lo but still inside the symmetric window of a
++            # HIGHER query row in the block (bug repro: BLOCK_Q=8, small W ->
++            # ~0.2 max diff). The exact per-row S-mask already zeroed P for
++            # out-of-window keys, so for non-causal rows we skip the V prune
++            # entirely (P==0 makes those V rows contribute 0 regardless).
++            keep_all = dist == dist  # all-True, shape [TILE_SIZE, 1]
++            if USE_PER_SEQ_CAUSAL:
++                is_causal_seq = tl.load(per_seq_causal_ptr + seq_idx)
++                sw_mask_v = tl.where(is_causal_seq, dist < SLIDING_WINDOW, keep_all)
++            elif USE_CAUSAL:
++                sw_mask_v = dist < SLIDING_WINDOW
++            else:
++                sw_mask_v = keep_all
++            V = tl.where(sw_mask_v, V, 0.0)
+         if USE_PER_TOKEN_HEAD_SCALES:
+             # Per-token-head quant: apply v_scale to P instead of V.
+             P_v = (P * v_token_head_scales[None, :]).to(V.dtype)
+@@ -539,7 +564,11 @@ def unified_attention(
+     # Chunked attention: restrict attention to aligned blocks with lookback.
+     chunk_lookback=-1,
+ ):
+-    assert causal, "Only causal attention is supported"
++    # Resolve causal: bool or per-seq tensor.
++    use_per_seq_causal = isinstance(causal, torch.Tensor)
++    use_causal = bool(causal) if not use_per_seq_causal else True
++    per_seq_causal_ptr = causal if use_per_seq_causal else None
++
+     assert q_descale is None, "Q scales not supported"
+ 
+     if sinks is not None:
+@@ -578,6 +607,16 @@ def unified_attention(
+     BLOCK_M = (
+         16 if num_queries_per_kv <= 16 else triton.next_power_of_2(num_queries_per_kv)
+     )
++    # Multi-query-per-launch (canvas/prefill, max_seqlen_q > 1) feeds a much
++    # fatter Q@K GEMM than autoregressive decode (max_seqlen_q == 1). At the
++    # decode default BLOCK_M=16 with GQA the dot's M dim is tiny (e.g. GQA=2 ->
++    # 8 real query rows), starving the matrix engine. Doubling BLOCK_M to 32 for
++    # the multi-query case widens the GEMM and reuses each KV tile across more
++    # queries; measured ~40% faster for DiffusionGemma's 256-canvas attention
++    # (full + sliding layers), and no regression for decode (kept at 16). 64+
++    # regresses: too few q-blocks to fill the device. Math is unchanged.
++    if max_seqlen_q > 1 and num_queries_per_kv <= 16:
++        BLOCK_M = 32
+     BLOCK_Q = BLOCK_M // num_queries_per_kv
+ 
+     # Ideally we would launch with kernel with:
+@@ -695,10 +734,13 @@ def unified_attention(
+         USE_QQ_BIAS=use_qq_bias,
+         USE_SOFTCAP=(softcap > 0),
+         USE_SINKS=(sinks is not None),
++        SLIDING_WINDOW=(1 + window_size[0]),
++        USE_CAUSAL=use_causal,
++        USE_PER_SEQ_CAUSAL=use_per_seq_causal,
++        per_seq_causal_ptr=per_seq_causal_ptr,
+         USE_MM_PREFIX=use_mm_prefix,
+         MAX_MM_RANGES=max_mm_ranges,
+         mm_prefix_range_ptr=mm_prefix_range,
+-        SLIDING_WINDOW=(1 + window_size[0]),
+         stride_k_cache_0=k.stride(0),
+         stride_k_cache_1=k.stride(1),
+         stride_k_cache_2=k.stride(2),
+diff --git a/vllm/v1/core/sched/async_scheduler.py b/vllm/v1/core/sched/async_scheduler.py
+index 0b3958dbc..2def58562 100644
+--- a/vllm/v1/core/sched/async_scheduler.py
++++ b/vllm/v1/core/sched/async_scheduler.py
+@@ -26,10 +26,14 @@ class AsyncScheduler(Scheduler):
+             scheduler_output.pending_structured_output_tokens |= (
+                 request.use_structured_output and request.num_output_placeholders > 0
+             )
+-            # The request will generate a new token plus num_spec_tokens
+-            # in this scheduling step.
++            # The request will generate num_sampled_tokens_per_step new tokens
++            # plus num_spec_tokens in this scheduling step. Diffusion has no AR
++            # bonus token (num_sampled_tokens_per_step == 0) — only the canvas
++            # (spec) tokens.
+             cur_num_spec_tokens = len(spec_decode_tokens.get(req_id, ()))
+-            request.num_output_placeholders += 1 + cur_num_spec_tokens
++            request.num_output_placeholders += (
++                self.num_sampled_tokens_per_step + cur_num_spec_tokens
++            )
+             # Add placeholders for the new draft/spec tokens.
+             # We will update the actual spec token ids in the worker process.
+             request.spec_token_ids = self._spec_token_placeholders
+diff --git a/vllm/v1/core/sched/scheduler.py b/vllm/v1/core/sched/scheduler.py
+index 8aaeb3970..d74607735 100644
+--- a/vllm/v1/core/sched/scheduler.py
++++ b/vllm/v1/core/sched/scheduler.py
+@@ -109,6 +109,10 @@ class Scheduler(SchedulerInterface):
+             self.kv_events_config is not None
+             and self.kv_events_config.enable_kv_cache_events
+         )
++        # Diffusion models may not sample any tokens for a denoising step.
++        self.num_sampled_tokens_per_step = (
++            1 if not vllm_config.model_config.is_diffusion else 0
++        )
+ 
+         # Create KVConnector for the Scheduler. Note that each Worker
+         # will have a corresponding KVConnector with Role=WORKER.
+@@ -208,9 +212,9 @@ class Scheduler(SchedulerInterface):
+ 
+         speculative_config = vllm_config.speculative_config
+         self.use_eagle = False
+-        self.num_spec_tokens = self.num_lookahead_tokens = 0
+-        if speculative_config:
+-            self.num_spec_tokens = speculative_config.num_speculative_tokens
++        self.num_spec_tokens = vllm_config.num_speculative_tokens
++        self.num_lookahead_tokens = 0
++        if speculative_config is not None:
+             if speculative_config.use_eagle():
+                 self.use_eagle = True
+                 self.num_lookahead_tokens = self.num_spec_tokens
+@@ -375,7 +379,10 @@ class Scheduler(SchedulerInterface):
+             # Make sure the input position does not exceed the max model len.
+             # This is necessary when using spec decoding.
+             num_new_tokens = min(
+-                num_new_tokens, self.max_model_len - 1 - request.num_computed_tokens
++                num_new_tokens,
++                self.max_model_len
++                - request.num_computed_tokens
++                - self.num_sampled_tokens_per_step,
+             )
+ 
+             # Schedule encoder inputs.
+@@ -1312,9 +1319,12 @@ class Scheduler(SchedulerInterface):
+             scheduled_spec_token_ids = (
+                 scheduler_output.scheduled_spec_decode_tokens.get(req_id)
+             )
+-            if scheduled_spec_token_ids and generated_token_ids:
++            if scheduled_spec_token_ids and (
++                generated_token_ids or self.num_sampled_tokens_per_step == 0
++            ):
+                 num_draft_tokens = len(scheduled_spec_token_ids)
+-                num_accepted = len(generated_token_ids) - 1
++                num_sampled = self.num_sampled_tokens_per_step
++                num_accepted = max(len(generated_token_ids) - num_sampled, 0)
+                 num_rejected = num_draft_tokens - num_accepted
+                 # num_computed_tokens represents the number of tokens
+                 # processed in the current step, considering scheduled
 diff --git a/vllm/v1/engine/__init__.py b/vllm/v1/engine/__init__.py
 index f6c80055b..df166841f 100644
 --- a/vllm/v1/engine/__init__.py
@@ -1848,10 +10980,59 @@ index f6c80055b..df166841f 100644
  
  class EngineCoreRequest(
 diff --git a/vllm/v1/engine/core.py b/vllm/v1/engine/core.py
-index 122cdd8f9..796820382 100644
+index 122cdd8f9..8b24b9ec1 100644
 --- a/vllm/v1/engine/core.py
 +++ b/vllm/v1/engine/core.py
-@@ -1418,6 +1418,8 @@ class EngineCoreProc(EngineCore):
+@@ -152,6 +152,9 @@ class EngineCore:
+             hash_block_size=hash_block_size,
+         )
+         self.use_spec_decode = vllm_config.speculative_config is not None
++        self.check_for_draft_tokens = (
++            self.use_spec_decode or vllm_config.model_config.is_diffusion
++        )
+         if self.scheduler.connector is not None:  # type: ignore
+             self.model_executor.init_kv_output_aggregator(self.scheduler.connector)  # type: ignore
+ 
+@@ -438,8 +441,7 @@ class EngineCore:
+         # When using async scheduling we can't get draft token ids in advance,
+         # so we update draft token ids in the worker process and don't
+         # need to update draft token ids here.
+-        if not self.async_scheduling and self.use_spec_decode and model_executed:
+-            # Take the draft token ids.
++        if self.check_for_draft_tokens and not self.async_scheduling and model_executed:
+             draft_token_ids = self.model_executor.take_draft_token_ids()
+             if draft_token_ids is not None:
+                 self.scheduler.update_draft_token_ids(draft_token_ids)
+@@ -540,18 +542,17 @@ class EngineCore:
+         # in a field and do it immediately once step_with_batch_queue is
+         # re-called. The latter slightly favors TTFT over TPOT/throughput.
+         if deferred_scheduler_output:
+-            # If we are doing speculative decoding with structured output,
+-            # we need to get the draft token ids from the prior step before
+-            # we can compute the grammar bitmask for the deferred request.
+-            if self.use_spec_decode:
++            # When draft tokens are used with structured output, validate them
++            # before computing the grammar bitmask for the deferred request.
++            if self.check_for_draft_tokens:
+                 draft_token_ids = self.model_executor.take_draft_token_ids()
+-                assert draft_token_ids is not None
+-                # Update the draft token ids in the scheduler output to
+-                # filter out the invalid spec tokens, which will be padded
+-                # with -1 and skipped by the grammar bitmask computation.
+-                self.scheduler.update_draft_token_ids_in_output(
+-                    draft_token_ids, deferred_scheduler_output
+-                )
++                if draft_token_ids is not None:
++                    # Update the draft token ids in the scheduler output to
++                    # filter out the invalid spec tokens, which will be padded
++                    # with -1 and skipped by the grammar bitmask computation.
++                    self.scheduler.update_draft_token_ids_in_output(
++                        draft_token_ids, deferred_scheduler_output
++                    )
+             # We now have the tokens needed to compute the bitmask for the
+             # deferred request. Get the bitmask and call sample tokens.
+             grammar_output = self.scheduler.get_grammar_bitmask(
+@@ -1418,6 +1419,8 @@ class EngineCoreProc(EngineCore):
                  max_model_len=self.vllm_config.model_config.max_model_len,
                  num_gpu_blocks=self.vllm_config.cache_config.num_gpu_blocks or 0,
                  dp_stats_address=self.frontend_stats_publish_address,
@@ -2023,6 +11204,33 @@ index 54046d98f..1c147b07a 100644
                  raise Exception(
                      "CPU Offloading is currently only supported on CUDA-alike GPUs"
                  )
+diff --git a/vllm/v1/metrics/loggers.py b/vllm/v1/metrics/loggers.py
+index 6855efd9f..8cd70d9d3 100644
+--- a/vllm/v1/metrics/loggers.py
++++ b/vllm/v1/metrics/loggers.py
+@@ -110,7 +110,9 @@ class LoggingStatLogger(StatLoggerBase):
+         self.connector_prefix_caching_metrics = CachingMetrics()
+         self.mm_caching_metrics = CachingMetrics()
+ 
+-        self.spec_decoding_logging = SpecDecodingLogging()
++        model_config = self.vllm_config.model_config
++        is_diffusion = model_config is not None and model_config.is_diffusion
++        self.spec_decoding_logging = SpecDecodingLogging(is_diffusion=is_diffusion)
+         kv_transfer_config = self.vllm_config.kv_transfer_config
+         self.kv_connector_logging = KVConnectorLogging(kv_transfer_config)
+         self.cudagraph_logging = None
+@@ -436,7 +438,10 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
+         per_engine_labelvalues = self.per_engine_labelvalues
+ 
+         self.spec_decoding_prom = self._spec_decoding_cls(
+-            vllm_config.speculative_config, labelnames, per_engine_labelvalues
++            vllm_config.speculative_config,
++            labelnames,
++            per_engine_labelvalues,
++            is_diffusion=vllm_config.model_config.is_diffusion,
+         )
+         self.kv_connector_prom = self._kv_connector_cls(
+             vllm_config, labelnames, per_engine_labelvalues
 diff --git a/vllm/v1/sample/ops/topk_topp_sampler.py b/vllm/v1/sample/ops/topk_topp_sampler.py
 index 363b113f0..c538fd58c 100644
 --- a/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -2039,6 +11247,726 @@ index 363b113f0..c538fd58c 100644
          return random_sampled, logits_to_return
  
  
+diff --git a/vllm/v1/spec_decode/metrics.py b/vllm/v1/spec_decode/metrics.py
+index 9a41ff5c8..5da41510b 100644
+--- a/vllm/v1/spec_decode/metrics.py
++++ b/vllm/v1/spec_decode/metrics.py
+@@ -53,7 +53,11 @@ class SpecDecodingLogging:
+     before resetting to zero.
+     """
+ 
+-    def __init__(self):
++    def __init__(self, is_diffusion: bool = False):
++        # Diffusion (dLLM) models reuse the spec-decode data path with
++        # overloaded semantics, so the raw spec-decode framing (drafts, bonus
++        # token, per-position vector) is logged with diffusion-native terms.
++        self.is_diffusion = is_diffusion
+         self.reset()
+ 
+     def reset(self):
+@@ -85,6 +89,17 @@ class SpecDecodingLogging:
+             draft_throughput = num_draft_tokens / elapsed_time
+             accepted_throughput = num_accepted_tokens / elapsed_time
+ 
++        if self.is_diffusion:
++            self._log_diffusion(
++                log_fn,
++                num_denoising_steps=num_drafts,
++                num_canvas_tokens=num_draft_tokens,
++                num_committed_tokens=num_accepted_tokens,
++                committed_throughput=accepted_throughput,
++            )
++            self.reset()
++            return
++
+         draft_acceptance_rate = (
+             num_accepted_tokens / num_draft_tokens * 100
+             if num_draft_tokens > 0
+@@ -117,6 +132,43 @@ class SpecDecodingLogging:
+         )
+         self.reset()
+ 
++    def _log_diffusion(
++        self,
++        log_fn,
++        num_denoising_steps: int,
++        num_canvas_tokens: int,
++        num_committed_tokens: int,
++        committed_throughput: float,
++    ):
++        # Each "draft" is one denoising step that re-evaluates the canvas block
++        # and finalizes some of its positions.
++        mean_committed_per_step = (
++            num_committed_tokens / num_denoising_steps
++            if num_denoising_steps > 0
++            else float("nan")
++        )
++        mean_steps_per_canvas = (
++            num_canvas_tokens / num_committed_tokens
++            if num_committed_tokens > 0
++            else float("nan")
++        )
++
++        log_fn(
++            "DiffusionDecoding metrics: "
++            "Committed token throughput: %.2f tokens/s, "
++            "Mean denoising steps per canvas: %.2f, "
++            "Mean tokens committed per denoising step: %.2f, "
++            "Committed: %d tokens, "
++            "Denoising steps: %d, "
++            "Canvas positions evaluated: %d",
++            committed_throughput,
++            mean_steps_per_canvas,
++            mean_committed_per_step,
++            num_committed_tokens,
++            num_denoising_steps,
++            num_canvas_tokens,
++        )
++
+ 
+ class SpecDecodingProm:
+     """Record spec decoding metrics in Prometheus.
+@@ -146,56 +198,66 @@ class SpecDecodingProm:
+         speculative_config: SpeculativeConfig | None,
+         labelnames: list[str],
+         per_engine_labelvalues: dict[int, list[object]],
++        is_diffusion: bool = False,
+     ):
+-        self.spec_decoding_enabled = speculative_config is not None
++        # Diffusion (dLLM) models reuse the spec-decode counters but expose them
++        # under diffusion-native names; the per-position acceptance vector does
++        # not apply, so it is omitted.
++        self.is_diffusion = is_diffusion
++        self.spec_decoding_enabled = speculative_config is not None or is_diffusion
+         if not self.spec_decoding_enabled:
+             return
+ 
+-        counter_drafts = self._counter_cls(
+-            name="vllm:spec_decode_num_drafts",
+-            documentation="Number of spec decoding drafts.",
+-            labelnames=labelnames,
+-        )
+-        self.counter_spec_decode_num_drafts = create_metric_per_engine(
+-            counter_drafts, per_engine_labelvalues
+-        )
+-
+-        counter_draft_tokens = self._counter_cls(
+-            name="vllm:spec_decode_num_draft_tokens",
+-            documentation="Number of draft tokens.",
+-            labelnames=labelnames,
+-        )
+-        self.counter_spec_decode_num_draft_tokens = create_metric_per_engine(
+-            counter_draft_tokens, per_engine_labelvalues
+-        )
++        if is_diffusion:
++            counter_specs = [
++                ("vllm:diffusion_num_denoising_steps", "Number of denoising steps."),
++                (
++                    "vllm:diffusion_num_canvas_positions",
++                    "Number of canvas positions evaluated.",
++                ),
++                (
++                    "vllm:diffusion_num_committed_tokens",
++                    "Number of committed (finalized) tokens.",
++                ),
++            ]
++        else:
++            counter_specs = [
++                ("vllm:spec_decode_num_drafts", "Number of spec decoding drafts."),
++                ("vllm:spec_decode_num_draft_tokens", "Number of draft tokens."),
++                ("vllm:spec_decode_num_accepted_tokens", "Number of accepted tokens."),
++            ]
++
++        counters = [
++            create_metric_per_engine(
++                self._counter_cls(name=name, documentation=doc, labelnames=labelnames),
++                per_engine_labelvalues,
++            )
++            for name, doc in counter_specs
++        ]
++        # num_drafts/num_draft_tokens/num_accepted_tokens map onto denoising
++        # steps/canvas positions/committed tokens in the diffusion path.
++        self.counter_spec_decode_num_drafts = counters[0]
++        self.counter_spec_decode_num_draft_tokens = counters[1]
++        self.counter_spec_decode_num_accepted_tokens = counters[2]
+ 
+-        counter_accepted_tokens = self._counter_cls(
+-            name="vllm:spec_decode_num_accepted_tokens",
+-            documentation="Number of accepted tokens.",
+-            labelnames=labelnames,
+-        )
+-        self.counter_spec_decode_num_accepted_tokens = create_metric_per_engine(
+-            counter_accepted_tokens, per_engine_labelvalues
+-        )
+-
+-        assert speculative_config is not None
+-        num_spec_tokens = (
+-            speculative_config.num_speculative_tokens
+-            if self.spec_decoding_enabled
+-            else 0
+-        )
+-        pos_labelnames = labelnames + ["position"]
+-        base_counter = self._counter_cls(
+-            name="vllm:spec_decode_num_accepted_tokens_per_pos",
+-            documentation="Accepted tokens per draft position.",
+-            labelnames=pos_labelnames,
+-        )
+         self.counter_spec_decode_num_accepted_tokens_per_pos: dict[
+             int, list[prometheus_client.Counter]
+-        ] = {
+-            idx: [base_counter.labels(*lv, str(pos)) for pos in range(num_spec_tokens)]
+-            for idx, lv in per_engine_labelvalues.items()
+-        }
++        ] = {}
++        if not is_diffusion:
++            assert speculative_config is not None
++            num_spec_tokens = speculative_config.num_speculative_tokens
++            pos_labelnames = labelnames + ["position"]
++            base_counter = self._counter_cls(
++                name="vllm:spec_decode_num_accepted_tokens_per_pos",
++                documentation="Accepted tokens per draft position.",
++                labelnames=pos_labelnames,
++            )
++            self.counter_spec_decode_num_accepted_tokens_per_pos = {
++                idx: [
++                    base_counter.labels(*lv, str(pos)) for pos in range(num_spec_tokens)
++                ]
++                for idx, lv in per_engine_labelvalues.items()
++            }
+ 
+     def observe(self, spec_decoding_stats: SpecDecodingStats, engine_idx: int = 0):
+         if not self.spec_decoding_enabled:
+@@ -210,6 +272,6 @@ class SpecDecodingProm:
+             spec_decoding_stats.num_accepted_tokens
+         )
+         for pos, counter in enumerate(
+-            self.counter_spec_decode_num_accepted_tokens_per_pos[engine_idx]
++            self.counter_spec_decode_num_accepted_tokens_per_pos.get(engine_idx, [])
+         ):
+             counter.inc(spec_decoding_stats.num_accepted_tokens_per_pos[pos])
+diff --git a/vllm/v1/worker/gpu/attn_utils.py b/vllm/v1/worker/gpu/attn_utils.py
+index 5930777de..b515ee67e 100644
+--- a/vllm/v1/worker/gpu/attn_utils.py
++++ b/vllm/v1/worker/gpu/attn_utils.py
+@@ -312,6 +312,7 @@ def build_attn_metadata(
+     positions: torch.Tensor | None = None,
+     model_specific_attn_metadata: ModelSpecificAttnMetadata | None = None,
+     for_cudagraph_capture: bool = False,
++    causal: bool = True,
+ ) -> dict[str, Any]:
+     seq_lens = seq_lens[:num_reqs]
+     if dcp_local_seq_lens is not None:
+@@ -341,7 +342,7 @@ def build_attn_metadata(
+             max_query_len=max_query_len,
+             block_table_tensor=block_table,
+             slot_mapping=slot_mapping,
+-            causal=True,
++            causal=causal,
+             dcp_local_seq_lens=dcp_local_seq_lens,
+             positions=positions,
+             **common_attn_metadata_extra_kwargs,
+diff --git a/vllm/v1/worker/gpu/input_batch.py b/vllm/v1/worker/gpu/input_batch.py
+index b253d7d8c..4a518fd46 100644
+--- a/vllm/v1/worker/gpu/input_batch.py
++++ b/vllm/v1/worker/gpu/input_batch.py
+@@ -289,6 +289,7 @@ def _combine_sampled_and_draft_tokens_kernel(
+     cu_num_logits_ptr,
+     logits_indices_ptr,
+     BLOCK_SIZE: tl.constexpr,
++    NUM_NEW_SAMPLED_TOKENS: tl.constexpr = 1,
+ ):
+     batch_idx = tl.program_id(0)
+     req_state_idx = tl.load(idx_mapping_ptr + batch_idx)
+@@ -297,7 +298,7 @@ def _combine_sampled_and_draft_tokens_kernel(
+     cu_num_logits_start = tl.load(cu_num_logits_ptr + batch_idx)
+     cu_num_logits_end = tl.load(cu_num_logits_ptr + batch_idx + 1)
+     num_logits = cu_num_logits_end - cu_num_logits_start
+-    num_draft_tokens = num_logits - 1
++    num_draft_tokens = num_logits - NUM_NEW_SAMPLED_TOKENS
+ 
+     # Compute the logits indices.
+     block = tl.arange(0, BLOCK_SIZE)
+@@ -315,9 +316,10 @@ def _combine_sampled_and_draft_tokens_kernel(
+         # Handling prefill tokens. No sampled or draft tokens.
+         return
+ 
+-    # Write the last sampled token ID to input_ids.
+-    last_token_id = tl.load(last_sampled_tokens_ptr + req_state_idx)
+-    tl.store(input_ids_ptr + query_end - num_logits, last_token_id)
++    if NUM_NEW_SAMPLED_TOKENS > 0:
++        # Write the last sampled token ID to input_ids.
++        last_token_id = tl.load(last_sampled_tokens_ptr + req_state_idx)
++        tl.store(input_ids_ptr + query_end - num_logits, last_token_id)
+ 
+     # Write the draft tokens (if any) to input_ids.
+     if num_draft_tokens > 0:
+@@ -343,7 +345,11 @@ def combine_sampled_and_draft_tokens(
+     draft_tokens: torch.Tensor,
+     cu_num_logits: torch.Tensor,
+     num_logits: int,
++    num_new_sampled_tokens: int = 1,  # excl accepted draft tokens, a.k.a bonus tokens
+ ) -> torch.Tensor:
++    assert num_new_sampled_tokens in (0, 1), (
++        f"num_new_sampled_tokens must be 0 or 1, got {num_new_sampled_tokens}"
++    )
+     # use idx_mapping.shape[0] for actual request count
+     num_reqs = idx_mapping.shape[0]
+     num_speculative_steps = draft_tokens.shape[-1]
+@@ -364,9 +370,12 @@ def combine_sampled_and_draft_tokens(
+         draft_tokens.stride(0),
+         cu_num_logits,
+         logits_indices,
+-        # NOTE(woosuk): Add 1 to ensure the block can cover the last sampled token
+-        # in addition to all draft tokens.
+-        BLOCK_SIZE=triton.next_power_of_2(num_speculative_steps + 1),
++        NUM_NEW_SAMPLED_TOKENS=num_new_sampled_tokens,
++        # NOTE(woosuk): Add num_new_sampled_tokens to ensure the block covers the
++        # last sampled token in addition to all draft tokens.
++        BLOCK_SIZE=triton.next_power_of_2(
++            num_speculative_steps + num_new_sampled_tokens
++        ),
+     )
+     return logits_indices
+ 
+diff --git a/vllm/v1/worker/gpu/model_runner.py b/vllm/v1/worker/gpu/model_runner.py
+index b81bd0dc5..f9cecfca8 100644
+--- a/vllm/v1/worker/gpu/model_runner.py
++++ b/vllm/v1/worker/gpu/model_runner.py
+@@ -166,11 +166,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+ 
+         # Speculative decoding.
+         self.speculator = None
+-        self.num_speculative_steps = 0
+         self.use_aux_hidden_state_outputs = False
++        self.num_speculative_steps = vllm_config.num_speculative_tokens
+         if self.speculative_config is not None:
+-            self.num_speculative_steps = self.speculative_config.num_speculative_tokens
+-
+             if self.is_last_pp_rank:
+                 self.speculator = init_speculator(self.vllm_config, self.device)
+ 
+@@ -182,7 +180,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+ 
+         # Draft tokens propagation - for spec-dec + struct outputs.
+         self.draft_tokens_handler = DraftTokensHandler(self.device)
+-        self.uniform_decode_query_len = 1 + self.num_speculative_steps
+ 
+         # Pooling models.
+         self.is_pooling_model = self.model_config.runner_type == "pooling"
+@@ -207,33 +204,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+         self.rejection_sampler: RejectionSampler | None = None
+         self.prompt_logprobs_worker: PromptLogprobsWorker | None = None
+         self.structured_outputs_worker: StructuredOutputsWorker | None = None
+-        if self.is_last_pp_rank and not self.is_pooling_model:
+-            # Initialize sampling-related workers.
+-            # These components are only set up on the last PP rank and
+-            # for generative (non-pooling) models.
+-            self.sampler = Sampler(
+-                max_num_reqs=self.max_num_reqs,
+-                vocab_size=self.vocab_size,
+-                device=self.device,
+-                req_states=self.req_states,
+-                logprobs_mode=self.model_config.logprobs_mode,
+-                num_speculative_tokens=self.num_speculative_steps + 1,
+-            )
+-            if self.speculative_config is not None:
+-                self.rejection_sampler = RejectionSampler(
+-                    self.sampler,
+-                    self.speculative_config,
+-                    self.device,
+-                )
+-            self.prompt_logprobs_worker = PromptLogprobsWorker(self.max_num_reqs)
+-            self.structured_outputs_worker = StructuredOutputsWorker(
+-                max_num_logits=self.max_num_reqs * (self.num_speculative_steps + 1),
+-                vocab_size=self.vocab_size,
+-                device=self.device,
+-            )
+-
+-        # For CUDA graphs, and will init cudagraph_manager after init_attn_backend.
+-        self.decode_query_len = self.num_speculative_steps + 1
++        # Samplers and decode_query_len created in load_model() after
++        # model_state exists (num_new_sampled_tokens_per_step from ModelState).
+         self.cudagraph_manager: ModelCudaGraphManager | None = None
+         # LoRA-related workers.
+         self.lora_state = LoraState(max_num_reqs=self.max_num_reqs)
+@@ -305,6 +277,42 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+         self.model_state = init_model_state(
+             self.vllm_config, self.model, self.encoder_cache, self.device
+         )
++
++        self.decode_query_len = (
++            self.num_speculative_steps
++            + self.model_state.num_new_sampled_tokens_per_step
++        )
++
++        # Initialize samplers. Model states may override via custom_sampler().
++        if self.is_last_pp_rank and not self.is_pooling_model:
++            self.sampler = Sampler(
++                max_num_reqs=self.max_num_reqs,
++                vocab_size=self.vocab_size,
++                device=self.device,
++                req_states=self.req_states,
++                logprobs_mode=self.model_config.logprobs_mode,
++                num_speculative_tokens=self.decode_query_len,
++                # NOTE(xpu-port): downstream gumbel_sample is hard-coded fp64
++                # and the downstream Sampler/ModelConfig has no use_fp64_gumbel;
++                # drop the upstream-only kwarg.
++            )
++            custom = self.model_state.custom_sampler(self.sampler)
++
++            if custom:
++                self.sampler, self.rejection_sampler = custom
++            elif self.speculative_config is not None:
++                self.rejection_sampler = RejectionSampler(
++                    self.sampler,
++                    self.speculative_config,
++                    self.device,
++                )
++            self.prompt_logprobs_worker = PromptLogprobsWorker(self.max_num_reqs)
++            self.structured_outputs_worker = StructuredOutputsWorker(
++                max_num_logits=self.max_num_reqs * self.decode_query_len,
++                vocab_size=self.vocab_size,
++                device=self.device,
++            )
++
+         if self.is_pooling_model and self.is_last_pp_rank:
+             self.pooling_runner = PoolingRunner(self.model)
+         eplb_models_added |= self.eplb.maybe_register_model(
+@@ -392,7 +400,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+         cudagraph_mode = self.compilation_config.resolve_cudagraph_mode_and_sizes(
+             attn_cg_support.min_cg_support,
+             attn_cg_support.min_cg_attn_backend,
+-            self.uniform_decode_query_len,
++            self.decode_query_len,
+             self.parallel_config.tensor_parallel_size,
+             self.kv_cache_config,
+             self.max_num_reqs,
+@@ -644,6 +652,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+         return cuda_graph_size
+ 
+     def _remove_request(self, req_id: str) -> bool:
++        # model_state.remove_request before req_states so slot index resolvable
++        self.model_state.remove_request(req_id)
+         if not self.req_states.remove_request(req_id):
+             return False
+         if self.encoder_cache is not None:
+@@ -761,16 +771,16 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+                 dtype=np.int32,
+                 count=num_reqs,
+             )
++            num_bonus_tokens = self.model_state.num_new_sampled_tokens_per_step
+             total_num_draft_tokens = int(num_draft_tokens_per_req.sum())
+-            total_num_logits = num_reqs + total_num_draft_tokens
+-
+-            num_logits = num_draft_tokens_per_req + 1
++            total_num_logits = num_reqs * num_bonus_tokens + total_num_draft_tokens
++            num_logits = num_draft_tokens_per_req + num_bonus_tokens
+             cu_num_logits_np = np.empty(num_reqs + 1, dtype=np.int32)
+             cu_num_logits_np[0] = 0
+             np.cumsum(num_logits, out=cu_num_logits_np[1:])
+             cu_num_logits = async_copy_to_gpu(cu_num_logits_np, device=self.device)
+ 
+-            max_expand_len = self.num_speculative_steps + 1
++            max_expand_len = self.decode_query_len
+             expanded_idx_mapping, expanded_local_pos = expand_idx_mapping(
+                 idx_mapping, total_num_logits, cu_num_logits, max_expand_len
+             )
+@@ -839,6 +849,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+             self.req_states.draft_tokens,
+             cu_num_logits,
+             total_num_logits,
++            self.model_state.num_new_sampled_tokens_per_step,
+         )
+ 
+         # CPU upper bound on seq_lens; padded entries left at zero.
+@@ -921,8 +932,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+                 grammar_output.grammar_bitmask,
+             )
+ 
+-        if input_batch.num_draft_tokens == 0:
+-            # No draft tokens (common case).
++        if input_batch.num_draft_tokens == 0 or self.rejection_sampler is None:
+             assert self.sampler is not None
+             sampler_output = self.sampler(logits, input_batch)
+         else:
+@@ -936,16 +946,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+                 self.speculator.draft_logits,
+             )
+ 
+-        # Get the number of sampled and rejected tokens.
+-        # For chunked prefills, num_sampled and num_rejected are both 0.
+-        num_sampled, num_rejected = get_num_sampled_and_rejected(
+-            sampler_output.num_sampled,
+-            input_batch.seq_lens,
+-            input_batch.cu_num_logits,
+-            input_batch.idx_mapping,
+-            self.req_states.prefill_len.gpu,
+-        )
+-        return sampler_output, num_sampled, num_rejected
++        return sampler_output, sampler_output.num_sampled, sampler_output.num_rejected
+ 
+     def postprocess(
+         self,
+@@ -1300,7 +1301,14 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+                 mm_inputs=mm_inputs,
+             )
+             self.req_states.draft_tokens[input_batch.idx_mapping] = draft_tokens
+-            self.draft_tokens_handler.set_draft_tokens(input_batch, draft_tokens)
++
++        if self.num_speculative_steps > 0:
++            # Spec-decode and diffusion LLMs both use draft tokens but the latter does
++            # not have a speculator (i.e. self.speculator is None)
++            self.draft_tokens_handler.set_draft_tokens(
++                input_batch,
++                self.req_states.draft_tokens[input_batch.idx_mapping],
++            )
+ 
+         if self.use_async_scheduling:
+             return async_output
+diff --git a/vllm/v1/worker/gpu/model_states/__init__.py b/vllm/v1/worker/gpu/model_states/__init__.py
+index 06b5a92c3..3e242213e 100644
+--- a/vllm/v1/worker/gpu/model_states/__init__.py
++++ b/vllm/v1/worker/gpu/model_states/__init__.py
+@@ -13,6 +13,11 @@ def init_model_state(
+     encoder_cache: EncoderCache | None,
+     device: torch.device,
+ ):
++    # Let the model provide its own ModelState if it defines one.
++    if hasattr(model, "get_model_state_cls"):
++        cls = model.get_model_state_cls()
++        return cls(vllm_config, model, encoder_cache, device)
++
+     if "WhisperForConditionalGeneration" in vllm_config.model_config.architectures:
+         from vllm.v1.worker.gpu.model_states.whisper import WhisperModelState
+ 
+diff --git a/vllm/v1/worker/gpu/model_states/interface.py b/vllm/v1/worker/gpu/model_states/interface.py
+index 721e5c201..f35ece27b 100644
+--- a/vllm/v1/worker/gpu/model_states/interface.py
++++ b/vllm/v1/worker/gpu/model_states/interface.py
+@@ -53,6 +53,9 @@ class ModelState(ABC):
+     def add_request(self, req_index: int, new_req_data: NewRequestData) -> None:
+         return None
+ 
++    def remove_request(self, req_id: str) -> None:
++        return None
++
+     def apply_staged_writes(self) -> None:
+         return None
+ 
+@@ -94,3 +97,16 @@ class ModelState(ABC):
+         for_capture: bool = False,
+     ) -> dict[str, Any]:
+         raise NotImplementedError
++
++    def custom_sampler(self, sampler: Any) -> tuple[Any, Any] | None:
++        """Wrap or replace the default sampler.
++
++        Called after model loading with the already-constructed base
++        ``Sampler``.  Return ``None`` to keep the defaults, or
++        ``(sampler, rejection_sampler | None)`` to override.
++        """
++        return None
++
++    num_new_sampled_tokens_per_step: int = 1
++    """New tokens sampled on each decode step 
++    (excluding accepted draft tokens, a.k.a num bonus tokens)."""
+diff --git a/vllm/v1/worker/gpu/sample/output.py b/vllm/v1/worker/gpu/sample/output.py
+index f38ac8aff..130f4ddbf 100644
+--- a/vllm/v1/worker/gpu/sample/output.py
++++ b/vllm/v1/worker/gpu/sample/output.py
+@@ -13,3 +13,4 @@ class SamplerOutput:
+     logprobs_tensors: LogprobsTensors | None
+     num_nans: torch.Tensor | None
+     num_sampled: torch.Tensor | None
++    num_rejected: torch.Tensor | None = None
+diff --git a/vllm/v1/worker/gpu/sample/sampler.py b/vllm/v1/worker/gpu/sample/sampler.py
+index 5d91d5b2f..f7d654ca5 100644
+--- a/vllm/v1/worker/gpu/sample/sampler.py
++++ b/vllm/v1/worker/gpu/sample/sampler.py
+@@ -7,7 +7,7 @@ import torch
+ import vllm.envs as envs
+ from vllm.config.model import LogprobsMode
+ from vllm.sampling_params import SamplingParams
+-from vllm.v1.worker.gpu.input_batch import InputBatch
++from vllm.v1.worker.gpu.input_batch import InputBatch, get_num_sampled_and_rejected
+ from vllm.v1.worker.gpu.metrics.logits import get_num_nans
+ from vllm.v1.worker.gpu.sample.bad_words import BadWordsState
+ from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample
+@@ -37,6 +37,7 @@ class Sampler:
+         self.logprobs_mode = logprobs_mode
+         self.compute_nans = envs.VLLM_COMPUTE_NANS_IN_LOGITS  # False by default.
+ 
++        self.req_states = req_states
+         self.sampling_states = SamplingStates(max_num_reqs, vocab_size)
+         self.penalties_state = PenaltiesState(req_states)
+         self.logit_bias_state = LogitBiasState(max_num_reqs, device)
+@@ -106,6 +107,17 @@ class Sampler:
+         else:
+             logprobs_tensors = None
+ 
++        # 1 sampled token per request, except chunked-prefill requests
++        # (seq_len < prefill_len) which aren't done prefilling and produce no
++        # output token. num_rejected is always 0 here (one logit per request).
++        num_sampled, num_rejected = get_num_sampled_and_rejected(
++            input_batch.seq_lens.new_ones(input_batch.num_reqs),
++            input_batch.seq_lens,
++            input_batch.cu_num_logits,
++            input_batch.idx_mapping,
++            self.req_states.prefill_len.gpu,
++        )
++
+         # These are GPU tensors.
+         sampler_output = SamplerOutput(
+             # The sampled tokens are expanded to 2D tensor with shape
+@@ -114,7 +126,8 @@ class Sampler:
+             sampled_token_ids=sampled.view(-1, 1),
+             logprobs_tensors=logprobs_tensors,
+             num_nans=num_nans,
+-            num_sampled=input_batch.seq_lens.new_ones(input_batch.num_reqs),
++            num_sampled=num_sampled,
++            num_rejected=num_rejected,
+         )
+         return sampler_output
+ 
+diff --git a/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py b/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
+index d41a7d8c8..9d6cbd082 100644
+--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
++++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
+@@ -6,7 +6,10 @@ from vllm.config import SpeculativeConfig
+ from vllm.triton_utils import tl, triton
+ from vllm.v1.outputs import LogprobsTensors
+ from vllm.v1.spec_decode.utils import unconditional_to_conditional_rates
+-from vllm.v1.worker.gpu.input_batch import InputBatch
++from vllm.v1.worker.gpu.input_batch import (
++    InputBatch,
++    get_num_sampled_and_rejected,
++)
+ from vllm.v1.worker.gpu.metrics.logits import get_num_nans
+ from vllm.v1.worker.gpu.sample.logprob import compute_topk_logprobs
+ from vllm.v1.worker.gpu.sample.output import SamplerOutput
+@@ -155,9 +158,18 @@ class RejectionSampler:
+                 f"Unknown rejection sample method: {self.rejection_sample_method}"
+             )
+ 
++        num_sampled, num_rejected = get_num_sampled_and_rejected(
++            num_sampled,
++            input_batch.seq_lens,
++            input_batch.cu_num_logits,
++            input_batch.idx_mapping,
++            self.sampler.req_states.prefill_len.gpu,
++        )
++
+         return SamplerOutput(
+             sampled_token_ids=sampled,
+             logprobs_tensors=logprobs_tensors,
+             num_nans=num_nans,
+             num_sampled=num_sampled,
++            num_rejected=num_rejected,
+         )
+diff --git a/vllm/v1/worker/gpu/warmup.py b/vllm/v1/worker/gpu/warmup.py
+index 83d87c74a..234ebb4ef 100644
+--- a/vllm/v1/worker/gpu/warmup.py
++++ b/vllm/v1/worker/gpu/warmup.py
+@@ -7,6 +7,8 @@ from typing import Any
+ import numpy as np
+ import torch
+ 
++import os
++
+ from vllm import PoolingParams, SamplingParams
+ from vllm.utils.math_utils import cdiv
+ from vllm.v1.core.sched.output import (
+@@ -30,17 +32,18 @@ def warmup_kernels(
+     pipeline parallel coordination.
+ 
+     The first iteration simulates a prefill with requests of
+-    2 + num_spec_steps prompt tokens each. The second iteration simulates
+-    a decode step with all requests generating 1 + num_spec_steps tokens.
++    decode_query_len + 1 prompt tokens each. The second iteration simulates
++    a decode step with all requests generating decode_query_len tokens.
+     """
+     num_spec_steps = model_runner.num_speculative_steps
+-    # Use 1 + num_spec_steps + 1 tokens so the prefill batch's per-request
+-    # query length exceeds decode_query_len (= 1 + num_spec_steps), preventing
+-    # it from being misclassified as a uniform decode batch.
+-    prompt_len = 2 + num_spec_steps
++    decode_query_len = model_runner.decode_query_len
++    # Use decode_query_len + 1 tokens so the prefill batch's per-request query
++    # length exceeds decode_query_len, preventing it from being misclassified as
++    # a uniform decode batch.
++    prompt_len = decode_query_len + model_runner.decode_query_len
+     prompt_token_ids = list(range(prompt_len))
+-    # After prefill, decode generates 1 verified + num_spec_steps draft tokens.
+-    decode_len = prompt_len + 1 + num_spec_steps
++    # After prefill, decode generates decode_query_len tokens.
++    decode_len = prompt_len + decode_query_len
+ 
+     kv_cache_groups = model_runner.kv_cache_config.kv_cache_groups
+     num_kv_cache_groups = len(kv_cache_groups)
+@@ -57,7 +60,7 @@ def warmup_kernels(
+     num_reqs = min(
+         model_runner.scheduler_config.max_num_seqs,
+         model_runner.scheduler_config.max_num_batched_tokens
+-        // max(prompt_len, 1 + num_spec_steps),
++        // max(prompt_len, decode_query_len),
+         # Reserve block 0 (null block) and ensure we have enough blocks.
+         max(1, (model_runner.kv_cache_config.num_blocks - 1) // max_blocks_per_req),
+     )
+@@ -71,6 +74,27 @@ def warmup_kernels(
+     else:
+         sampling_params = SamplingParams.for_sampler_warmup()
+         pooling_params = None
++        # NOTE(xpu-port): DiffusionGemma has canvas_length=256, so the warmup
++        # decode_query_len (==canvas_length) makes the dummy prompt ~512 tokens;
++        # combined with the 262k vocab, the prompt-logprobs warmup chunk
++        # (512 x 262144 fp32) exhausts Level Zero resources on XPU
++        # (UR_RESULT_ERROR_OUT_OF_RESOURCES). Prompt-logprobs warmup is only a
++        # kernel pre-warm and is not needed to serve requests, so skip it for
++        # diffusion models (the kernel still JIT-warms on first real use).
++        if (
++            getattr(model_runner.model_config, "is_diffusion", False)
++            and os.environ.get("DISABLE_DIFFUSION_WARMUP_TRIM", "0") != "1"
++        ):
++            sampling_params.prompt_logprobs = None
++            # NOTE(xpu-port): also skip sample-logprobs warmup. With logprobs
++            # set, DiffusionGemma's sampler materializes the full-vocab
++            # temperature-scaled logits (torch.cat -> [num_decode, CL, 262k]
++            # fp32, see diffusion_gemma._compiled_sample / _want_scaled). Under
++            # cudagraph capture (VLLM_XPU_ENABLE_XPU_GRAPH=1) the post-capture
++            # warmup launch of that 262k path trips Level Zero error 40
++            # (UR_RESULT_ERROR_OUT_OF_RESOURCES). Like prompt-logprobs above,
++            # this is warmup-only; the kernel JIT-warms on first real use.
++            sampling_params.logprobs = None
+ 
+     # Assign distinct block IDs per request per group. 0 null block, start from 1.
+     next_block_id = 1
+@@ -79,7 +103,7 @@ def warmup_kernels(
+         nonlocal next_block_id
+         return list(range(next_block_id, next_block_id := next_block_id + num_blocks))
+ 
+-    # Step 1: Prefill all requests with 2 + num_spec_steps prompt tokens each.
++    # Step 1: Prefill all requests with 1 + decode_query_len prompt tokens each.
+     new_reqs = [
+         NewRequestData.from_request(
+             Request(req_ids[i], prompt_token_ids, sampling_params, pooling_params),
+@@ -117,7 +141,7 @@ def warmup_kernels(
+ 
+         worker_sample_tokens(grammar_output)
+ 
+-        # Step 2: Decode all requests with 1 + num_spec_steps tokens each.
++        # Step 2: Decode all requests with decode_query_len tokens each.
+         cached_req_data = CachedRequestData.make_empty()
+         cached_req_data.req_ids = list(req_ids)
+         cached_req_data.num_computed_tokens = [prompt_len] * num_reqs
+@@ -131,7 +155,7 @@ def warmup_kernels(
+         decode_output = SchedulerOutput.make_empty()
+         decode_output.scheduled_cached_reqs = cached_req_data
+         decode_output.num_scheduled_tokens = {
+-            req_id: 1 + num_spec_steps for req_id in req_ids
++            req_id: decode_query_len for req_id in req_ids
+         }
+         if num_spec_steps > 0:
+             decode_output.scheduled_spec_decode_tokens = {
 diff --git a/vllm/v1/worker/mamba_utils.py b/vllm/v1/worker/mamba_utils.py
 index c832389b1..241860f9c 100644
 --- a/vllm/v1/worker/mamba_utils.py

--- a/vllm/patches/vllm_xpu_kernels.patch
+++ b/vllm/patches/vllm_xpu_kernels.patch
@@ -1,5 +1,5 @@
 diff --git a/csrc/flash_attn/flash_api.cpp b/csrc/flash_attn/flash_api.cpp
-index 8d12b68..9cc057b 100644
+index 8d12b68..7c0e824 100644
 --- a/csrc/flash_attn/flash_api.cpp
 +++ b/csrc/flash_attn/flash_api.cpp
 @@ -118,7 +118,11 @@ std::vector<at::Tensor> mha_varlen_fwd(
@@ -25,17 +25,140 @@ index 8d12b68..9cc057b 100644
    } else if (max_seqlen_q > 1) {
      if (!out_.has_value()) {
        out = torch::empty_like(q);
-@@ -262,7 +267,8 @@ std::vector<at::Tensor> mha_varlen_fwd(
+@@ -238,6 +243,18 @@ std::vector<at::Tensor> mha_varlen_fwd(
+                             cu_seqlens_q.slice(0, 0, batch_size);
+     at::Tensor is_prefill_mask = seq_lens_q.gt(1);
+     std::optional<const at::Tensor> is_prefill_opt = is_prefill_mask;
++    // Whether the mixed batch actually contains any decode sequence
++    // (seq_len_q == 1). When every sequence is prefill (seq_len_q > 1), the
++    // paged_decode kernel below would launch but skip all batches via its
++    // is_prefill mask -- yet it still requests per-WG SLM proportional to
++    // q_packed (= num_heads_q / num_heads_kv) * head_size_vo. For head_dim=512
++    // with a large GQA group (e.g. gemma-4 full-attn single-card: 16 q-heads /
++    // 1 kv-head), that SLM exceeds the Intel Xe per-WG limit and the launch
++    // fails with UR_RESULT_ERROR_OUT_OF_RESOURCES even though the kernel has no
++    // work to do. Skip the decode launch entirely when there are no decode
++    // sequences (it is a no-op in that case anyway).
++    bool has_decode = (seq_lens_q.numel() > 0) &&
++                      (seq_lens_q.eq(1).any().item<bool>());
+ 
+     cutlass_chunk_prefill_interface(
+         queue,
+@@ -262,58 +279,61 @@ std::vector<at::Tensor> mha_varlen_fwd(
          is_local,
          is_sink,
          softmax_lse_opt,
 -        is_prefill_opt);
+-
+-    // Paged decode: processes only decode batches (skips prefill)
+-    int eff_window_left =
+-        window_size_left == -1 ? max_seqlen_k : window_size_left;
+-    int eff_window_right =
+-        window_size_right == -1 ? max_seqlen_k : window_size_right;
+-    int effective_seqlen_k =
+-        is_local ? std::min(max_seqlen_k, eff_window_left + 1) : max_seqlen_k;
+-
+-    int num_tokens = batch_size;
+-    int num_heads_q = q.size(1);
+-    int head_dim = q.size(2);
+-    int num_heads_kv = k.size(2);
+-    int kv_block_size = k.size(1);
+-
+-    int num_kv_splits = 1;
+-    at::Tensor tmp_out = out;
+-    at::Tensor decode_max_logits = at::empty(
+-        {num_tokens, num_heads_q, num_kv_splits},
+-        q.options().dtype(at::kFloat).device(q.device()));
+-    at::Tensor decode_exp_sums = at::empty(
+-        {num_tokens, num_heads_q, num_kv_splits},
+-        q.options().dtype(at::kFloat).device(q.device()));
+-
+-    cutlass_paged_decode_interface(
+-        queue,
+-        q,
+-        k,
+-        v,
+-        out,
+-        tmp_out,
+-        decode_exp_sums,
+-        decode_max_logits,
+-        block_table,
+-        cu_seqlens_q,
+-        seqlens_k,
+-        max_seqlen_q,
+-        max_seqlen_k,
+-        k_scale,
+-        v_scale,
+-        softmax_scale,
+-        softmax_sink_,
+-        eff_window_left,
+-        eff_window_right,
+-        is_varlen,
+-        is_paged,
+-        false,  // is_causal: always false for decode;
+-        is_local,
+-        is_sink,
+-        num_kv_splits,
+-        is_prefill_opt);
 +        is_prefill_opt,
 +        per_seq_causal_);
- 
-     // Paged decode: processes only decode batches (skips prefill)
-     int eff_window_left =
-@@ -439,7 +445,8 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
++
++    if (has_decode) {
++        // Paged decode: processes only decode batches (skips prefill)
++      int eff_window_left =
++          window_size_left == -1 ? max_seqlen_k : window_size_left;
++      int eff_window_right =
++          window_size_right == -1 ? max_seqlen_k : window_size_right;
++      int effective_seqlen_k =
++          is_local ? std::min(max_seqlen_k, eff_window_left + 1) : max_seqlen_k;
++
++      int num_tokens = batch_size;
++      int num_heads_q = q.size(1);
++      int head_dim = q.size(2);
++      int num_heads_kv = k.size(2);
++      int kv_block_size = k.size(1);
++
++      int num_kv_splits = 1;
++      at::Tensor tmp_out = out;
++      at::Tensor decode_max_logits = at::empty(
++          {num_tokens, num_heads_q, num_kv_splits},
++          q.options().dtype(at::kFloat).device(q.device()));
++      at::Tensor decode_exp_sums = at::empty(
++          {num_tokens, num_heads_q, num_kv_splits},
++          q.options().dtype(at::kFloat).device(q.device()));
++
++      cutlass_paged_decode_interface(
++          queue,
++          q,
++          k,
++          v,
++          out,
++          tmp_out,
++          decode_exp_sums,
++          decode_max_logits,
++          block_table,
++          cu_seqlens_q,
++          seqlens_k,
++          max_seqlen_q,
++          max_seqlen_k,
++          k_scale,
++          v_scale,
++          softmax_scale,
++          softmax_sink_,
++          eff_window_left,
++          eff_window_right,
++          is_varlen,
++          is_paged,
++          false,  // is_causal: always false for decode;
++          is_local,
++          is_sink,
++          num_kv_splits,
++          is_prefill_opt);
++    }
+   } else {
+     // Normalize -1 (unbounded) to max_seqlen_k for kernel masking logic
+     // In decode phase the window_size_right doesn't have effect
+@@ -439,7 +459,8 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
        "float softmax_scale, Tensor? softmax_sink, bool zero_tensors, "
        "bool is_causal, int window_size_left, int window_size_right, float "
        "softcap, bool return_softmax, "
@@ -84,10 +207,10 @@ index 65d2f24..c2acd2d 100644
  void cutlass_paged_decode_interface(
      sycl::queue& queue,
 diff --git a/csrc/xpu/attn/xe_2/chunk_prefill.hpp b/csrc/xpu/attn/xe_2/chunk_prefill.hpp
-index 44f9dd0..f5f38bb 100644
+index 44f9dd0..574df8e 100644
 --- a/csrc/xpu/attn/xe_2/chunk_prefill.hpp
 +++ b/csrc/xpu/attn/xe_2/chunk_prefill.hpp
-@@ -74,6 +74,11 @@ struct chunk_prefill_args_t {
+@@ -74,8 +74,24 @@ struct chunk_prefill_args_t {
    int o_stride_batch = 0;
    // per-batch mask: true = prefill, false = decode; nullptr = process all
    void* is_prefill = nullptr;
@@ -98,8 +221,21 @@ index 44f9dd0..f5f38bb 100644
 +  void* per_seq_causal = nullptr;
  };
  
++// XPU-graph-safe kernel entry: receives the SLM block as an explicit char* (a
++// sycl::local_accessor allocated by the launch layer when a compat::local_mem_size
++// is supplied), instead of cutlass::device_kernel which fetches
++// work_group_scratch_memory (un-capturable by SYCL command graph). A dedicated
++// free function keeps the launch<auto F> non-type template parameter unambiguous.
++template <typename Op>
++void chunk_prefill_graph_safe_kernel(typename Op::Params params, char* smem) {
++  Op op;
++  op(params, smem);
++}
++
  template <class FMHAKernel, bool isVarLen>
-@@ -174,7 +179,8 @@ struct KernelLauncher {
+ struct KernelLauncher {
+   using StrideQ = typename FMHAKernel::StrideQ;
+@@ -174,7 +190,8 @@ struct KernelLauncher {
           reinterpret_cast<ElementQ*>(args.sm_sink),
           args.softmax_lse,
           args.lse_stride,
@@ -109,6 +245,30 @@ index 44f9dd0..f5f38bb 100644
          {args.sm_scale,
           args.k_scale,
           args.v_scale,
+@@ -218,16 +235,16 @@ struct KernelLauncher {
+     const auto sycl_block = compat::dim3(block.x, block.y, block.z);
+     const auto sycl_grid = compat::dim3(grid.x, grid.y, grid.z);
+ 
+-    // Launch parameters depend on whether SYCL compiler supports work-group
+-    // scratch memory extension
+-    compat::experimental::launch_properties launch_props{
+-        syclex::work_group_scratch_size(smem_size),
+-    };
++    // XPU-graph: static local_accessor (compat::local_mem_size) instead of
++    // work_group_scratch_size so the prefill/chunk-prefill kernel is
++    // SYCL-command-graph-capturable. SLM size == FMHAKernel::SharedStorageSize
++    // (compile-time constant). Mirrors paged_decode.hpp; kernel body unchanged.
+     compat::experimental::kernel_properties kernel_props{
+         syclex::sub_group_size<cute::intel::sg_size>, intelex::grf_size<256>};
+     compat::experimental::launch_policy policy{
+-        sycl_grid, sycl_block, launch_props, kernel_props};
+-    compat::experimental::launch<cutlass::device_kernel<FMHAKernel>>(
++        sycl_grid, sycl_block, kernel_props,
++        compat::experimental::local_mem_size(smem_size)};
++    compat::experimental::launch<chunk_prefill_graph_safe_kernel<FMHAKernel>>(
+         policy, queue, params);
+   }
+ };
 diff --git a/csrc/xpu/attn/xe_2/chunk_prefill_utils.hpp b/csrc/xpu/attn/xe_2/chunk_prefill_utils.hpp
 index 0561534..aae4154 100644
 --- a/csrc/xpu/attn/xe_2/chunk_prefill_utils.hpp
@@ -121,29 +281,38 @@ index 0561534..aae4154 100644
 +    std::optional<const at::Tensor>& is_prefill,
 +    std::optional<const at::Tensor>& per_seq_causal);
 diff --git a/csrc/xpu/attn/xe_2/collective/chunk_prefill_mainloop.hpp b/csrc/xpu/attn/xe_2/collective/chunk_prefill_mainloop.hpp
-index f4f7344..e6ec3bd 100644
+index f4f7344..f8ff2ae 100644
 --- a/csrc/xpu/attn/xe_2/collective/chunk_prefill_mainloop.hpp
 +++ b/csrc/xpu/attn/xe_2/collective/chunk_prefill_mainloop.hpp
-@@ -269,7 +269,8 @@ struct FMHAFwdMainloop<
+@@ -269,7 +269,15 @@ struct FMHAFwdMainloop<
        int blk_k1_causal,
        int thr_id,
        int seq_len,
 -      int full_tile_offset) {
 +      int full_tile_offset,
-+      bool seq_is_causal = true) {  // per-seq: false => bidirectional
++      bool seq_is_causal = true,  // per-seq: false => bidirectional
++      // True ONLY for a genuine per-sequence bidirectional sequence
++      // (DiffusionGemma: compiled CausalMask=true but per_seq_causal[idx_b]
++      // ==false). For a normal causal sliding-window layer the kernel is
++      // compiled with CausalMask=false, so seq_is_causal is false too, but the
++      // window must stay one-sided (local_right) -- this flag keeps the two
++      // cases apart.
++      bool is_per_seq_bidir = false) {
      using namespace sycl::ext::oneapi::this_work_item;
  
      // Short dimension names:
-@@ -469,12 +470,18 @@ struct FMHAFwdMainloop<
+@@ -469,12 +477,20 @@ struct FMHAFwdMainloop<
          Tensor gP = local_tile(
              cPgP, take<0, 2>(TileShapeQK{}), make_coord(get<0>(blk_qv), K));
          auto cS_thread = thr_mma_qk.partition_C(gP);
-+        // For a bidirectional sequence (per-seq causal == false) inside a
-+        // causal-windowed kernel, the right window is one-sided (local_right
-+        // is 0 for causal sliding layers), which would wrongly re-impose
-+        // causal masking. Make the window SYMMETRIC for bidirectional seqs by
-+        // mirroring local_left on the right.
-+        int eff_right = seq_is_causal ? params.local_right : params.local_left;
++        // Symmetrize the window (mirror local_left on the right) ONLY for a
++        // genuine per-sequence bidirectional sequence (DiffusionGemma). A
++        // normal causal sliding-window layer is compiled CausalMask=false, so
++        // seq_is_causal is false as well, but its window is one-sided
++        // (local_right==0) and must NOT be symmetrized -- doing so would drop
++        // causal masking entirely and attend to future tokens.
++        int eff_right =
++            is_per_seq_bidir ? params.local_left : params.local_right;
          CUTLASS_PRAGMA_UNROLL
          for (int i = 0; i < tSrS.size(); ++i) {
            int row_idx = get<0>(cS_thread(i));
@@ -154,6 +323,68 @@ index f4f7344..e6ec3bd 100644
            if (left_mask || right_mask) {
              tSrS(i) = ElementS(-INFINITY);
            }
+diff --git a/csrc/xpu/attn/xe_2/fmha_utils.hpp b/csrc/xpu/attn/xe_2/fmha_utils.hpp
+index 27ad8bc..96ac672 100644
+--- a/csrc/xpu/attn/xe_2/fmha_utils.hpp
++++ b/csrc/xpu/attn/xe_2/fmha_utils.hpp
+@@ -154,6 +154,22 @@ struct chunk_policy_head512_b16 {
+   using SubgroupLayoutQK = Layout<Shape<_32, _1, _1>>;
+ };
+ 
++// Cap the per-work-group V (output head_dim) tile at 256 elements. The decode
++// epilogue's cross-SG reduction SLM buffer is sized q_packed * V_tile *
++// SGPerWG * sizeof(float); at head_dim=512 with a large GQA group
++// (q_packed=16) the full-512 V tile needs ~128 KiB, exceeding the Intel Xe
++// per-work-group SLM cap and failing the launch with
++// UR_RESULT_ERROR_OUT_OF_RESOURCES. Capping the V tile at 256 makes the decode
++// tile scheduler emit grid.x = ceil_div(head_size_vo, 256) work-groups (2 for
++// head_dim=512), each owning an independent 256-wide output slice (the V
++// dimension is the output feature axis -> embarrassingly parallel, no cross-WG
++// reduction; softmax over K is recomputed per slice). This mirrors how the
++// chunk_prefill head512 policy splits V via grid.x=2. For head_dim<=256 the cap
++// is a no-op, so smaller head sizes are unchanged.
++template <typename head_dim>
++using decode_v_tile_t =
++    cute::conditional_t<(head_dim::value > 256), _256, head_dim>;
++
+ // define decode policy
+ template <typename q_packed, typename head_dim, typename kv_tile>
+ struct decode_policy_qpacked_head {
+@@ -169,7 +185,7 @@ template <typename q_packed, typename head_dim>
+ struct decode_policy_qpacked_head<q_packed, head_dim, _16> {
+   using ShapeQK = Shape<q_packed, _16, _64>;
+   using ShapePV = Shape<q_packed, _32, _16>;
+-  using ShapeOut = Shape<q_packed, head_dim>;
++  using ShapeOut = Shape<q_packed, decode_v_tile_t<head_dim>>;
+   using SubgroupLayoutQK = Layout<Shape<_1, _1, _1>>;
+ };
+ 
+@@ -178,7 +194,7 @@ template <typename q_packed, typename head_dim>
+ struct decode_policy_qpacked_head<q_packed, head_dim, _32> {
+   using ShapeQK = Shape<q_packed, _32, _64>;
+   using ShapePV = Shape<q_packed, _32, _32>;
+-  using ShapeOut = Shape<q_packed, head_dim>;
++  using ShapeOut = Shape<q_packed, decode_v_tile_t<head_dim>>;
+   using SubgroupLayoutQK = Layout<Shape<_1, _2, _1>>;
+ };
+ 
+@@ -190,7 +206,7 @@ template <typename q_packed, typename head_dim>
+ struct decode_policy_qpacked_head<q_packed, head_dim, _64> {
+   using ShapeQK = Shape<q_packed, _64, _64>;
+   using ShapePV = Shape<q_packed, _32, _64>;
+-  using ShapeOut = Shape<q_packed, head_dim>;
++  using ShapeOut = Shape<q_packed, decode_v_tile_t<head_dim>>;
+   using SubgroupLayoutQK = Layout<Shape<_1, _4, _1>>;
+ };
+ 
+@@ -206,6 +222,6 @@ template <typename q_packed, typename head_dim>
+ struct decode_policy_qpacked_head<q_packed, head_dim, _128> {
+   using ShapeQK = Shape<q_packed, _128, _64>;
+   using ShapePV = Shape<q_packed, _32, _128>;
+-  using ShapeOut = Shape<q_packed, head_dim>;
++  using ShapeOut = Shape<q_packed, decode_v_tile_t<head_dim>>;
+   using SubgroupLayoutQK = Layout<Shape<_1, _8, _1>>;
+ };
 diff --git a/csrc/xpu/attn/xe_2/fmha_xe2.cpp b/csrc/xpu/attn/xe_2/fmha_xe2.cpp
 index 4286270..32995e4 100644
 --- a/csrc/xpu/attn/xe_2/fmha_xe2.cpp
@@ -210,7 +441,7 @@ index a666921..f91c3b1 100644
 +    std::optional<const at::Tensor>& is_prefill,
 +    std::optional<const at::Tensor>& per_seq_causal);
 diff --git a/csrc/xpu/attn/xe_2/kernel/chunk_prefill_kernel.hpp b/csrc/xpu/attn/xe_2/kernel/chunk_prefill_kernel.hpp
-index 90bd62b..4ac3f36 100644
+index 90bd62b..9f6b2dd 100644
 --- a/csrc/xpu/attn/xe_2/kernel/chunk_prefill_kernel.hpp
 +++ b/csrc/xpu/attn/xe_2/kernel/chunk_prefill_kernel.hpp
 @@ -153,6 +153,9 @@ class XeFMHAFwdKernel {
@@ -223,7 +454,7 @@ index 90bd62b..4ac3f36 100644
    };
    using KernelParams = KernelArguments;
  
-@@ -271,9 +274,17 @@ class XeFMHAFwdKernel {
+@@ -271,9 +274,23 @@ class XeFMHAFwdKernel {
        int seq_coord =
            cute::min(seq_len_qo, (blk_q * get<0>(TileShapeQK{}) + q_offset_sg));
  
@@ -234,6 +465,12 @@ index 90bd62b..4ac3f36 100644
 +      const bool seq_is_causal =
 +          CausalMask &&
 +          (p.per_seq_causal == nullptr || p.per_seq_causal[idx_b]);
++      // Genuine per-sequence bidirectional sequence: only when a per_seq_causal
++      // mask is actually supplied (DiffusionGemma) AND this sequence is marked
++      // bidirectional. Normal causal sliding-window layers have
++      // per_seq_causal==nullptr and must NOT be treated as bidirectional.
++      const bool is_per_seq_bidir =
++          (p.per_seq_causal != nullptr) && !p.per_seq_causal[idx_b];
 +
        // calc sg level seq_len_kv
        const int seq_len =
@@ -242,7 +479,7 @@ index 90bd62b..4ac3f36 100644
                ? LocalMask
                      ? cute::min(
                            seq_len_kv,
-@@ -290,9 +301,12 @@ class XeFMHAFwdKernel {
+@@ -290,9 +307,12 @@ class XeFMHAFwdKernel {
                      get<1>(TileShapeQK{})
                : 0;
        const int k_blocks = cute::ceil_div(seq_len, get<1>(TileShapeQK{}));
@@ -257,16 +494,87 @@ index 90bd62b..4ac3f36 100644
  
        int offset_q = 0, offset_k = 0, offset_v = 0, offset_o = 0;
        if constexpr (is_var_len) {
-@@ -355,7 +369,8 @@ class XeFMHAFwdKernel {
+@@ -355,7 +375,9 @@ class XeFMHAFwdKernel {
            k_blocks_causal,
            thr_id,
            seq_len,
 -          full_tile_offset);
 +          full_tile_offset,
-+          seq_is_causal);
++          seq_is_causal,
++          is_per_seq_bidir);
  
        // return softmax_lse
        if constexpr (SoftmaxLSE) {
+diff --git a/csrc/xpu/attn/xe_2/paged_decode.hpp b/csrc/xpu/attn/xe_2/paged_decode.hpp
+index 61ad263..d34bbd5 100644
+--- a/csrc/xpu/attn/xe_2/paged_decode.hpp
++++ b/csrc/xpu/attn/xe_2/paged_decode.hpp
+@@ -138,6 +138,18 @@ struct paged_decode_args_t {
+   int64_t q_stride_batch = 0;
+ };
+ 
++// XPU-graph-safe kernel entry: receives the SLM block as an explicit char* (a
++// sycl::local_accessor allocated by the launch layer when a compat::local_mem_size
++// is supplied), instead of cutlass::device_kernel which fetches
++// work_group_scratch_memory (un-capturable by SYCL command graph). A dedicated
++// free function (not an overload of cutlass::device_kernel) keeps the
++// `launch<auto F>` non-type template-parameter unambiguous.
++template <typename Op>
++void paged_decode_graph_safe_kernel(typename Op::Params params, char* smem) {
++  Op op;
++  op(params, smem);
++}
++
+ template <class FMHAKernel, class ReductionSplitKernel, bool isVarLen>
+ struct DecodeKernelLauncher {
+   using StrideQ = typename FMHAKernel::StrideQ;
+@@ -399,16 +411,18 @@ struct DecodeKernelLauncher {
+     const auto sycl_block = compat::dim3(block.x, block.y, block.z);
+     const auto sycl_grid = compat::dim3(grid.x, grid.y, grid.z);
+ 
+-    // Launch parameters depend on whether SYCL compiler supports work-group
+-    // scratch memory extension
+-    compat::experimental::launch_properties launch_props{
+-        syclex::work_group_scratch_size(smem_size),
+-    };
++    // XPU-graph: use a static local_accessor (compat::local_mem_size) instead
++    // of work_group_scratch_size. The scratch-memory extension cannot be
++    // captured by a SYCL command graph; local_accessor (SLM) can. The launch
++    // layer allocates a sycl::local_accessor of smem_size bytes and calls the
++    // device_kernel(params, local_ptr<char>) overload. smem_size ==
++    // FMHAKernel::SharedStorageSize is a compile-time constant.
+     compat::experimental::kernel_properties kernel_props{
+         syclex::sub_group_size<cute::intel::sg_size>, intelex::grf_size<256>};
+     compat::experimental::launch_policy policy{
+-        sycl_grid, sycl_block, launch_props, kernel_props};
+-    compat::experimental::launch<cutlass::device_kernel<FMHAKernel>>(
++        sycl_grid, sycl_block, kernel_props,
++        compat::experimental::local_mem_size(smem_size)};
++    compat::experimental::launch<paged_decode_graph_safe_kernel<FMHAKernel>>(
+         policy, queue, params);
+ 
+     // event.wait();
+@@ -420,17 +434,14 @@ struct DecodeKernelLauncher {
+       const auto reduce_sycl_block = compat::dim3(block.x, block.y, block.z);
+       const auto reduce_sycl_grid =
+           compat::dim3(reduce_grid.x, reduce_grid.y, reduce_grid.z);
+-      compat::experimental::launch_properties launch_props_reduce{
+-          syclex::work_group_scratch_size(reduce_smem_size),
+-      };
+       compat::experimental::launch_policy reduce_policy{
+           reduce_sycl_grid,
+           reduce_sycl_block,
+-          launch_props_reduce,
+-          kernel_props};
++          kernel_props,
++          compat::experimental::local_mem_size(reduce_smem_size)};
+ 
+       compat::experimental::launch<
+-          cutlass::device_kernel<ReductionSplitKernel>>(
++          paged_decode_graph_safe_kernel<ReductionSplitKernel>>(
+           reduce_policy, queue, reduce_params);
+       // reduce_event.wait();
+     }
 diff --git a/csrc/xpu/gdn_attn/xe_2/chunk_causal_conv1d_xe2.hpp b/csrc/xpu/gdn_attn/xe_2/chunk_causal_conv1d_xe2.hpp
 index b9729cd..20fff80 100644
 --- a/csrc/xpu/gdn_attn/xe_2/chunk_causal_conv1d_xe2.hpp


### PR DESCRIPTION
## Summary

Regenerate the two build patches used to build the `v0.21.0-b8.4-0630` image.

| Patch | Source | Base | Size |
|-------|--------|------|------|
| `vllm_for_multi_arc.patch` | intel-sandbox/llm-scaler-vllm-xpu `downstream/release/v0.21.0` (`c2785fc`) | vllm-project/vllm `v0.21.0` (`ad7125a`) | 11,984 lines |
| `vllm_xpu_kernels.patch` | analytics-zoo/vllm-xpu-kernels `feat/per-seq-causal-mixed-attn` (`6cc525f`) | Dockerfile-pinned base `3cab97a` | 918 lines, 16 files |

The kernels patch adds:
- per-sequence causal mask to chunk-prefill flash (single launch)
- gemma xpu graph (prefill and decode)
- gelu_tanh activation wiring in XpuFusedMoe dispatch

## Verification

- Both patches verified to apply cleanly against their respective base commits (`git apply --check`).
- The `vllm_xpu_kernels.patch` base commit `3cab97a` is unchanged (still pinned in `vllm/docker/Dockerfile`); the patch is regenerated against that same base, no Dockerfile change needed.
- Image `amr-registry.caas.intel.com/intelanalytics/llm-scaler-vllm:v0.21.0-b8.4-0630` built and pushed with these patches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)