### PR TITLE
Fix ESIMD SYCL include order and pin dev base image

### DIFF
--- a/vllm/custom-esimd-kernels-vllm/csrc/eagle/eagle.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/eagle/eagle.sycl
@@ -1,3 +1,4 @@
+#include <sycl/sycl.hpp>
 #include <torch/extension.h>
 #include <c10/xpu/XPUStream.h>
 #include <sycl/ext/intel/esimd.hpp>

--- a/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe.sycl
@@ -1,3 +1,4 @@
+#include <sycl/sycl.hpp>
 #include <torch/extension.h>
 #include <cstdlib>
 #include <algorithm>

--- a/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe_int4.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe_int4.sycl
@@ -14,6 +14,7 @@
 // Shared expert weights: FP16 (NOT quantized, no scale).
 // ═══════════════════════════════════════════════════════════════════════════════
 
+#include <sycl/sycl.hpp>
 #include <torch/extension.h>
 #include <c10/xpu/XPUStream.h>
 #include <sycl/ext/intel/esimd.hpp>

--- a/vllm/custom-esimd-kernels-vllm/csrc/moe_prefill/moe_prefill_int4.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/moe_prefill/moe_prefill_int4.sycl
@@ -1,6 +1,6 @@
+#include <sycl/sycl.hpp>
 #include <torch/extension.h>
 #include <c10/xpu/XPUStream.h>
-#include <sycl/sycl.hpp>
 #include <sycl/ext/intel/esimd.hpp>
 #include <sycl/ext/intel/experimental/esimd/memory.hpp>
 #include <cstdio>

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel.sycl
@@ -1,10 +1,11 @@
+#include <sycl/sycl.hpp>
+
 #include <ATen/ATen.h>
 #include <ATen/Parallel.h>
 #include <c10/xpu/XPUStream.h>
 #include <torch/python.h>
 
 #include <cstdint>
-#include <sycl/sycl.hpp>
 
 #include "esimd_kernels/fp8_GEMV_v2.h"
 #include "esimd_kernels/fp8_GEMV_bmg.h"

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_gemm.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_gemm.sycl
@@ -3,13 +3,14 @@
  * Separate from esimd_kernel.sycl to avoid ODR conflicts with fp8_GEMV_v2.h
  * (both define fp8_dequant, select_vl_ks with identical implementations).
  */
+#include <sycl/sycl.hpp>
+
 #include <ATen/ATen.h>
 #include <ATen/Parallel.h>
 #include <c10/xpu/XPUStream.h>
 #include <torch/python.h>
 
 #include <cstdint>
-#include <sycl/sycl.hpp>
 
 #include "esimd_kernels/fp8_GEMM_pert.h"
 #include "esimd_kernels/int4_GEMM.h"

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_lgrf.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_lgrf.sycl
@@ -2,13 +2,14 @@
  * Compiled with -doubleGRF flags for 512 register access.
  */
 
+#include <sycl/sycl.hpp>
+
 #include <ATen/ATen.h>
 #include <ATen/Parallel.h>
 #include <c10/xpu/XPUStream.h>
 #include <torch/python.h>
 
 #include <cstdint>
-#include <sycl/sycl.hpp>
 
 #include "esimd_kernels/gdn_conv_fused.h"
 #include "esimd_kernels/gdn_conv_fused_seq.h"

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_moe.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_moe.sycl
@@ -3,13 +3,14 @@
  * MoE kernels use ~42 GRFs — well within 256 limit.
  */
 
+#include <sycl/sycl.hpp>
+
 #include <ATen/ATen.h>
 #include <ATen/Parallel.h>
 #include <c10/xpu/XPUStream.h>
 #include <torch/python.h>
 
 #include <cstdint>
-#include <sycl/sycl.hpp>
 
 #include "esimd_kernels/moe_ops.h"
 #include "esimd_kernels/fp8_moe_gemm.h"

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_topk_v2.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_topk_v2.sycl
@@ -1,12 +1,13 @@
 /* esimd_kernel_topk_v2.sycl — Standalone TopK V2 kernel (no DPAS dependency) */
 
+#include <sycl/sycl.hpp>
+
 #include <ATen/ATen.h>
 #include <ATen/Parallel.h>
 #include <c10/xpu/XPUStream.h>
 #include <torch/python.h>
 
 #include <cstdint>
-#include <sycl/sycl.hpp>
 
 // Include only moe_ops.h (TopK kernels, no DPAS)
 #include "esimd_kernels/moe_ops.h"

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/q4_0_quant.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/q4_0_quant.sycl
@@ -13,9 +13,9 @@
 //   float_val = (nibble_unsigned - 8) * scale
 // ═══════════════════════════════════════════════════════════════════════════════
 
+#include <sycl/sycl.hpp>
 #include <torch/extension.h>
 #include <c10/xpu/XPUStream.h>
-#include <sycl/sycl.hpp>
 #include <sycl/ext/intel/esimd.hpp>
 
 #include <cstdint>

--- a/vllm/docker/Dockerfile.dev
+++ b/vllm/docker/Dockerfile.dev
@@ -3,7 +3,7 @@
 #
 # DEV / DEBUG build of llm-scaler-vllm (Intel XPU).  Single stage.
 #
-#   base : intel/omix:latest-devel-ubuntu24.04
+#   base : intel/omix:0.2.0-devel-ubuntu24.04
 #            - oneAPI 2025.3 DPC++ compiler (icpx), oneCCL 2021.17, oneDNN/oneMKL
 #            - AND the SAME Intel GPU runtime stack as the prod runtime base
 #              (intel/pytorch:xpu-2.11.0): intel-opencl-icd/ocloc/libze-intel-gpu1
@@ -32,7 +32,7 @@
 # and ./examples resolve):
 #     docker build -f docker/Dockerfile.dev -t <name>:v0.21.0-omix-pr508-dev .
 
-FROM intel/omix:latest-devel-ubuntu24.04
+FROM intel/omix:0.2.0-devel-ubuntu24.04
 
 ARG http_proxy
 ARG https_proxy


### PR DESCRIPTION
## Summary
- Include SYCL before PyTorch/ATen headers in custom ESIMD SYCL translation units.
- Pin Dockerfile.dev to intel/omix:0.2.0-devel-ubuntu24.04 to match the production Dockerfile base.

## Testing
- git diff --cached --check