### PR TITLE
vllm: add dev/debug Dockerfile (single-stage OMIX devel base)

### DIFF
--- a/vllm/docker/Dockerfile.dev
+++ b/vllm/docker/Dockerfile.dev
@@ -1,0 +1,174 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+# DEV / DEBUG build of llm-scaler-vllm (Intel XPU).  Single stage.
+#
+#   base : intel/omix:latest-devel-ubuntu24.04
+#            - oneAPI 2025.3 DPC++ compiler (icpx), oneCCL 2021.17, oneDNN/oneMKL
+#            - AND the SAME Intel GPU runtime stack as the prod runtime base
+#              (intel/pytorch:xpu-2.11.0): intel-opencl-icd/ocloc/libze-intel-gpu1
+#              26.14.37833.4, libze_loader 1.28.2, libigc2 2.32.7, libigdgmm 22.10.0.
+#              Verified byte-identical -> this image can BOTH compile and run on GPU.
+#
+# Relationship to prod (docker/Dockerfile, released as v0.21.0-omix-pr508):
+#   prod is a 2-stage build that ships a stripped, cleaned runtime WITHOUT a compiler.
+#   Great for size, painful to debug.  This dev image keeps EVERYTHING:
+#     * the oneAPI compiler + GPU runtime (base already has both)
+#     * the /llm-scaler/vllm/{vllm,vllm-xpu-kernels,custom-esimd-kernels-vllm} source
+#       trees AND their build/ dirs, so any component can be rebuilt in place
+#     * debug symbols (NO `strip`, NO plugin dedup, NO cleanup)
+#     * gdb / debug tooling
+#   Package versions are kept in lockstep with prod: torch 2.11.0+xpu, the same
+#   vLLM v0.21.0 + multi_arc patch, the same esimd kernels, the same
+#   vllm-xpu-kernels commit + patch, transformers 5.8.0, triton-xpu 3.7.0,
+#   bigdl-core 2.4.0b2.
+#
+#   The ONE intentional divergence: vLLM is installed EDITABLE (`pip install -e`)
+#   from the persisted source tree, so Python-side edits take effect without a
+#   rebuild.  The two kernel packages are installed as wheels (native .so), same
+#   as prod, but their sources + build/ dirs are kept for recompilation.
+#
+# Build context root MUST be the `vllm/` dir (so ./patches, ./custom-esimd-kernels-vllm
+# and ./examples resolve):
+#     docker build -f docker/Dockerfile.dev -t <name>:v0.21.0-omix-pr508-dev .
+
+FROM intel/omix:latest-devel-ubuntu24.04
+
+ARG http_proxy
+ARG https_proxy
+ARG no_proxy
+# vllm-xpu-kernels pinned base commit (identical to prod build).
+ARG VLLM_XPU_KERNELS_COMMIT=3cab97a
+
+ENV http_proxy=${http_proxy} \
+    https_proxy=${https_proxy} \
+    no_proxy=${no_proxy} \
+    VIRTUAL_ENV=/opt/venv \
+    PATH="/root/.local/bin:/opt/venv/bin:${PATH}" \
+    UV_HTTP_TIMEOUT=500 \
+    PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/xpu" \
+    UV_EXTRA_INDEX_URL="https://download.pytorch.org/whl/xpu" \
+    UV_INDEX_STRATEGY="unsafe-best-match" \
+    UV_LINK_MODE="copy" \
+    VLLM_TARGET_DEVICE=xpu \
+    WHEELS=/wheels \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    VLLM_QUANTIZE_Q40_LIB="/opt/venv/lib/python3.12/site-packages/vllm_int4_for_multi_arc.so" \
+    VLLM_OFFLOAD_WEIGHTS_BEFORE_QUANT=1 \
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
+    VLLM_WORKER_MULTIPROC_METHOD=spawn
+
+# Build RUN steps use `source .../setvars.sh` and `set -eo pipefail` (bash-only).
+SHELL ["bash", "-c"]
+
+# --- build tooling + runtime OS deps + debug tooling (the oneAPI DPC++ compiler
+#     and the Intel GPU runtime are already in the OMIX devel base) ---
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends --fix-missing \
+        git curl ca-certificates \
+        python3-dev python3-venv python3-pip \
+        ninja-build cmake pkg-config numactl \
+        ffmpeg libsndfile1 libsm6 libxext6 libgl1 \
+        gdb vim less htop procps
+
+# --- isolated venv at /opt/venv (same path prod runtime uses, so the env-var
+#     paths above resolve; OMIX system python is PEP-668 blocked) ---
+RUN python3 -m venv ${VIRTUAL_ENV}
+
+# --- uv for fast, deterministic installs (matches prod) ---
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# --- torch pinned to the prod runtime ABI (2.11.0+xpu) so all native .so link
+#     against the libtorch the image ships ---
+RUN --mount=type=cache,target=/root/.cache/uv \
+    pip install --upgrade pip wheel setuptools && \
+    uv pip install torch==2.11.0+xpu torchaudio torchvision \
+        --index-url https://download.pytorch.org/whl/xpu
+
+RUN mkdir -p ${WHEELS}
+
+COPY ./patches/vllm_for_multi_arc.patch ./patches/vllm_xpu_kernels.patch /tmp/
+COPY ./custom-esimd-kernels-vllm /llm-scaler/vllm/custom-esimd-kernels-vllm
+
+WORKDIR /llm-scaler/vllm
+
+# ---------------------------------------------------------------------------
+# vLLM v0.21.0 + multi-arc patch  ->  EDITABLE install (source kept at
+# /llm-scaler/vllm/vllm, native ext + build/ compiled in place).
+# Deps resolve here (mirrors prod's `pip install vllm-*.whl`); the triton
+# clobber they pull is repaired at the end, same as prod.
+# ---------------------------------------------------------------------------
+RUN --mount=type=cache,target=/root/.cache/uv \
+    set -eo pipefail && \
+    source /opt/intel/oneapi/setvars.sh --force && \
+    git clone --depth 1 -b v0.21.0 https://github.com/vllm-project/vllm.git ./vllm && \
+    cd ./vllm && \
+    git apply /tmp/vllm_for_multi_arc.patch && \
+    uv pip install -r requirements/xpu.txt && \
+    uv pip install grpcio-tools protobuf nanobind && \
+    export CMAKE_PREFIX_PATH="$(python3 -c 'import site; print(site.getsitepackages()[0])'):${CMAKE_PREFIX_PATH:-}" && \
+    pip install --no-build-isolation -e . \
+        --extra-index-url https://download.pytorch.org/whl/xpu
+
+# ---------------------------------------------------------------------------
+# custom ESIMD kernels  ->  wheel + install  (TORCH_XPU_ARCH_LIST=bmg-g21).
+# Source + build/ + dist/ kept for recompilation.
+# ---------------------------------------------------------------------------
+RUN --mount=type=cache,target=/root/.cache/uv \
+    set -eo pipefail && \
+    source /opt/intel/oneapi/setvars.sh --force && \
+    cd ./custom-esimd-kernels-vllm && \
+    TORCH_XPU_ARCH_LIST=bmg-g21 MAX_JOBS=1 python3 setup.py bdist_wheel && \
+    cp dist/*.whl ${WHEELS}/ && \
+    pip install --no-deps --force-reinstall dist/*.whl
+
+# ---------------------------------------------------------------------------
+# vllm-xpu-kernels (patch + pinned commit)  ->  wheel + install.
+# Source + build/ kept for recompilation.
+# ---------------------------------------------------------------------------
+RUN --mount=type=cache,target=/root/.cache/uv \
+    set -eo pipefail && \
+    source /opt/intel/oneapi/setvars.sh --force && \
+    git clone https://github.com/vllm-project/vllm-xpu-kernels.git ./vllm-xpu-kernels && \
+    cd ./vllm-xpu-kernels && \
+    git checkout ${VLLM_XPU_KERNELS_COMMIT} && \
+    git apply /tmp/vllm_xpu_kernels.patch && \
+    sed -i 's|^--extra-index-url=https://download.pytorch.org/whl/xpu|# --extra-index-url=https://download.pytorch.org/whl/xpu|' requirements.txt && \
+    sed -i '/^torch==/s/^/# /' requirements.txt && \
+    sed -i 's|^triton-xpu|# triton-xpu|' requirements.txt && \
+    sed -i 's|^transformers|# transformers|' requirements.txt && \
+    uv pip install -r requirements.txt && \
+    export CMAKE_PREFIX_PATH="$(python3 -c 'import site; print(site.getsitepackages()[0])'):${CMAKE_PREFIX_PATH:-}" && \
+    pip wheel --no-build-isolation --no-deps . -w ${WHEELS} && \
+    pip install --no-deps --force-reinstall ${WHEELS}/vllm_xpu_kernels-*.whl
+
+# ---------------------------------------------------------------------------
+# lean-core serving deps (same versions as prod) + bigdl-core (ships
+# vllm_int4_for_multi_arc.so used by the sym_int4 path).
+# ---------------------------------------------------------------------------
+RUN --mount=type=cache,target=/root/.cache/uv \
+    set -eo pipefail && \
+    pip install transformers==5.8.0 accelerate hf_transfer 'modelscope!=1.15.0' && \
+    pip install librosa soundfile decord ijson && \
+    pip install bigdl-core==2.4.0b2
+
+# ---------------------------------------------------------------------------
+# triton-xpu fix (same as prod): installing vllm deps pulls upstream CUDA
+# triton==3.7.1 (via xgrammar), which drops the `intel` backend.  Reinstall
+# triton-xpu 3.7.0.  DEV DIFF: do NOT strip libtriton.so / dedup plugins /
+# run any cleanup -- debug symbols are kept.
+# ---------------------------------------------------------------------------
+RUN --mount=type=cache,target=/root/.cache/uv \
+    set -eo pipefail && \
+    pip uninstall -y triton triton-xpu || true && \
+    pip install --no-deps triton-xpu==3.7.0 \
+        --extra-index-url https://download.pytorch.org/whl/xpu
+
+# Component inventory in the build log for sanity.
+RUN pip list 2>/dev/null | grep -iE "^(vllm|torch|triton|transformers|bigdl|accelerate)" || true
+
+# --- dev default: interactive login shell (oneAPI env auto-sourced by the base).
+#     Override with `docker run ... vllm serve <model> ...` to serve. ---
+CMD ["/bin/bash", "-l"]

--- a/vllm/docker/Dockerfile.dev
+++ b/vllm/docker/Dockerfile.dev
@@ -10,7 +10,7 @@
 #              26.14.37833.4, libze_loader 1.28.2, libigc2 2.32.7, libigdgmm 22.10.0.
 #              Verified byte-identical -> this image can BOTH compile and run on GPU.
 #
-# Relationship to prod (docker/Dockerfile, released as v0.21.0-omix-pr508):
+# Relationship to prod (docker/Dockerfile):
 #   prod is a 2-stage build that ships a stripped, cleaned runtime WITHOUT a compiler.
 #   Great for size, painful to debug.  This dev image keeps EVERYTHING:
 #     * the oneAPI compiler + GPU runtime (base already has both)


### PR DESCRIPTION
## What

Adds `vllm/docker/Dockerfile.dev` — a debug-friendly counterpart to the prod OMIX image (`docker/Dockerfile`, released as `v0.21.0-omix-pr508`). Prod is left untouched.

The prod image is a 2-stage build (compiler only in the builder stage, runtime stripped/cleaned) — great for size (~14.7GB), but painful to debug: no compiler, build artifacts and debug symbols removed.

## Design

Single stage `FROM intel/omix:latest-devel-ubuntu24.04`. Key point: the OMIX **devel** base carries **both** the oneAPI 2025.3 compiler (`icpx`) **and** the *identical* Intel GPU runtime stack as the prod runtime base (`intel/pytorch:xpu-2.11.0`) — verified byte-identical PPA versions (`intel-opencl-icd`/`libze-intel-gpu1` `26.14.37833.4`, `libze_loader` `1.28.2`, `libigc2` `2.32.7-1256`, `libigdgmm12` `22.10.0`). So it can both compile and run on GPU without grafting.

Build mirrors the prod builder (venv `/opt/venv` + `torch==2.11.0+xpu`, same vLLM v0.21.0 + multi_arc patch, same custom-esimd-kernels `bmg-g21`, same vllm-xpu-kernels `3cab97a` + patch, same lean-core deps, same `triton-xpu` 3.7.0 fix).

### Dev-oriented differences vs prod
- vLLM installed **editable** (`pip install -e`) for live source edits
- kernel source trees + `build/` dirs kept for in-place recompilation
- **no** strip / **no** plugin dedup / **no** cleanup (debug symbols retained; `libtriton.so` stays 1.1G vs prod's 228MB)
- `gdb`/`vim`/`less`/`htop` added; `CMD` is an interactive login shell

## Verification (Intel Arc Pro B60)

- `icpx` 2025.3.3 + `setvars` OK; GPU runtime versions match prod
- torch 2.11.0+xpu, GPUs visible; `vllm` / `vllm_xpu_kernels` / `custom_esimd_kernels_vllm` import OK; triton `intel` backend present; bigdl int4 `.so` present
- single-card `vllm serve` correct; **TP=2** correct (`world_size=2 backend=xccl`)
- versions aligned with pr508 (transformers 5.8.0 / triton-xpu 3.7.0 / bigdl-core 2.4.0b2)

Image size ~32.3GB (size is intentionally unconstrained for this dev variant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)