### PR TITLE
Fix SYCL device-link target selection

### DIFF
--- a/vllm/custom-esimd-kernels-vllm/esimd_build_extention.py
+++ b/vllm/custom-esimd-kernels-vllm/esimd_build_extention.py
@@ -297,12 +297,34 @@ def _get_sycl_arch_list():
     arch_list = [x for x in arch_list if not x.startswith('dg2-')]
     return ','.join(arch_list)
 
-_SYCL_DLINK_FLAGS = [
-    *_COMMON_SYCL_FLAGS,
-    '-fsycl-link',
-    '--offload-compress',
-    f'-Xs "-device {_get_sycl_arch_list()}"',
-]
+
+def _get_sycl_dlink_flags(compile_flags):
+    """Build device-link flags using the effective SYCL compile target.
+
+    Extension-specific flags are appended after ``_COMMON_SYCL_FLAGS`` and can
+    therefore override ``-fsycl-targets``.  Device linking must use the same
+    target as compilation; otherwise icpx may try to link a target that is not
+    present in the input object.
+    """
+    target_prefix = '-fsycl-targets='
+    target_flag = next(
+        (flag for flag in reversed(compile_flags)
+         if flag.startswith(target_prefix)),
+        None,
+    )
+
+    dlink_flags = [
+        flag for flag in _COMMON_SYCL_FLAGS
+        if not flag.startswith(target_prefix)
+    ]
+    if target_flag is not None:
+        dlink_flags.append(target_flag)
+    dlink_flags.extend([
+        '-fsycl-link',
+        '--offload-compress',
+        f'-Xs "-device {_get_sycl_arch_list()}"',
+    ])
+    return dlink_flags
 
 # JIT_EXTENSION_VERSIONER = ExtensionVersioner()
 
@@ -807,9 +829,10 @@ class BuildExtension(build_ext):
                 # Note the order: shlex.quote sycl_flags first, _wrap_sycl_host_flags
                 # second. Reason is that sycl host flags are quoted, space containing
                 # strings passed to SYCL compiler.
+                sycl_dlink_post_cflags = _get_sycl_dlink_flags(
+                    sycl_cflags + sycl_post_cflags)
                 sycl_cflags = [shlex.quote(f) for f in sycl_cflags]
                 # sycl_cflags += _wrap_sycl_host_flags(host_cflags)
-                sycl_dlink_post_cflags = list(_SYCL_DLINK_FLAGS)
                 # Propagate -doubleGRF from extension compile flags to dlink
                 if any('doubleGRF' in f for f in sycl_post_cflags):
                     sycl_dlink_post_cflags = [
@@ -2647,7 +2670,7 @@ def _write_ninja_file_to_build_library(path,
         host_cflags = [item.replace('\\"', '\\\\"') for item in host_cflags]
         host_cflags = ' '.join(host_cflags)
         # sycl_cflags += _wrap_sycl_host_flags(host_cflags)
-        sycl_dlink_post_cflags = _SYCL_DLINK_FLAGS
+        sycl_dlink_post_cflags = _get_sycl_dlink_flags(sycl_cflags)
     else:
         sycl_cflags = None
         sycl_dlink_post_cflags = None

--- a/vllm/custom-esimd-kernels-vllm/tests/test_build_flags.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/test_build_flags.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import esimd_build_extention as build_extension  # noqa: E402
+
+
+def test_sycl_dlink_uses_common_compile_target(monkeypatch):
+    monkeypatch.setenv("TORCH_XPU_ARCH_LIST", "bmg-g21")
+
+    flags = build_extension._get_sycl_dlink_flags(
+        build_extension._COMMON_SYCL_FLAGS)
+
+    assert "-fsycl-targets=spir64_gen,spir64" in flags
+    assert '-Xs "-device bmg-g21"' in flags
+
+
+def test_sycl_dlink_uses_extension_target_override(monkeypatch):
+    monkeypatch.setenv("TORCH_XPU_ARCH_LIST", "bmg-g21")
+    compile_flags = [
+        *build_extension._COMMON_SYCL_FLAGS,
+        "-fsycl-targets=spir64_gen",
+    ]
+
+    flags = build_extension._get_sycl_dlink_flags(compile_flags)
+
+    assert "-fsycl-targets=spir64_gen" in flags
+    assert "-fsycl-targets=spir64_gen,spir64" not in flags
+    assert flags.count("-fsycl-targets=spir64_gen") == 1


### PR DESCRIPTION
## Summary

- derive SYCL device-link targets from the effective compile flags
- keep AOT-only extensions on `spir64_gen` during device linking
- preserve the default `spir64_gen,spir64` target set for extensions without overrides
- add unit coverage for default and extension-specific target selection

## Problem

AOT extensions override the common compile target with `-fsycl-targets=spir64_gen`, but device linking previously always requested `spir64_gen,spir64`. The resulting object contained only `spir64_gen`, causing an `icpx` target mismatch and an `llvm-foreach` segmentation fault during device linking.

## Validation

```text
TORCH_XPU_ARCH_LIST=bmg-g21 python3 -m pytest -q vllm/custom-esimd-kernels-vllm/tests/test_build_flags.py
2 passed
```