### PR TITLE
vllm: avoid persisting build proxies in images

### DIFF
--- a/vllm/docker/Dockerfile
+++ b/vllm/docker/Dockerfile
@@ -32,10 +32,7 @@ ARG no_proxy
 # vllm-xpu-kernels pinned base commit (identical to legacy build).
 ARG VLLM_XPU_KERNELS_COMMIT=3cab97a
 
-ENV http_proxy=${http_proxy} \
-    https_proxy=${https_proxy} \
-    no_proxy=${no_proxy} \
-    VIRTUAL_ENV=/opt/buildenv \
+ENV VIRTUAL_ENV=/opt/buildenv \
     PATH="/root/.local/bin:/opt/buildenv/bin:${PATH}" \
     UV_HTTP_TIMEOUT=500 \
     PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/xpu" \
@@ -134,10 +131,7 @@ ARG https_proxy
 ARG no_proxy
 
 # The base already exports PATH=/opt/venv/bin:... and DEVICE=xpu.
-ENV http_proxy=${http_proxy} \
-    https_proxy=${https_proxy} \
-    no_proxy=${no_proxy} \
-    PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/xpu" \
+ENV PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/xpu" \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_NO_CACHE_DIR=1 \
     VLLM_QUANTIZE_Q40_LIB="/opt/venv/lib/python3.12/site-packages/vllm_int4_for_multi_arc.so" \

--- a/vllm/docker/Dockerfile.dev
+++ b/vllm/docker/Dockerfile.dev
@@ -40,10 +40,7 @@ ARG no_proxy
 # vllm-xpu-kernels pinned base commit (identical to prod build).
 ARG VLLM_XPU_KERNELS_COMMIT=3cab97a
 
-ENV http_proxy=${http_proxy} \
-    https_proxy=${https_proxy} \
-    no_proxy=${no_proxy} \
-    VIRTUAL_ENV=/opt/venv \
+ENV VIRTUAL_ENV=/opt/venv \
     PATH="/root/.local/bin:/opt/venv/bin:${PATH}" \
     UV_HTTP_TIMEOUT=500 \
     PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/xpu" \


### PR DESCRIPTION
## Summary

- remove `http_proxy`, `https_proxy`, and `no_proxy` from image-level `ENV` declarations
- keep the proxy build arguments available during Docker builds
- apply the fix to both production and development Dockerfiles

## Validation

- `git diff --check`
- verified neither Dockerfile exports proxy variables through `ENV`