### PR TITLE
Pin OMIX build images to 0.1.0

### DIFF
--- a/vllm/docker/Dockerfile
+++ b/vllm/docker/Dockerfile
@@ -3,7 +3,7 @@
 #
 # Multi-stage OMIX build of llm-scaler-vllm (Intel XPU).
 #
-#   builder : intel/omix:latest-devel-ubuntu24.04   -- oneAPI 2025.3 DPC++ compiler
+#   builder : intel/omix:0.1.0-devel-ubuntu24.04    -- oneAPI 2025.3 DPC++ compiler
 #                                                       + oneCCL/oneDNN/oneMKL.  Compiles
 #                                                       all native wheels.  NOT shipped.
 #   runtime : intel/pytorch:xpu-2.11.0-ubuntu24.04  -- torch 2.11.0+xpu + GPU UMD driver
@@ -24,7 +24,7 @@
 # =========================================================================
 # Stage 1: builder -- compile every native wheel with the oneAPI toolchain
 # =========================================================================
-FROM intel/omix:0.2.0-devel-ubuntu24.04 AS builder
+FROM intel/omix:0.1.0-devel-ubuntu24.04 AS builder
 
 ARG http_proxy
 ARG https_proxy

--- a/vllm/docker/Dockerfile.dev
+++ b/vllm/docker/Dockerfile.dev
@@ -3,7 +3,7 @@
 #
 # DEV / DEBUG build of llm-scaler-vllm (Intel XPU).  Single stage.
 #
-#   base : intel/omix:0.2.0-devel-ubuntu24.04
+#   base : intel/omix:0.1.0-devel-ubuntu24.04
 #            - oneAPI 2025.3 DPC++ compiler (icpx), oneCCL 2021.17, oneDNN/oneMKL
 #            - AND the SAME Intel GPU runtime stack as the prod runtime base
 #              (intel/pytorch:xpu-2.11.0): intel-opencl-icd/ocloc/libze-intel-gpu1
@@ -32,7 +32,7 @@
 # and ./examples resolve):
 #     docker build -f docker/Dockerfile.dev -t <name>:v0.21.0-omix-pr508-dev .
 
-FROM intel/omix:0.2.0-devel-ubuntu24.04
+FROM intel/omix:0.1.0-devel-ubuntu24.04
 
 ARG http_proxy
 ARG https_proxy


### PR DESCRIPTION
## Summary
- Pin both production and dev OMIX build images to `intel/omix:0.1.0-devel-ubuntu24.04`.
- Keep the builder compiler on oneAPI 2025.3 to match the `torch==2.11.0+xpu` / `intel-sycl-rt==2025.3.2` SYCL header stack.

## Testing
- `git diff --cached --check`
- Verified `intel/omix:0.1.0-devel-ubuntu24.04` uses `icpx` 2025.3.3 while current `0.2.0` / `latest` uses `icpx` 2026.0.0.