### PR TITLE
vllm: rebuild Docker image as 2-stage OMIX build (25GB → 17.2GB)

### DIFF
--- a/vllm/docker/Dockerfile
+++ b/vllm/docker/Dockerfile
@@ -139,7 +139,8 @@ SHELL ["bash", "-c"]
 WORKDIR /llm
 
 ENV PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/xpu" \
-    PIP_DISABLE_PIP_VERSION_CHECK=1
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1
 
 # --- thin runtime OS deps (media/audio + numactl); NO build-essential / UCX / NIXL ---
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -180,11 +181,20 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # which clobbers the base image's `triton-xpu` libtriton.so and drops the `intel`
 # backend (breaks `import triton.backends`).  Restore the XPU triton, as the legacy
 # build did.  --no-deps keeps it from dragging anything else.
-# Do NOT `strip` the result: `strip --strip-debug` also removes the `intel` binding.
+#
+# Then shrink triton IN THIS SAME LAYER (a later RUN can't reclaim space from here):
+#   * strip --strip-debug libtriton.so: 1.16GB -> ~228MB.  Safe on the *correctly
+#     installed* triton-xpu (validated: intel backend imports + JIT compiles on XPU).
+#     The earlier failure was stripping the CUDA-clobbered .so, not the strip itself.
+#   * dedup the two identical libMLIRDialectPlugin.so copies (500MB each) to a symlink.
 RUN --mount=type=cache,target=/root/.cache/uv \
     pip uninstall -y triton triton-xpu || true && \
     pip install --no-deps triton-xpu==3.7.0 \
-        --extra-index-url https://download.pytorch.org/whl/xpu
+        --extra-index-url https://download.pytorch.org/whl/xpu && \
+    TRITON=/opt/venv/lib/python3.12/site-packages/triton && \
+    strip --strip-debug ${TRITON}/_C/libtriton.so && \
+    rm -f ${TRITON}/plugins/libMLIRDialectPlugin.so.22.0git && \
+    ln -s libMLIRDialectPlugin.so ${TRITON}/plugins/libMLIRDialectPlugin.so.22.0git
 
 # --- sanity: native modules import & link, triton backends load, int4 quant lib loads ---
 RUN python3 -c "import torch, vllm, custom_esimd_kernels_vllm, vllm_xpu_kernels; print('torch', torch.__version__, 'vllm', vllm.__version__)" && \

--- a/vllm/docker/Dockerfile
+++ b/vllm/docker/Dockerfile
@@ -1,184 +1,204 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
+#
+# Multi-stage OMIX build of llm-scaler-vllm (Intel XPU).
+#
+#   builder : intel/omix:latest-devel-ubuntu24.04   -- oneAPI 2025.3 DPC++ compiler
+#                                                       + oneCCL/oneDNN/oneMKL.  Compiles
+#                                                       all native wheels.  NOT shipped.
+#   runtime : intel/pytorch:xpu-2.11.0-ubuntu24.04  -- torch 2.11.0+xpu + GPU UMD driver
+#                                                       in /opt/venv.  No compiler.  Shipped.
+#
+# Why: the legacy single-base build (llm-scaler-platform) carried the whole oneAPI
+# toolchain into the final image (~25-34GB).  Here the compiler lives only in the
+# builder stage; the runtime stage receives pre-built wheels, so the shipped image
+# is much smaller.
+#
+# Scope ("lean core"): vLLM + custom ESIMD kernels + vllm-xpu-kernels + core serving
+# deps + bigdl-core (ships vllm_int4_for_multi_arc.so used by the sym_int4 path).
+# Dropped vs legacy: MinerU, UCX/NIXL (PD disaggregation), triton reinstall.
+#
+# Build context root MUST be the `vllm/` dir (so ./patches, ./custom-esimd-kernels-vllm
+# and ./examples resolve).
 
-# ======== Base Stage ========
-FROM amr-registry.caas.intel.com/intelanalytics/llm-scaler-platform:26.24.9.1 AS vllm-base
+# =========================================================================
+# Stage 1: builder -- compile every native wheel with the oneAPI toolchain
+# =========================================================================
+FROM intel/omix:latest-devel-ubuntu24.04 AS builder
 
-ARG https_proxy
 ARG http_proxy
-ARG PYTHON_VERSION=3.12
+ARG https_proxy
+ARG no_proxy
+ENV http_proxy=${http_proxy} \
+    https_proxy=${https_proxy} \
+    no_proxy=${no_proxy}
 
-WORKDIR /llm/
+# vllm-xpu-kernels pinned base commit (identical to legacy build).
+ARG VLLM_XPU_KERNELS_COMMIT=3cab97a
 
-# Install only packages not already in base image
+SHELL ["bash", "-c"]
+
+# --- build tooling (the oneAPI DPC++ compiler is already in the OMIX devel base) ---
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     apt-get update -y && \
     apt-get install -y --no-install-recommends --fix-missing \
-    curl \
-    ffmpeg \
-    git \
-    libsndfile1 \
-    libsm6 \
-    libxext6 \
-    libgl1 \
-    libaio-dev \
-    lsb-release \
-    numactl \
-    wget \
-    linux-libc-dev \
-    python3.12-dev
+        git curl ca-certificates \
+        python3-dev python3-venv python3-pip \
+        ninja-build cmake pkg-config numactl
 
-# Setup uv and Python virtual environment
-ENV PATH="/root/.local/bin:$PATH"
-ENV VIRTUAL_ENV="/opt/venv"
-ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    uv venv --python ${PYTHON_VERSION} --seed ${VIRTUAL_ENV}
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+# --- isolated build venv (avoid OMIX system-python PEP 668 block; clean resolution) ---
+ENV VIRTUAL_ENV=/opt/buildenv
+RUN python3 -m venv ${VIRTUAL_ENV}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
-SHELL ["bash", "-c"]
+# --- uv for fast, deterministic installs (matches legacy build) ---
+ENV PATH="/root/.local/bin:${PATH}"
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 
-WORKDIR /llm/vllm
+ENV UV_HTTP_TIMEOUT=500 \
+    PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/xpu" \
+    UV_EXTRA_INDEX_URL="https://download.pytorch.org/whl/xpu" \
+    UV_INDEX_STRATEGY="unsafe-best-match" \
+    UV_LINK_MODE="copy"
 
-# Configure package index for XPU
-ENV UV_HTTP_TIMEOUT=500
-ENV PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/xpu"
-ENV UV_EXTRA_INDEX_URL="https://download.pytorch.org/whl/xpu"
-ENV UV_INDEX_STRATEGY="unsafe-best-match"
-ENV UV_LINK_MODE="copy"
+# --- torch MUST match the runtime base (2.11.0+xpu) so SyclExtension .so files link
+#     against the same libtorch ABI the runtime ships (rpath $ORIGIN/../../torch/lib) ---
+RUN --mount=type=cache,target=/root/.cache/uv \
+    pip install --upgrade pip wheel setuptools && \
+    uv pip install torch==2.11.0+xpu torchaudio torchvision \
+        --index-url https://download.pytorch.org/whl/xpu
 
-# Set vLLM build environment
-ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib/"
+ENV WHEELS=/wheels
+RUN mkdir -p ${WHEELS}
+
 ENV VLLM_TARGET_DEVICE=xpu
-ENV VLLM_WORKER_MULTIPROC_METHOD=spawn
 
-# Clone + patch + build vLLM v0.21.0
+# ---------------------------------------------------------------------------
+# 1a. vLLM v0.21.0 + multi-arc patch  ->  wheel
+# ---------------------------------------------------------------------------
 COPY ./patches/vllm_for_multi_arc.patch /tmp/
 RUN --mount=type=cache,target=/root/.cache/uv \
-    git clone --depth 1 -b v0.21.0 https://github.com/vllm-project/vllm.git /llm/vllm && \
-    cd /llm/vllm && \
-    git apply /tmp/vllm_for_multi_arc.patch || true && \
-    uv pip install --upgrade pip && \
+    set -eo pipefail && \
+    source /opt/intel/oneapi/setvars.sh --force && \
+    git clone --depth 1 -b v0.21.0 https://github.com/vllm-project/vllm.git /src/vllm && \
+    cd /src/vllm && \
+    git apply /tmp/vllm_for_multi_arc.patch && \
     uv pip install -r requirements/xpu.txt && \
     uv pip install grpcio-tools protobuf nanobind && \
-    source /opt/intel/oneapi/ccl/2021.15/env/vars.sh --force && \
-    export CMAKE_PREFIX_PATH="$(python3 -c 'import site; print(site.getsitepackages()[0])'):${CMAKE_PREFIX_PATH}" && \
-    uv pip install --no-build-isolation .
+    export CMAKE_PREFIX_PATH="$(python3 -c 'import site; print(site.getsitepackages()[0])'):${CMAKE_PREFIX_PATH:-}" && \
+    pip wheel --no-build-isolation --no-deps . -w ${WHEELS}
 
-# Install unified custom ESIMD kernels
-COPY ./custom-esimd-kernels-vllm /tmp/custom-esimd-kernels-vllm
+# ---------------------------------------------------------------------------
+# 1b. custom ESIMD kernels  ->  wheel  (TORCH_XPU_ARCH_LIST=bmg-g21)
+# ---------------------------------------------------------------------------
+COPY ./custom-esimd-kernels-vllm /src/custom-esimd-kernels-vllm
 RUN --mount=type=cache,target=/root/.cache/uv \
-    cd /tmp/custom-esimd-kernels-vllm && \
+    set -eo pipefail && \
+    source /opt/intel/oneapi/setvars.sh --force && \
+    cd /src/custom-esimd-kernels-vllm && \
     TORCH_XPU_ARCH_LIST=bmg-g21 MAX_JOBS=1 python3 setup.py bdist_wheel && \
-    uv pip install dist/*.whl --no-deps && \
-    rm -rf /tmp/custom-esimd-kernels-vllm
+    cp dist/*.whl ${WHEELS}/
 
-# Build vllm-xpu-kernels
+# ---------------------------------------------------------------------------
+# 1c. vllm-xpu-kernels (patch + pinned commit)  ->  wheel
+# ---------------------------------------------------------------------------
 COPY ./patches/vllm_xpu_kernels.patch /tmp/
 RUN --mount=type=cache,target=/root/.cache/uv \
-    cd /llm && \
-    git clone https://github.com/vllm-project/vllm-xpu-kernels.git && \
-    cd vllm-xpu-kernels && \
-    git checkout 3cab97a && \
+    set -eo pipefail && \
+    source /opt/intel/oneapi/setvars.sh --force && \
+    git clone https://github.com/vllm-project/vllm-xpu-kernels.git /src/vllm-xpu-kernels && \
+    cd /src/vllm-xpu-kernels && \
+    git checkout ${VLLM_XPU_KERNELS_COMMIT} && \
     git apply /tmp/vllm_xpu_kernels.patch && \
     sed -i 's|^--extra-index-url=https://download.pytorch.org/whl/xpu|# --extra-index-url=https://download.pytorch.org/whl/xpu|' requirements.txt && \
     sed -i '/^torch==/s/^/# /' requirements.txt && \
     sed -i 's|^triton-xpu|# triton-xpu|' requirements.txt && \
     sed -i 's|^transformers|# transformers|' requirements.txt && \
     uv pip install -r requirements.txt && \
-    uv pip install --no-build-isolation . && \
-    cd /llm && \
-    rm -rf /llm/vllm-xpu-kernels /tmp/vllm_xpu_kernels.patch
+    export CMAKE_PREFIX_PATH="$(python3 -c 'import site; print(site.getsitepackages()[0])'):${CMAKE_PREFIX_PATH:-}" && \
+    pip wheel --no-build-isolation --no-deps . -w ${WHEELS}
 
-# Clone + install MinerU
-RUN --mount=type=cache,target=/root/.cache/uv \
-    git clone --depth 1 -b release-2.6.2 https://github.com/opendatalab/MinerU.git /llm/MinerU && \
-    cd /llm/MinerU && \
-    uv pip install -e .[core] && \
-    sed -i 's/kwargs.get("max_concurrency", 100)/kwargs.get("max_concurrency", 200)/' /llm/MinerU/mineru/backend/vlm/vlm_analyze.py && \
-    sed -i 's/kwargs.get("http_timeout", 600)/kwargs.get("http_timeout", 1200)/' /llm/MinerU/mineru/backend/vlm/vlm_analyze.py && \
-    uv pip uninstall opencv-python || true
+# Wheel inventory (visible in the build log for sanity).
+RUN ls -la ${WHEELS}/
 
-# Install bigdl-core
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install bigdl-core==2.4.0b2
-
-# Cleanup
-RUN rm -rf /tmp/*
-
-CMD ["bash", "-c", "source /opt/intel/oneapi/ccl/2021.15/env/vars.sh --force && exec bash"]
-
-# ======== OpenAI Serving Stage ========
-FROM vllm-base AS vllm-openai
+# =========================================================================
+# Stage 2: runtime -- lightweight serving image (no compiler, no /opt/intel/oneapi)
+# =========================================================================
+FROM intel/pytorch:xpu-2.11.0-ubuntu24.04 AS vllm-openai
 
 ARG http_proxy
 ARG https_proxy
+ARG no_proxy
+ENV http_proxy=${http_proxy} \
+    https_proxy=${https_proxy} \
+    no_proxy=${no_proxy}
 
-# Install additional dependencies for serving
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install accelerate hf_transfer 'modelscope!=1.15.0' && \
-    uv pip install librosa soundfile decord ijson && \
-    uv pip install transformers==5.8.0
+# The base already exports PATH=/opt/venv/bin:... and DEVICE=xpu.
+SHELL ["bash", "-c"]
+WORKDIR /llm
 
-# Install UCX and NIXL for distributed communication
-ARG UCX_VERSION=e5d98879705239d254ede40b4a52891850cb5349
-ARG NIXL_VERSION=0.7.0
+ENV PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/xpu" \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
 
+# --- thin runtime OS deps (media/audio + numactl); NO build-essential / UCX / NIXL ---
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-    apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
-    autoconf \
-    automake \
-    libtool \
-    pkg-config \
-    rdma-core \
-    libibverbs-dev \
-    ibverbs-utils \
-    librdmacm-dev \
-    libibumad-dev \
-    infiniband-diags \
-    perftest
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends --fix-missing \
+        ffmpeg libsndfile1 libsm6 libxext6 libgl1 numactl curl && \
+    rm -rf /var/lib/apt/lists/*
 
-ENV PKG_CONFIG_PATH=/tmp/ucx_install/lib/pkgconfig:${PKG_CONFIG_PATH}
-ENV LD_LIBRARY_PATH=/tmp/ucx_install/lib:${LD_LIBRARY_PATH}
+# --- compiled wheels from the builder stage ---
+COPY --from=builder /wheels /wheels
+
+# --- install vLLM WITH its python deps.  This resolves pure-python deps and, per
+#     requirements/xpu.txt, also pulls the upstream prebuilt vllm_xpu_kernels wheel.
+#     torch/torchvision/torchaudio/triton are already present in the base venv and
+#     stay untouched (the +xpu pins are satisfied via --extra-index-url). ---
 RUN --mount=type=cache,target=/root/.cache/uv \
-    git clone --depth 1 https://github.com/openucx/ucx /tmp/ucx_source && \
-    cd /tmp/ucx_source && git fetch --depth 1 origin "${UCX_VERSION}" && git checkout FETCH_HEAD && \
-    bash autogen.sh && \
-    ./configure --prefix=/tmp/ucx_install --with-ze=yes --enable-mt && \
-    make CFLAGS="-Wno-error=incompatible-pointer-types" -j$(nproc) && make install && \
-    git clone --depth 1 -b "${NIXL_VERSION}" https://github.com/ai-dynamo/nixl /tmp/nixl_source && \
-    cd /tmp/nixl_source && \
-    uv pip install --upgrade meson pybind11 patchelf && \
-    uv pip install -r requirements.txt && \
-    uv pip install . && \
-    rm -rf /tmp/ucx_source /tmp/nixl_source
+    pip install /wheels/vllm-*.whl \
+        --extra-index-url https://download.pytorch.org/whl/xpu
 
-# Fix triton + strip debug symbols (~1.4GB savings)
+# --- install our custom kernels LAST so they win, exactly as the legacy build did:
+#     force-reinstall overwrites the upstream prebuilt vllm_xpu_kernels with our
+#     patched build; --no-deps guarantees neither drags a second torch. ---
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip uninstall triton triton-xpu && \
-    uv pip install triton-xpu==3.7.0 && \
-    strip --strip-debug /opt/venv/lib/python3.12/site-packages/triton/_C/libtriton.so && \
-    rm -f /opt/venv/lib/python3.12/site-packages/triton/plugins/libMLIRDialectPlugin.so.22.0git && \
-    ln -s libMLIRDialectPlugin.so /opt/venv/lib/python3.12/site-packages/triton/plugins/libMLIRDialectPlugin.so.22.0git
+    pip install --no-deps --force-reinstall \
+        /wheels/custom_esimd_kernels_vllm-*.whl \
+        /wheels/vllm_xpu_kernels-*.whl && \
+    rm -rf /wheels
 
-# Remove torch-bundled oneccl to avoid conflicts with system oneCCL
-RUN uv pip uninstall oneccl oneccl-devel || true
-
-# Install test utilities
+# --- lean-core serving deps.  bigdl-core ships vllm_int4_for_multi_arc.so used by
+#     the sym_int4 path (VLLM_QUANTIZE_Q40_LIB below). ---
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install -e /llm/vllm/tests/vllm_test_utils
+    pip install transformers==5.8.0 accelerate hf_transfer 'modelscope!=1.15.0' && \
+    pip install librosa soundfile decord ijson && \
+    pip install bigdl-core==2.4.0b2
+
+# Installing the vLLM wheel's python deps pulls upstream CUDA `triton` (via xgrammar),
+# which clobbers the base image's `triton-xpu` libtriton.so and drops the `intel`
+# backend (breaks `import triton.backends`).  Restore the XPU triton, as the legacy
+# build did.  --no-deps keeps it from dragging anything else.
+# Do NOT `strip` the result: `strip --strip-debug` also removes the `intel` binding.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    pip uninstall -y triton triton-xpu || true && \
+    pip install --no-deps triton-xpu==3.7.0 \
+        --extra-index-url https://download.pytorch.org/whl/xpu
+
+# --- sanity: native modules import & link, triton backends load, int4 quant lib loads ---
+RUN python3 -c "import torch, vllm, custom_esimd_kernels_vllm, vllm_xpu_kernels; print('torch', torch.__version__, 'vllm', vllm.__version__)" && \
+    python3 -c "import triton, triton.backends; print('triton', triton.__version__, 'backends OK')" && \
+    python3 -c "import ctypes; ctypes.CDLL('/opt/venv/lib/python3.12/site-packages/vllm_int4_for_multi_arc.so'); print('int4 quant lib OK')"
 
 COPY ./examples/offline_inference.py /llm/
 
-# Production environment
-ENV VLLM_QUANTIZE_Q40_LIB="/opt/venv/lib/python3.12/site-packages/vllm_int4_for_multi_arc.so"
-ENV VLLM_OFFLOAD_WEIGHTS_BEFORE_QUANT=1
-ENV VLLM_ALLOW_LONG_MAX_MODEL_LEN=1
+# --- production environment ---
+ENV VLLM_QUANTIZE_Q40_LIB="/opt/venv/lib/python3.12/site-packages/vllm_int4_for_multi_arc.so" \
+    VLLM_OFFLOAD_WEIGHTS_BEFORE_QUANT=1 \
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
+    VLLM_WORKER_MULTIPROC_METHOD=spawn
 
-RUN rm -rf /usr/lib/python3/dist-packages/PyJWT-*.dist-info /tmp/* && \
-    echo "source /opt/intel/oneapi/setvars.sh --force" >> /root/.bashrc
-
-ENTRYPOINT ["bash", "-c", "source /opt/intel/oneapi/ccl/2021.15/env/vars.sh --force && exec vllm serve \"$@\"", "--"]
+# --- entrypoint: no oneCCL vars.sh (absent in this base); multi-card relies on
+#     torch 2.11 built-in XCCL. ---
+ENTRYPOINT ["bash", "-c", "exec vllm serve \"$@\"", "--"]


### PR DESCRIPTION
## Context

The vLLM XPU image was built on a single fat base (`llm-scaler-platform`) that
bundles the oneAPI DPC++ **compiler** + oneCCL + GPU runtime in one layer, and
compiled everything (vLLM, custom ESIMD kernels, vllm-xpu-kernels) **in-place**.
The shipped image therefore carried the whole compiler toolchain it never needs
at serve time (~25GB).

This PR adopts Intel's **OMIX layered-container** model: compile in an OMIX
`devel` builder stage, ship only the resulting wheels in a lighter OMIX
`pytorch` runtime stage.

## Changes

`vllm/docker/Dockerfile` rewritten as two stages:

- **builder** = `intel/omix:latest-devel-ubuntu24.04` (oneAPI DPC++). Compiles
  three wheels into `/wheels`: vLLM v0.21.0 (+`vllm_for_multi_arc.patch`), custom
  ESIMD kernels (`TORCH_XPU_ARCH_LIST=bmg-g21`), and vllm-xpu-kernels (`@3cab97a`
  + patch). Uses an isolated `/opt/buildenv` venv with `torch==2.11.0+xpu` to
  match the runtime ABI.
- **runtime** = `intel/pytorch:xpu-2.11.0-ubuntu24.04` (torch 2.11.0+xpu + GPU
  UMD driver, no compiler). Installs only those wheels + lean-core serving deps.

**Scope (lean core):** keep vLLM + ESIMD kernels + vllm-xpu-kernels + core
serving deps + bigdl-core. **Dropped:** MinerU and UCX/NIXL (PD-disaggregation).

### Size: 25GB → **17.2GB** (−31%)

After the 2-stage split (20.5GB), three same-layer cleanups bring it to 17.2GB
(cleanup must run in the same RUN layer that creates the bloat — a later layer
cannot reclaim space in a union FS):

- `strip --strip-debug` triton `libtriton.so` (1.16GB → 228MB)
- dedup the two identical 500MB `libMLIRDialectPlugin.so` copies → symlink
- `PIP_NO_CACHE_DIR=1` (pip was baking ~1.8GB of cache into layers)

## Notable gotchas handled

- **triton clobber:** installing the vLLM wheel's deps pulls upstream CUDA
  `triton` (via xgrammar), which overwrites the base's `triton-xpu` libtriton.so
  and drops the `intel` backend (`import triton.backends` fails). Fixed by
  reinstalling `triton-xpu==3.7.0 --no-deps` after deps, then stripping/dedup in
  the same layer.
- `vllm_int4_for_multi_arc.so` (`VLLM_QUANTIZE_Q40_LIB`) ships with
  `bigdl-core==2.4.0b2`, which lean-core keeps — no manual copy needed.
- Entrypoint drops the oneCCL `vars.sh` sourcing (absent in this base);
  multi-card uses torch 2.11 built-in XCCL.
- A build-time sanity check asserts native modules import, `triton.backends`
  loads, and the int4 quant lib is loadable — so any regression fails the build.

## Verification

Dual-card (`ZE_AFFINITY_MASK=0,1`, TP=2) fp8 serve with `Qwen3.5-35B-A3B`:

- imports OK (torch 2.11.0+xpu intact, triton 3.7.0 backends OK)
- multi-card init via torch XCCL works, `/health` → 200
- smoke test: correct concurrent completions
- **GSM8K 300q: accuracy 0.923, invalid 0.000**
- a triton JIT kernel compiles & runs on XPU after the strip (max_err 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)