### PR TITLE
Omni: generalize RoPE patch for flux.math.apply_rope, add Krea2 RMSNorm sub-switch

### DIFF
--- a/omni/ComfyUI-OmniXPU/README.md
+++ b/omni/ComfyUI-OmniXPU/README.md
@@ -15,7 +15,7 @@ Requires `omni_xpu_kernel` installed. Without it the node loads silently with no
 | Patch | Target |
 |-------|--------|
 | ESIMD Flash Attention | `optimized_attention` |
-| ESIMD RoPE | `_apply_rope1` / `apply_rope1` |
+| ESIMD RoPE | `_apply_rope1` / `apply_rope1` / `apply_rope` (flux.math dual-tensor) |
 | ESIMD LayerNorm/RMSNorm | `LayerNorm.forward` / `RMSNorm.forward` / `rms_norm()` |
 | FP8 GEMM | `fp8_linear` / `mixed_precision_ops` |
 | FP8 Negative Zero Fix | `manual_stochastic_round_to_float8` |
@@ -31,6 +31,7 @@ OMNIXPU_ENABLE=0            # Master switch — disable everything
 OMNIXPU_ATTENTION=0         # Disable ESIMD Flash Attention only
 OMNIXPU_ROPE=0              # Disable ESIMD RoPE only
 OMNIXPU_NORM=0              # Disable ESIMD LayerNorm/RMSNorm only
+OMNIXPU_KREA2_RMSNORM=0     # Disable the Krea2-specific local RMSNorm hook only
 OMNIXPU_FP8_GEMM=0          # Disable FP8 GEMM only
 OMNIXPU_FP8_NEG_ZERO_FIX=0  # Disable FP8 negative zero fix only
 OMNIXPU_INTERPOLATE_FIX=0   # Disable interpolate workaround only

--- a/omni/ComfyUI-OmniXPU/patches/patch_norm.py
+++ b/omni/ComfyUI-OmniXPU/patches/patch_norm.py
@@ -9,6 +9,7 @@ Mirrors the omni_b7 branch (analytics-zoo/ComfyUI @ 4aa7b1c):
 """
 
 import logging
+import os
 
 import torch
 import comfy.model_management
@@ -174,7 +175,13 @@ def apply():
     except (ImportError, AttributeError):
         pass  # comfy.rmsnorm may not exist in all versions
 
-    # --- Krea2 local RMSNorm ---
+    # --- Krea2 local RMSNorm (separate opt-in sub-switch) ---
+    # Gated by OMNIXPU_KREA2_RMSNORM (default on). This is deliberately a
+    # separate switch from the general norm patch: Krea2 is the only model that
+    # defines its OWN RMSNorm class instead of using comfy.ops.RMSNorm / the
+    # comfy rms_norm wrapper, so this hook is Krea2-specific and may become
+    # unnecessary if upstream refactors Krea2 onto the shared wrapper.
+    #
     # comfy.ldm.krea2.model defines its OWN RMSNorm(nn.Module) that calls
     # torch F.rms_norm directly, using the (1 + scale) weight convention and
     # fp32 accumulation. It uses neither comfy.ops.RMSNorm nor
@@ -182,28 +189,31 @@ def apply():
     # forward to use the omni ESIMD kernel (which also supports fp32), while
     # preserving the exact numerics: weight = scale.float() + 1.0, fp32 compute,
     # cast back to the input dtype.
-    try:
-        import comfy.ldm.krea2.model as _krea2_model
+    if os.environ.get("OMNIXPU_KREA2_RMSNORM", "1") == "0":
+        log.info("[OmniXPU] norm: Krea2 RMSNorm patch disabled (OMNIXPU_KREA2_RMSNORM=0)")
+    else:
+        try:
+            import comfy.ldm.krea2.model as _krea2_model
 
-        _KreaRMS = _krea2_model.RMSNorm
+            _KreaRMS = _krea2_model.RMSNorm
 
-        def _krea2_rms_forward(self, x):
-            dtype = x.dtype
-            weight = comfy.model_management.cast_to(
-                self.scale, dtype=torch.float32, device=x.device) + 1.0
-            h = x.shape[-1]
-            if (_omni_norm is not None and x.is_xpu and x.ndim >= 2
-                    and h <= 8192 and h % 32 == 0):
-                _log_first("Krea2RMSNorm", x.shape)
-                orig = x.shape
-                x_2d = x.float().reshape(-1, h).contiguous()
-                return _omni_norm.rms_norm(weight, x_2d, self.eps).reshape(orig).to(dtype)
-            return torch.nn.functional.rms_norm(
-                x.float(), (h,), weight=weight, eps=self.eps).to(dtype)
+            def _krea2_rms_forward(self, x):
+                dtype = x.dtype
+                weight = comfy.model_management.cast_to(
+                    self.scale, dtype=torch.float32, device=x.device) + 1.0
+                h = x.shape[-1]
+                if (_omni_norm is not None and x.is_xpu and x.ndim >= 2
+                        and h <= 8192 and h % 32 == 0):
+                    _log_first("Krea2RMSNorm", x.shape)
+                    orig = x.shape
+                    x_2d = x.float().reshape(-1, h).contiguous()
+                    return _omni_norm.rms_norm(weight, x_2d, self.eps).reshape(orig).to(dtype)
+                return torch.nn.functional.rms_norm(
+                    x.float(), (h,), weight=weight, eps=self.eps).to(dtype)
 
-        _KreaRMS.forward = _krea2_rms_forward
-        log.info("[OmniXPU] norm: patched Krea2 local RMSNorm.forward")
-    except (ImportError, AttributeError):
-        pass  # krea2 model not present in this ComfyUI version
+            _KreaRMS.forward = _krea2_rms_forward
+            log.info("[OmniXPU] norm: patched Krea2 local RMSNorm.forward")
+        except (ImportError, AttributeError):
+            pass  # krea2 model not present in this ComfyUI version
 
     return True, None

--- a/omni/ComfyUI-OmniXPU/patches/patch_norm.py
+++ b/omni/ComfyUI-OmniXPU/patches/patch_norm.py
@@ -174,4 +174,36 @@ def apply():
     except (ImportError, AttributeError):
         pass  # comfy.rmsnorm may not exist in all versions
 
+    # --- Krea2 local RMSNorm ---
+    # comfy.ldm.krea2.model defines its OWN RMSNorm(nn.Module) that calls
+    # torch F.rms_norm directly, using the (1 + scale) weight convention and
+    # fp32 accumulation. It uses neither comfy.ops.RMSNorm nor
+    # comfy.rmsnorm.rms_norm, so the patches above never reach it. Hijack its
+    # forward to use the omni ESIMD kernel (which also supports fp32), while
+    # preserving the exact numerics: weight = scale.float() + 1.0, fp32 compute,
+    # cast back to the input dtype.
+    try:
+        import comfy.ldm.krea2.model as _krea2_model
+
+        _KreaRMS = _krea2_model.RMSNorm
+
+        def _krea2_rms_forward(self, x):
+            dtype = x.dtype
+            weight = comfy.model_management.cast_to(
+                self.scale, dtype=torch.float32, device=x.device) + 1.0
+            h = x.shape[-1]
+            if (_omni_norm is not None and x.is_xpu and x.ndim >= 2
+                    and h <= 8192 and h % 32 == 0):
+                _log_first("Krea2RMSNorm", x.shape)
+                orig = x.shape
+                x_2d = x.float().reshape(-1, h).contiguous()
+                return _omni_norm.rms_norm(weight, x_2d, self.eps).reshape(orig).to(dtype)
+            return torch.nn.functional.rms_norm(
+                x.float(), (h,), weight=weight, eps=self.eps).to(dtype)
+
+        _KreaRMS.forward = _krea2_rms_forward
+        log.info("[OmniXPU] norm: patched Krea2 local RMSNorm.forward")
+    except (ImportError, AttributeError):
+        pass  # krea2 model not present in this ComfyUI version
+
     return True, None

--- a/omni/ComfyUI-OmniXPU/patches/patch_rope.py
+++ b/omni/ComfyUI-OmniXPU/patches/patch_rope.py
@@ -95,4 +95,32 @@ def apply():
                     pass
         log.info("[OmniXPU] rope: rebound %d by-value imports of apply_rope1", rebound)
 
+    # ── Krea2-only: dual-tensor apply_rope ───────────────────────────────────
+    # comfy.ldm.krea2.model.Attention calls the TOP-LEVEL
+    # comfy.ldm.flux.math.apply_rope(q, k, freqs), whose inference branch
+    # forwards to comfy_kitchen.ck.apply_rope. The single-tensor apply_rope1
+    # patch above never gets hit for Krea2. To accelerate Krea2 -- and ONLY
+    # Krea2 -- we rebind the apply_rope name that comfy.ldm.krea2.model imported
+    # by value at module top-level. We deliberately do NOT touch
+    # flux_math.apply_rope, so every other model (flux, lumina, hidream, sam3,
+    # triposplat, lens, pixeldit) keeps its original rope path unchanged.
+    try:
+        import comfy.ldm.krea2.model as _krea2_model
+    except ImportError:
+        _krea2_model = None
+    if _krea2_model is not None and getattr(_krea2_model, "apply_rope", None) is not None:
+        _orig_krea2_apply_rope = _krea2_model.apply_rope
+
+        def _krea2_apply_rope(xq, xk, freqs_cis):
+            # Engage the omni ESIMD rotary kernel only when eligible (kernel
+            # loaded, XPU tensors, head_dim in {64,128}, 4D q/k, freqs ndim == 6);
+            # otherwise fall back to the original apply_rope.
+            if (_can_use(xq) and _can_use(xk) and xq.ndim == 4 and xk.ndim == 4
+                    and freqs_cis.ndim == 6):
+                return _omni_apply_rope1(xq, freqs_cis), _omni_apply_rope1(xk, freqs_cis)
+            return _orig_krea2_apply_rope(xq, xk, freqs_cis)
+
+        _krea2_model.apply_rope = _krea2_apply_rope
+        log.info("[OmniXPU] rope: patched Krea2 apply_rope (Krea2-only)")
+
     return True, None

--- a/omni/ComfyUI-OmniXPU/patches/patch_rope.py
+++ b/omni/ComfyUI-OmniXPU/patches/patch_rope.py
@@ -95,32 +95,52 @@ def apply():
                     pass
         log.info("[OmniXPU] rope: rebound %d by-value imports of apply_rope1", rebound)
 
-    # ── Krea2-only: dual-tensor apply_rope ───────────────────────────────────
-    # comfy.ldm.krea2.model.Attention calls the TOP-LEVEL
-    # comfy.ldm.flux.math.apply_rope(q, k, freqs), whose inference branch
-    # forwards to comfy_kitchen.ck.apply_rope. The single-tensor apply_rope1
-    # patch above never gets hit for Krea2. To accelerate Krea2 -- and ONLY
-    # Krea2 -- we rebind the apply_rope name that comfy.ldm.krea2.model imported
-    # by value at module top-level. We deliberately do NOT touch
-    # flux_math.apply_rope, so every other model (flux, lumina, hidream, sam3,
-    # triposplat, lens, pixeldit) keeps its original rope path unchanged.
-    try:
-        import comfy.ldm.krea2.model as _krea2_model
-    except ImportError:
-        _krea2_model = None
-    if _krea2_model is not None and getattr(_krea2_model, "apply_rope", None) is not None:
-        _orig_krea2_apply_rope = _krea2_model.apply_rope
+    # ── General dual-tensor apply_rope ───────────────────────────────────────
+    # comfy.ldm.flux.math.apply_rope(q, k, freqs) is the dual-tensor entry used
+    # by flux (its own attention()), lumina, hidream, sam3, krea2, triposplat,
+    # lens and pixeldit. Its inference branch forwards to comfy_kitchen
+    # ck.apply_rope, which has no XPU backend (falls back to eager torch), so
+    # none of these models reach the omni ESIMD rotary kernel via the
+    # single-tensor apply_rope1 patch above. Patch apply_rope the same way:
+    # route eligible tensors through the ESIMD kernel, fall back otherwise.
+    # Numerically equivalent to the reference (verified: fp32 ~1e-7,
+    # bf16 ~3e-3 rounding) — see krea2/verify_rope_equivalence.py.
+    #
+    # NOTE: this targets the flux.math.apply_rope symbol only. The
+    # identically-named comfy.text_encoders.llama.apply_rope (used by the
+    # llama/qwen35/sa3/gpt_oss text encoders and comfy.ldm.ideogram4) is a
+    # different function with a different freq layout; the identity check in
+    # the rebind walk below leaves it untouched.
+    if hasattr(flux_math, "apply_rope"):
+        _orig_apply_rope = flux_math.apply_rope
 
-        def _krea2_apply_rope(xq, xk, freqs_cis):
-            # Engage the omni ESIMD rotary kernel only when eligible (kernel
-            # loaded, XPU tensors, head_dim in {64,128}, 4D q/k, freqs ndim == 6);
-            # otherwise fall back to the original apply_rope.
+        def _patched_apply_rope(xq, xk, freqs_cis):
             if (_can_use(xq) and _can_use(xk) and xq.ndim == 4 and xk.ndim == 4
                     and freqs_cis.ndim == 6):
                 return _omni_apply_rope1(xq, freqs_cis), _omni_apply_rope1(xk, freqs_cis)
-            return _orig_krea2_apply_rope(xq, xk, freqs_cis)
+            return _orig_apply_rope(xq, xk, freqs_cis)
 
-        _krea2_model.apply_rope = _krea2_apply_rope
-        log.info("[OmniXPU] rope: patched Krea2 apply_rope (Krea2-only)")
+        flux_math.apply_rope = _patched_apply_rope
+
+        # Rebind by-value imports of apply_rope in already-loaded modules
+        # (lumina, hidream, sam3, krea2, triposplat, lens, pixeldit all do
+        # `from comfy.ldm.flux.math import apply_rope`). The identity check
+        # against the original flux.math.apply_rope excludes the llama-family
+        # function of the same name.
+        rebound_ar = 0
+        for mod_name, mod in list(sys.modules.items()):
+            if mod is None or mod is flux_math:
+                continue
+            try:
+                cur = getattr(mod, "apply_rope", None)
+            except Exception:
+                continue
+            if cur is _orig_apply_rope:
+                try:
+                    setattr(mod, "apply_rope", _patched_apply_rope)
+                    rebound_ar += 1
+                except Exception:
+                    pass
+        log.info("[OmniXPU] rope: patched apply_rope + rebound %d by-value imports", rebound_ar)
 
     return True, None


### PR DESCRIPTION
Krea2's DiT bypasses the existing OmniXPU norm/rope patches. This PR keeps RMSNorm as a Krea2-only patch and generalizes the RoPE patch, since the underlying entry point is shared across models rather than specific to Krea2.

**RMSNorm**: Krea2 defines its own local `RMSNorm` class instead of using the shared comfy wrapper, so the hook remains isolated to Krea2, now gated behind `OMNIXPU_KREA2_RMSNORM` (default on).

**RoPE**: `comfy.ldm.flux.math.apply_rope` (dual-tensor) is a shared entry point used by Flux, HiDream, Lumina, Krea2, SAM3, TripoSPlat, Lens, and PixelDiT. The patch now hooks `flux_math.apply_rope` directly and rebinds all by-value imports, routing every one of these models through the ESIMD rotary kernel. Verified numerically equivalent to the reference implementation (`krea2/verify_rope_equivalence.py`).

Note: HiDream-**O1** uses a separate module (`comfy/ldm/hidream_o1/`) with a different RoPE implementation (`llama.apply_rope`, M-RoPE) and is intentionally not covered by this patch.

**Verification (Arc Pro B60/B70)**: end-to-end tested on Flux and HiDream, no regressions.

**Env vars**: `OMNIXPU_ROPE=0` disables all ESIMD RoPE; `OMNIXPU_KREA2_RMSNORM=0` disables only the Krea2 RMSNorm hook.
