### PR TITLE
Add SYCL external libc compatibility shim

### DIFF
--- a/vllm/custom-esimd-kernels-vllm/include/sycl_compat.hpp
+++ b/vllm/custom-esimd-kernels-vllm/include/sycl_compat.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <sycl/detail/defines_elementary.hpp>
+
+#ifndef __DPCPP_SYCL_EXTERNAL_LIBC
+#define __DPCPP_SYCL_EXTERNAL_LIBC __DPCPP_SYCL_EXTERNAL
+#endif

--- a/vllm/custom-esimd-kernels-vllm/setup.py
+++ b/vllm/custom-esimd-kernels-vllm/setup.py
@@ -9,6 +9,10 @@ root = Path(__file__).parent.resolve()
 
 import torch
 torch_include = str(Path(torch.__file__).parent / "include")
+sycl_compat_args = [
+    "-include",
+    str(root / "include" / "sycl_compat.hpp"),
+]
 
 ext_modules = [
     SyclExtension(
@@ -23,7 +27,8 @@ ext_modules = [
         ],
         extra_compile_args={
             "cxx": ["-O3", "-std=c++17"],
-            "sycl": ["-ffast-math", "-fsycl-device-code-split=per_kernel",
+            "sycl": [*sycl_compat_args,
+                     "-ffast-math", "-fsycl-device-code-split=per_kernel",
                      f"-I{torch_include}"],
         },
         extra_link_args=["-Wl,-rpath,$ORIGIN/../../torch/lib"],
@@ -45,7 +50,8 @@ ext_modules.append(
         ],
         extra_compile_args={
             "cxx": ["-O3", "-std=c++17"],
-            "sycl": ["-fsycl", "-ffast-math", "-fsycl-device-code-split=per_kernel",
+            "sycl": [*sycl_compat_args,
+                     "-fsycl", "-ffast-math", "-fsycl-device-code-split=per_kernel",
                      "-fsycl-targets=spir64_gen", "-Xs", "-device bmg",
                      f"-I{torch_include}"],
         },
@@ -69,7 +75,8 @@ ext_modules.append(
         ],
         extra_compile_args={
             "cxx": ["-O3", "-std=c++17"],
-            "sycl": ["-ffast-math", "-fsycl-device-code-split=per_kernel",
+            "sycl": [*sycl_compat_args,
+                     "-ffast-math", "-fsycl-device-code-split=per_kernel",
                      f"-I{torch_include}"],
         },
         extra_link_args=["-Wl,-rpath,$ORIGIN/../../torch/lib"],
@@ -92,7 +99,8 @@ ext_modules.append(
         ],
         extra_compile_args={
             "cxx": ["-O3", "-std=c++17"],
-            "sycl": ["-ffast-math", "-fsycl-device-code-split=per_kernel",
+            "sycl": [*sycl_compat_args,
+                     "-ffast-math", "-fsycl-device-code-split=per_kernel",
                      f"-I{torch_include}"],
         },
         extra_link_args=["-Wl,-rpath,$ORIGIN/../../torch/lib"],
@@ -115,7 +123,8 @@ ext_modules.append(
         ],
         extra_compile_args={
             "cxx": ["-O3", "-std=c++17"],
-            "sycl": ["-fsycl", "-ffast-math", "-fsycl-device-code-split=per_kernel",
+            "sycl": [*sycl_compat_args,
+                     "-fsycl", "-ffast-math", "-fsycl-device-code-split=per_kernel",
                      "-fsycl-targets=spir64_gen", "-Xs", "-device bmg",
                      f"-I{torch_include}"],
         },
@@ -137,7 +146,8 @@ ext_modules.append(
         ],
         extra_compile_args={
             "cxx": ["-O3", "-std=c++20"],
-            "sycl": ["-ffast-math", "-fsycl-device-code-split=per_kernel",
+            "sycl": [*sycl_compat_args,
+                     "-ffast-math", "-fsycl-device-code-split=per_kernel",
                      f"-I{torch_include}"],
         },
         extra_link_args=["-Wl,-rpath,$ORIGIN/../../torch/lib"],
@@ -158,7 +168,8 @@ ext_modules.append(
         ],
         extra_compile_args={
             "cxx": ["-O3", "-std=c++20"],
-            "sycl": ["-ffast-math", "-fsycl-device-code-split=per_kernel",
+            "sycl": [*sycl_compat_args,
+                     "-ffast-math", "-fsycl-device-code-split=per_kernel",
                      f"-I{torch_include}"],
         },
         extra_link_args=["-Wl,-rpath,$ORIGIN/../../torch/lib"],
@@ -181,7 +192,8 @@ ext_modules.append(
         ],
         extra_compile_args={
             "cxx": ["-O3", "-std=c++20"],
-            "sycl": ["-ffast-math", "-fsycl-device-code-split=per_kernel",
+            "sycl": [*sycl_compat_args,
+                     "-ffast-math", "-fsycl-device-code-split=per_kernel",
                      f"-I{torch_include}"],
         },
         extra_link_args=["-Wl,-rpath,$ORIGIN/../../torch/lib"],
@@ -204,7 +216,8 @@ ext_modules.append(
         ],
         extra_compile_args={
             "cxx": ["-O3", "-std=c++20"],
-            "sycl": ["-fsycl", "-ffast-math", "-fsycl-device-code-split=per_kernel",
+            "sycl": [*sycl_compat_args,
+                     "-fsycl", "-ffast-math", "-fsycl-device-code-split=per_kernel",
                      "-fsycl-targets=spir64_gen", "-Xs", "-device bmg",
                      f"-I{torch_include}"],
         },
@@ -228,7 +241,8 @@ ext_modules.append(
         ],
         extra_compile_args={
             "cxx": ["-O3", "-std=c++17"],
-            "sycl": ["-fsycl", "-ffast-math", "-fsycl-device-code-split=per_kernel",
+            "sycl": [*sycl_compat_args,
+                     "-fsycl", "-ffast-math", "-fsycl-device-code-split=per_kernel",
                      "-fsycl-targets=spir64_gen", "-Xs", "-device bmg",
                      f"-I{torch_include}"],
         },


### PR DESCRIPTION
## Summary
- Add a forced-include SYCL compatibility header for custom ESIMD kernels.
- Define `__DPCPP_SYCL_EXTERNAL_LIBC` as a fallback to `__DPCPP_SYCL_EXTERNAL` when the compiler headers do not provide it.
- Apply the compatibility include to every SYCL extension build in `custom-esimd-kernels-vllm`.

## Testing
- `python3 -m py_compile vllm/custom-esimd-kernels-vllm/setup.py`
- `git diff --cached --check`

## Notes
- Intended to address oneAPI 2026.0 `sycl/stl_wrappers/cmath` builds that fail with `unknown type name __DPCPP_SYCL_EXTERNAL_LIBC`.