### PR TITLE
Refactor/omni keep compiler

### DIFF
--- a/omni/docker/Dockerfile
+++ b/omni/docker/Dockerfile
@@ -2,67 +2,54 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-ARG BASE_IMAGE=intel/llm-scaler-platform:26.13.7.1
+ARG BUILDER_IMAGE=intel/omix:0.1.0-devel-ubuntu24.04
+ARG RUNTIME_IMAGE=intel/pytorch:xpu-2.11.0-ubuntu24.04
 ARG PYTHON_VERSION=3.12
-ARG TORCH_VERSION=2.10.0
-ARG TORCHVISION_VERSION=0.25.0
-ARG TORCHAUDIO_VERSION=2.10.0
-ARG ONEAPI_VERSION=2025.2.0-517
+ARG TORCH_VERSION=2.11.0+xpu
 ARG IMAGE_TAG
 
-# ======== Builder Stage ========
-FROM ${BASE_IMAGE} AS builder
+FROM ${BUILDER_IMAGE} AS builder
 
 ARG https_proxy
 ARG http_proxy
+ARG no_proxy
 ARG PYTHON_VERSION
 ARG TORCH_VERSION
-ARG TORCHVISION_VERSION
-ARG TORCHAUDIO_VERSION
-ARG ONEAPI_VERSION
 ARG IMAGE_TAG
 
 RUN test -n "${IMAGE_TAG}"
 
-ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib/python${PYTHON_VERSION}/dist-packages/torch/lib:${LD_LIBRARY_PATH}"
+ENV VIRTUAL_ENV=/opt/buildenv \
+    PATH="/opt/buildenv/bin:${PATH}" \
+    LD_LIBRARY_PATH="/usr/local/lib:/opt/buildenv/lib/python${PYTHON_VERSION}/site-packages/torch/lib:${LD_LIBRARY_PATH}"
 
-# System packages
-RUN wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
-        | gpg --dearmor \
-        | tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null && \
-    echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" \
-        | tee /etc/apt/sources.list.d/oneAPI.list && \
-    add-apt-repository -y ppa:kobuk-team/intel-graphics && \
+SHELL ["bash", "-c"]
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     apt-get update -y && \
-    apt-get install -y python${PYTHON_VERSION} python${PYTHON_VERSION}-dev python3-pip && \
-    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1 && \
-    update-alternatives --install /usr/bin/python  python  /usr/bin/python${PYTHON_VERSION} 1 && \
     apt-get install -y --no-install-recommends --fix-missing \
-        curl ffmpeg git libsndfile1 libsm6 libxext6 libgl1 \
-        lsb-release numactl wget vim linux-libc-dev \
+        curl ffmpeg git patch ca-certificates \
+        python3-dev python3-venv python3-pip \
+        build-essential ninja-build cmake pkg-config \
+        libsndfile1 libsm6 libxext6 libgl1 numactl wget vim linux-libc-dev \
         libopengl0 libglx0 libxrender1 libxfixes3 libx11-dev \
         libxi6 libxxf86vm1 libxcursor1 libxrandr2 libxinerama1 \
-        libxkbcommon0 && \
-    apt remove python3-blinker -y && \
-    apt-get install -y intel-oneapi-dpcpp-ct=${ONEAPI_VERSION} && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    rm -f /usr/lib/python3*/EXTERNALLY-MANAGED
+        libxkbcommon0
 
-# PyTorch
+RUN python3 -m venv ${VIRTUAL_ENV} && \
+    pip install --upgrade pip setuptools wheel
+
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install \
         torch==${TORCH_VERSION} \
-        torchvision==${TORCHVISION_VERSION} \
-        torchaudio==${TORCHAUDIO_VERSION} \
+        torchvision \
+        torchaudio \
         --index-url https://download.pytorch.org/whl/xpu && \
     pip install pytest
 
-# omni_xpu_kernel is installed AFTER sgl-kernel-xpu (below): its cute FMHA
-# extension needs the cutlass-sycl headers that sgl-kernel-xpu fetches into
-# build/_deps/repo-cutlass-sycl-src.
 COPY ./omni_xpu_kernel /tmp/omni_xpu_kernel
 
-# xDiT / long-context-attention
 COPY ./patches/yunchang_for_multi_arc.patch /tmp/
 COPY ./patches/xdit_for_multi_arc.patch /tmp/
 
@@ -84,7 +71,6 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pip install -e . && \
     rm -f /tmp/yunchang_for_multi_arc.patch /tmp/xdit_for_multi_arc.patch
 
-# ComfyUI core (upstream, no patches)
 RUN --mount=type=cache,target=/root/.cache/pip \
     cd /llm && \
     git clone --depth 1 https://github.com/comfyanonymous/ComfyUI.git && \
@@ -93,14 +79,12 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     git checkout bb131be9e83d2f773c90f1d6f1e4b248a498c8c5 && \
     pip install -r requirements.txt
 
-# ComfyUI-OmniXPU: Intel XPU acceleration via custom node (replaces core patch)
 COPY ./ComfyUI-OmniXPU /llm/ComfyUI/custom_nodes/ComfyUI-OmniXPU
 RUN cd /llm/ComfyUI/custom_nodes/ComfyUI-OmniXPU && \
     git init && git add -A && \
     git -c user.name="llm-scaler" -c user.email="noreply@intel.com" \
         commit --allow-empty -m "ComfyUI-OmniXPU ${IMAGE_TAG}"
 
-# ComfyUI custom nodes (active)
 COPY ./patches/raylight_for_multi_arc.patch /tmp/
 COPY ./patches/comfyui_controlnet_aux_depth_anything_v2_xpu.patch /tmp/
 
@@ -138,7 +122,6 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pip install -r requirements.txt && \
     rm -f /tmp/raylight_for_multi_arc.patch /tmp/comfyui_controlnet_aux_depth_anything_v2_xpu.patch
 
-# nunchaku-torch runtime + ComfyUI-nunchaku-XPU custom node (SVDQuant W4A4/W4A16 diffusion inference)
 RUN --mount=type=cache,target=/root/.cache/pip \
     cd /llm && \
     git clone --depth 1 https://github.com/xiangyuT/nunchaku-torch.git && \
@@ -154,7 +137,6 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pip install -r requirements.txt && \
     pip install --no-deps kernels==0.14.0
 
-# ComfyUI disabled custom nodes (optional: --build-arg INSTALL_DISABLED_NODES=true)
 ARG INSTALL_DISABLED_NODES=true
 COPY ./patches/comfyui_voxcpm_for_xpu.patch /tmp/
 COPY ./patches/comfyui_indextts.patch /tmp/
@@ -209,20 +191,25 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     fi && \
     rm -f /tmp/*.patch
 
-# Xinference
 COPY ./patches/xinference_device_utils.patch /tmp/
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install "xinference[transformers]==1.15.0" \
         kokoro Jinja2==3.1.6 jieba ordered-set pypinyin cn2an pypinyin-dict && \
-    patch /usr/local/lib/python${PYTHON_VERSION}/dist-packages/xinference/device_utils.py \
+    patch ${VIRTUAL_ENV}/lib/python${PYTHON_VERSION}/site-packages/xinference/device_utils.py \
         < /tmp/xinference_device_utils.patch && \
     rm -f /tmp/xinference_device_utils.patch
 
-# SGLang Diffusion + sgl-kernel-xpu
 COPY ./patches/sglang_diffusion_for_multi_arc.patch /tmp/
 
+ARG DPCPP_SYCL_TARGET=bmg
+ARG SGL_KERNEL_XPU_COMMIT=9aef6481524906d11956bf4b4ab8e243c5128b4e
+
 RUN --mount=type=cache,target=/root/.cache/pip \
+    source /opt/intel/oneapi/setvars.sh --force && \
+    export TORCH_XPU_ARCH_LIST=${DPCPP_SYCL_TARGET} && \
+    export OMNI_XPU_DEVICE=${DPCPP_SYCL_TARGET} && \
+    mkdir -p /wheels && \
     cd /llm && \
     git clone --depth 1 https://github.com/sgl-project/sglang.git && \
     cd sglang && \
@@ -241,8 +228,8 @@ RUN --mount=type=cache,target=/root/.cache/pip \
         'peft==0.19.1' && \
     pip install \
         torch==${TORCH_VERSION} \
-        torchvision==${TORCHVISION_VERSION} \
-        torchaudio==${TORCHAUDIO_VERSION} \
+        torchvision \
+        torchaudio \
         --index-url https://download.pytorch.org/whl/xpu && \
     pip install triton==3.5.0 && \
     pip install pytorch-triton-xpu==3.5.0 \
@@ -250,75 +237,114 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     cd /llm && \
     git clone --depth 1 https://github.com/sgl-project/sgl-kernel-xpu.git && \
     cd sgl-kernel-xpu && \
-    pip install -v . && \
+    git fetch --depth 1 origin ${SGL_KERNEL_XPU_COMMIT} && \
+    git checkout ${SGL_KERNEL_XPU_COMMIT} && \
+    CMAKE_BUILD_PARALLEL_LEVEL=8 MAX_JOBS=8 pip wheel -v . \
+        --config-settings=cmake.define.DPCPP_SYCL_TARGET=${DPCPP_SYCL_TARGET} \
+        --wheel-dir /wheels --no-deps && \
+    pip install --no-deps /wheels/sgl_kernel-*.whl && \
     cp -r /llm/sglang/python/sglang/multimodal_gen/apps/ComfyUI_SGLDiffusion \
         /llm/ComfyUI/custom_nodes/ && \
     rm -f /tmp/sglang_diffusion_for_multi_arc.patch
 
-# omni_xpu_kernel (installed here so its cute FMHA ext can use sgl-kernel-xpu's
-# cutlass-sycl headers). CUTLASS_SYCL_ROOT points at the fetched tree; the cute
-# ext is AOT-compiled for OMNI_XPU_DEVICE (bmg = Arc B-series).
 RUN --mount=type=cache,target=/root/.cache/pip \
+    source /opt/intel/oneapi/setvars.sh --force && \
+    export TORCH_XPU_ARCH_LIST=${DPCPP_SYCL_TARGET} && \
     export CUTLASS_SYCL_ROOT=/llm/sgl-kernel-xpu/build/_deps/repo-cutlass-sycl-src && \
     export OMNI_XPU_REQUIRE_CUTE=1 && \
-    export OMNI_XPU_DEVICE=bmg && \
+    export OMNI_XPU_DEVICE=${DPCPP_SYCL_TARGET} && \
     cd /tmp/omni_xpu_kernel && \
     grep -Fqx "__version__ = \"${IMAGE_TAG}\"" omni_xpu_kernel/_version.py && \
-    pip install . --no-build-isolation && \
+    CMAKE_BUILD_PARALLEL_LEVEL=8 MAX_JOBS=8 \
+        pip wheel . --wheel-dir /wheels --no-deps --no-build-isolation && \
+    pip install --no-deps /wheels/omni_xpu_kernel-*.whl && \
     rm -rf /tmp/omni_xpu_kernel
 
-# Application files
+RUN ls -lh /wheels/
+
 COPY ./workflows/* /llm/ComfyUI/user/default/workflows/
 COPY ./example_inputs/* /llm/ComfyUI/input/
 COPY ./tools/* /llm/tools/
 COPY ./entrypoints/* /llm/entrypoints/
 
-# ======== Runtime Stage ========
-FROM ${BASE_IMAGE} AS runtime
+RUN pip freeze --exclude-editable --all | \
+    sed -E \
+        -e '/^(omni_xpu_kernel|sgl-kernel) @ file:/d' \
+        -e '/^(torch|torchaudio|torchvision|triton|triton-xpu|pytorch-triton-xpu)==/d' \
+        -e '/^(dpcpp-cpp-rt|impi-rt|intel-cmplr-lib-rt|intel-cmplr-lib-ur|intel-cmplr-lic-rt|intel-opencl-rt|intel-openmp|intel-pti|intel-sycl-rt|mkl|oneccl|oneccl-devel|onemkl-license|onemkl-sycl-blas|onemkl-sycl-dft|onemkl-sycl-lapack|onemkl-sycl-rng|onemkl-sycl-sparse|tbb|tcmlib|umf)==/d' \
+        -e '/^(pip|setuptools|wheel)==/d' \
+        > /runtime-requirements.txt && \
+    rm -rf /llm/sgl-kernel-xpu
+
+FROM ${RUNTIME_IMAGE} AS runtime
 
 ARG https_proxy
 ARG http_proxy
-ARG PYTHON_VERSION=3.12
-ARG ONEAPI_VERSION=2025.2.0-517
+ARG no_proxy
+ARG PYTHON_VERSION
 ARG IMAGE_TAG
+ARG DPCPP_SYCL_TARGET=bmg
 
 LABEL org.opencontainers.image.version="${IMAGE_TAG}"
 
-# System packages
-RUN wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
-        | gpg --dearmor \
-        | tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null && \
-    echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" \
-        | tee /etc/apt/sources.list.d/oneAPI.list && \
-    add-apt-repository -y ppa:kobuk-team/intel-graphics && \
-    apt-get update -y && \
-    apt-get install -y python${PYTHON_VERSION} python${PYTHON_VERSION}-dev python3-pip && \
-    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1 && \
-    update-alternatives --install /usr/bin/python  python  /usr/bin/python${PYTHON_VERSION} 1 && \
-    apt-get install -y --no-install-recommends --fix-missing \
-        curl ffmpeg git libsndfile1 libsm6 libxext6 libgl1 \
-        lsb-release numactl wget vim linux-libc-dev \
-        libopengl0 libglx0 libxrender1 libxfixes3 libx11-dev \
-        libxi6 libxxf86vm1 libxcursor1 libxrandr2 libxinerama1 \
-        libxkbcommon0 && \
-    apt remove python3-blinker -y && \
-    apt-get install -y intel-oneapi-dpcpp-ct=${ONEAPI_VERSION} && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    rm -f /usr/lib/python3*/EXTERNALLY-MANAGED
-
-# Copy built artifacts from builder
-COPY --from=builder /usr/local/lib/python${PYTHON_VERSION}/ /usr/local/lib/python${PYTHON_VERSION}/
-COPY --from=builder /usr/local/bin/ /usr/local/bin/
-COPY --from=builder /usr/local/lib/*.so* /usr/local/lib/
 COPY --from=builder /llm/ /llm/
+COPY --from=builder /runtime-requirements.txt /tmp/runtime-requirements.txt
 
-# Fix for multi-XPU support: copy SYCL native binary files to a common library path
-RUN cp /opt/intel/oneapi/compiler/2025.3/lib/libsycl-native-*.spv /usr/local/lib/
+ENV http_proxy=${http_proxy} \
+    https_proxy=${https_proxy} \
+    no_proxy=${no_proxy} \
+    PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/xpu" \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    TORCH_XPU_ARCH_LIST=${DPCPP_SYCL_TARGET} \
+    OMNI_XPU_DEVICE=${DPCPP_SYCL_TARGET} \
+    LD_LIBRARY_PATH="/usr/local/lib:/opt/venv/lib/python${PYTHON_VERSION}/site-packages/torch/lib:${LD_LIBRARY_PATH}" \
+    CCL_SYCL_ALLTOALL_ARC_LL=1 \
+    CCL_SYCL_CCL_BARRIER=1 \
+    OMNIXPU_INTERPOLATE_FIX=0 \
+    OMNI_IMAGE_VERSION="${IMAGE_TAG}"
 
-ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib/python${PYTHON_VERSION}/dist-packages/torch/lib:${LD_LIBRARY_PATH}"
-ENV CCL_SYCL_ALLTOALL_ARC_LL=1
-ENV CCL_SYCL_CCL_BARRIER=1
-ENV OMNIXPU_INTERPOLATE_FIX=0
-ENV OMNI_IMAGE_VERSION="${IMAGE_TAG}"
+SHELL ["bash", "-c"]
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=bind,from=builder,source=/wheels,target=/tmp/wheels \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends --fix-missing \
+        curl ffmpeg git libsndfile1 libsm6 libxext6 libgl1 numactl wget \
+        libopengl0 libglx0 libxrender1 libxfixes3 libxi6 libxxf86vm1 \
+        libxcursor1 libxrandr2 libxinerama1 libxkbcommon0 && \
+    pip install --no-deps -r /tmp/runtime-requirements.txt && \
+    pip install --no-deps \
+        /tmp/wheels/sgl_kernel-*.whl \
+        /tmp/wheels/omni_xpu_kernel-*.whl && \
+    pip install --no-deps -e /llm/long-context-attention && \
+    pip install --no-deps -e /llm/xDiT && \
+    pip install --no-deps -e /llm/nunchaku-torch && \
+    pip install --no-deps -e /llm/sglang/python && \
+    rm -f /tmp/runtime-requirements.txt && \
+    rm -rf /var/lib/apt/lists/* /root/.cmake /var/tmp/* && \
+    find /opt/venv -name '*.pyc' -delete && \
+    { find /opt/venv -name '__pycache__' -type d -exec rm -rf {} + 2>/dev/null || true; }
+
+# omni_xpu_kernel links against the oneDNN 3.9 ABI used during build.
+COPY --from=builder /opt/intel/oneapi/dnnl/2025.3/lib/libdnnl.so.3.9 /usr/local/lib/libdnnl.so.3.9
+
+RUN ln -sf libdnnl.so.3.9 /usr/local/lib/libdnnl.so.3 && \
+    ln -sf libdnnl.so.3.9 /usr/local/lib/libdnnl.so && \
+    ldconfig
+
+ENV LD_LIBRARY_PATH="/usr/local/lib:/opt/venv/lib:/opt/venv/lib/python3.12/site-packages/torch/lib"
+
+# Copy only the oneDNN runtime library required by omni_xpu_kernel.
+COPY --from=builder \
+    /opt/intel/oneapi/dnnl/2025.3/lib/libdnnl.so.3.9 \
+    /usr/local/lib/libdnnl.so.3.9
+
+RUN ln -sf libdnnl.so.3.9 /usr/local/lib/libdnnl.so.3 && \
+    ln -sf libdnnl.so.3.9 /usr/local/lib/libdnnl.so && \
+    ldconfig
+
+ENV LD_LIBRARY_PATH="/usr/local/lib:/opt/venv/lib:/opt/venv/lib/python3.12/site-packages/torch/lib:${LD_LIBRARY_PATH}"
 
 WORKDIR /llm/entrypoints

--- a/omni/docker/Dockerfile
+++ b/omni/docker/Dockerfile
@@ -2,75 +2,125 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-ARG BUILDER_IMAGE=intel/omix:0.1.0-devel-ubuntu24.04
-ARG RUNTIME_IMAGE=intel/pytorch:xpu-2.11.0-ubuntu24.04
+# Full Omni two-stage development image built with the repository's original two-stage
+# builder/runtime structure.
+#
+# The runtime stage deliberately uses the OMIX devel base as well.  Therefore
+# the single delivered image keeps the complete oneAPI compiler and GPU runtime
+# while the builder/runtime boundary still isolates the build procedure.
+
+ARG BASE_IMAGE=intel/omix:0.1.0-devel-ubuntu24.04
 ARG PYTHON_VERSION=3.12
 ARG TORCH_VERSION=2.11.0+xpu
+ARG TORCHVISION_VERSION=0.26.0+xpu
+ARG TORCHAUDIO_VERSION=2.11.0+xpu
+ARG SGL_KERNEL_COMMIT=9aef6481524906d11956bf4b4ab8e243c5128b4e
+ARG DPCPP_SYCL_TARGET=bmg
+ARG MAX_JOBS=8
 ARG IMAGE_TAG
 
-FROM ${BUILDER_IMAGE} AS builder
+# ======== Builder Stage ========
+# OMIX devel already provides oneAPI 2025.3 (compiler + runtime libraries), so
+# unlike llm-scaler-platform we must not reinstall a separately pinned DPC++
+# compiler from Intel's apt repository.
+FROM ${BASE_IMAGE} AS builder
 
 ARG https_proxy
 ARG http_proxy
-ARG no_proxy
+ARG no_proxy=localhost,127.0.0.1,::1,intel.com,.intel.com
 ARG PYTHON_VERSION
 ARG TORCH_VERSION
+ARG TORCHVISION_VERSION
+ARG TORCHAUDIO_VERSION
+ARG SGL_KERNEL_COMMIT
+ARG DPCPP_SYCL_TARGET
+ARG MAX_JOBS
 ARG IMAGE_TAG
 
 RUN test -n "${IMAGE_TAG}"
 
-ENV VIRTUAL_ENV=/opt/buildenv \
-    PATH="/opt/buildenv/bin:${PATH}" \
-    LD_LIBRARY_PATH="/usr/local/lib:/opt/buildenv/lib/python${PYTHON_VERSION}/site-packages/torch/lib:${LD_LIBRARY_PATH}"
+ENV DEBIAN_FRONTEND=noninteractive \
+    VIRTUAL_ENV=/opt/venv \
+    PATH="/opt/venv/bin:/opt/intel/oneapi/compiler/latest/bin:${PATH}" \
+    PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/xpu" \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    http_proxy=${http_proxy} \
+    https_proxy=${https_proxy} \
+    no_proxy=${no_proxy} \
+    TORCH_XPU_ARCH_LIST=${DPCPP_SYCL_TARGET} \
+    OMNI_XPU_DEVICE=${DPCPP_SYCL_TARGET} \
+    MAX_JOBS=${MAX_JOBS} \
+    CMAKE_BUILD_PARALLEL_LEVEL=${MAX_JOBS}
+
+# Make both Python entrypoints and native extensions work without requiring the
+# user to source setvars.sh first.  Source builds below still source setvars.sh
+# so they receive the complete oneAPI compiler environment.
+ENV LD_LIBRARY_PATH="/opt/venv/lib:/opt/venv/lib/python${PYTHON_VERSION}/site-packages/torch/lib:/opt/intel/oneapi/compiler/latest/lib:/opt/intel/oneapi/dnnl/latest/lib:/opt/intel/oneapi/mkl/latest/lib:/opt/intel/oneapi/tbb/latest/lib:/opt/intel/oneapi/mpi/latest/lib:${LD_LIBRARY_PATH}"
 
 SHELL ["bash", "-c"]
 
+# System packages
+# The compiler is deliberately not installed here: it is supplied and
+# maintained as part of the OMIX devel base image.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     apt-get update -y && \
     apt-get install -y --no-install-recommends --fix-missing \
-        curl ffmpeg git patch ca-certificates \
+        ca-certificates curl ffmpeg git patch \
         python3-dev python3-venv python3-pip \
         build-essential ninja-build cmake pkg-config \
-        libsndfile1 libsm6 libxext6 libgl1 numactl wget vim linux-libc-dev \
+        libsndfile1 libsm6 libxext6 libgl1 \
+        lsb-release numactl wget vim linux-libc-dev \
         libopengl0 libglx0 libxrender1 libxfixes3 libx11-dev \
         libxi6 libxxf86vm1 libxcursor1 libxrandr2 libxinerama1 \
         libxkbcommon0
 
+# Isolated Python environment.  This avoids modifying OMIX's system Python and
+# keeps every Python package used by the delivered image under /opt/venv.
 RUN python3 -m venv ${VIRTUAL_ENV} && \
     pip install --upgrade pip setuptools wheel
 
+# PyTorch
+# Torch 2.11 must match the native extensions built in this image.
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install \
         torch==${TORCH_VERSION} \
-        torchvision \
-        torchaudio \
+        torchvision==${TORCHVISION_VERSION} \
+        torchaudio==${TORCHAUDIO_VERSION} \
         --index-url https://download.pytorch.org/whl/xpu && \
     pip install pytest
 
-COPY ./omni_xpu_kernel /tmp/omni_xpu_kernel
+RUN mkdir -p /llm /wheels
 
-COPY ./patches/yunchang_for_multi_arc.patch /tmp/
-COPY ./patches/xdit_for_multi_arc.patch /tmp/
+# omni_xpu_kernel is installed AFTER sgl-kernel-xpu (below): its cute FMHA
+# extension needs the cutlass-sycl headers that sgl-kernel-xpu fetches into
+# build/_deps/repo-cutlass-sycl-src.
+# Keep the complete local source under /llm so it can be transferred to and
+# rebuilt inside the runtime image.
+COPY ./omni_xpu_kernel /llm/omni_xpu_kernel
 
+# Keep project patches for the final image as part of the source-development
+# environment and use them directly from this stable path.
+COPY ./patches /llm/patches
+
+# xDiT / long-context-attention
 RUN --mount=type=cache,target=/root/.cache/pip \
-    mkdir -p /llm && \
     cd /llm && \
     git clone --depth 1 https://github.com/feifeibear/long-context-attention.git && \
     cd long-context-attention && \
     git fetch --depth 1 origin fc5d55e61b78b3102fd824bea1791cf406cc2a4b && \
     git checkout fc5d55e61b78b3102fd824bea1791cf406cc2a4b && \
-    git apply /tmp/yunchang_for_multi_arc.patch && \
+    git apply /llm/patches/yunchang_for_multi_arc.patch && \
     pip install -e . && \
     cd /llm && \
     git clone --depth 1 https://github.com/xdit-project/xDiT.git && \
     cd xDiT && \
     git fetch --depth 1 origin fb8fb0e437a8745b9629020759de31d1626a4a7b && \
     git checkout fb8fb0e437a8745b9629020759de31d1626a4a7b && \
-    git apply /tmp/xdit_for_multi_arc.patch && \
-    pip install -e . && \
-    rm -f /tmp/yunchang_for_multi_arc.patch /tmp/xdit_for_multi_arc.patch
+    git apply /llm/patches/xdit_for_multi_arc.patch && \
+    pip install -e .
 
+# ComfyUI core (upstream, no patches)
 RUN --mount=type=cache,target=/root/.cache/pip \
     cd /llm && \
     git clone --depth 1 https://github.com/comfyanonymous/ComfyUI.git && \
@@ -79,15 +129,14 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     git checkout bb131be9e83d2f773c90f1d6f1e4b248a498c8c5 && \
     pip install -r requirements.txt
 
+# ComfyUI-OmniXPU: Intel XPU acceleration via custom node (replaces core patch)
 COPY ./ComfyUI-OmniXPU /llm/ComfyUI/custom_nodes/ComfyUI-OmniXPU
 RUN cd /llm/ComfyUI/custom_nodes/ComfyUI-OmniXPU && \
     git init && git add -A && \
     git -c user.name="llm-scaler" -c user.email="noreply@intel.com" \
         commit --allow-empty -m "ComfyUI-OmniXPU ${IMAGE_TAG}"
 
-COPY ./patches/raylight_for_multi_arc.patch /tmp/
-COPY ./patches/comfyui_controlnet_aux_depth_anything_v2_xpu.patch /tmp/
-
+# ComfyUI custom nodes (active)
 RUN --mount=type=cache,target=/root/.cache/pip \
     cd /llm/ComfyUI/custom_nodes && \
     git clone --depth 1 https://github.com/ltdrdata/ComfyUI-Manager.git comfyui-manager && \
@@ -97,7 +146,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     cd raylight && \
     git fetch --depth 1 origin c91ef47afb02e522bf08ff199ea2182642de0368 && \
     git checkout c91ef47afb02e522bf08ff199ea2182642de0368 && \
-    git apply /tmp/raylight_for_multi_arc.patch && \
+    git apply /llm/patches/raylight_for_multi_arc.patch && \
     pip install ray==2.49.2 -r requirements.txt && \
     cd /llm/ComfyUI/custom_nodes && \
     git clone --depth 1 https://github.com/yolain/ComfyUI-Easy-Use.git comfyui-easy-use && \
@@ -106,7 +155,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     cd comfyui_controlnet_aux && \
     git fetch --depth 1 origin e8b689a513c3e6b63edc44066560ca5919c0576e && \
     git checkout e8b689a513c3e6b63edc44066560ca5919c0576e && \
-    git apply /tmp/comfyui_controlnet_aux_depth_anything_v2_xpu.patch && \
+    git apply /llm/patches/comfyui_controlnet_aux_depth_anything_v2_xpu.patch && \
     cd .. && \
     pip install -r comfyui_controlnet_aux/requirements.txt && \
     git clone --depth 1 https://github.com/kijai/ComfyUI-KJNodes.git && \
@@ -119,9 +168,9 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pip install -r ComfyUI-CacheDiT/requirements.txt && \
     git clone --depth 1 https://github.com/analytics-zoo/ComfyUI-GGUF-XPU.git && \
     cd ComfyUI-GGUF-XPU && \
-    pip install -r requirements.txt && \
-    rm -f /tmp/raylight_for_multi_arc.patch /tmp/comfyui_controlnet_aux_depth_anything_v2_xpu.patch
+    pip install -r requirements.txt
 
+# nunchaku-torch runtime + ComfyUI-nunchaku-XPU custom node (SVDQuant W4A4/W4A16 diffusion inference)
 RUN --mount=type=cache,target=/root/.cache/pip \
     cd /llm && \
     git clone --depth 1 https://github.com/xiangyuT/nunchaku-torch.git && \
@@ -137,85 +186,75 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pip install -r requirements.txt && \
     pip install --no-deps kernels==0.14.0
 
-ARG INSTALL_DISABLED_NODES=true
-COPY ./patches/comfyui_voxcpm_for_xpu.patch /tmp/
-COPY ./patches/comfyui_indextts.patch /tmp/
-COPY ./patches/comfyui_hunyuan3d_for_xpu.patch /tmp/
-COPY ./patches/comfyui_hy_motion1.patch /tmp/
-COPY ./patches/comfyui_seedvr2_xpu.patch /tmp/
-COPY ./patches/comfyui_flashvsr_ultra_fast_xpu.patch /tmp/
-
+# ComfyUI disabled custom nodes (optional: --build-arg INSTALL_DISABLED_NODES=true)
+# SeedVR2 remains optional as requested; it is not installed in the default
+# image when INSTALL_DISABLED_NODES=false.
+ARG INSTALL_DISABLED_NODES=false
 RUN --mount=type=cache,target=/root/.cache/pip \
     if [ "${INSTALL_DISABLED_NODES}" = "true" ]; then \
-    cd /llm/ComfyUI/custom_nodes && \
-    git clone --depth 1 https://github.com/wildminder/ComfyUI-VoxCPM.git comfyui-voxcpm.disabled && \
-    cd comfyui-voxcpm.disabled && \
-    git fetch --depth 1 origin 7875a8a36a531b7efef8cac96dc74001d3cb5895 && \
-    git checkout 7875a8a36a531b7efef8cac96dc74001d3cb5895 && \
-    git apply /tmp/comfyui_voxcpm_for_xpu.patch && \
-    pip install -r requirements.txt && \
-    cd /llm/ComfyUI/custom_nodes && \
-    git clone --depth 1 https://github.com/billwuhao/ComfyUI_IndexTTS.git ComfyUI_IndexTTS.disabled && \
-    cd ComfyUI_IndexTTS.disabled && \
-    git apply /tmp/comfyui_indextts.patch && \
-    pip install -r requirements.txt torchcodec==0.9.0 && \
-    cd /llm/ComfyUI/custom_nodes && \
-    git clone --depth 1 https://github.com/visualbruno/ComfyUI-Hunyuan3d-2-1.git ComfyUI-Hunyuan3d-2-1.disabled && \
-    cd ComfyUI-Hunyuan3d-2-1.disabled && \
-    git fetch --depth 1 origin 9d7ef32509101495a7840b3ae8e718c8d1183305 && \
-    git checkout 9d7ef32509101495a7840b3ae8e718c8d1183305 && \
-    git apply /tmp/comfyui_hunyuan3d_for_xpu.patch && \
-    pip install rembg realesrgan -r requirements.txt && \
-    cd hy3dpaint/custom_rasterizer && python setup.py install && \
-    cd ../DifferentiableRenderer && python setup.py install && \
-    cd /llm/ComfyUI/custom_nodes && \
-    git clone --depth 1 https://github.com/jtydhr88/ComfyUI-HY-Motion1.git ComfyUI-HY-Motion1.disabled && \
-    cd ComfyUI-HY-Motion1.disabled && \
-    git fetch --depth 1 origin 47b1d0d96eeac6d4b99509ede91490eaba93440a && \
-    git checkout 47b1d0d96eeac6d4b99509ede91490eaba93440a && \
-    git apply /tmp/comfyui_hy_motion1.patch && \
-    pip install -r requirements.txt && \
-    cd /llm/ComfyUI/custom_nodes && \
-    git clone --depth 1 https://github.com/numz/ComfyUI-SeedVR2_VideoUpscaler.git ComfyUI-SeedVR2_VideoUpscaler.disabled && \
-    cd ComfyUI-SeedVR2_VideoUpscaler.disabled && \
-    git fetch --depth 1 origin 4490bd1f482e026674543386bb2a4d176da245b9 && \
-    git checkout 4490bd1f482e026674543386bb2a4d176da245b9 && \
-    git apply /tmp/comfyui_seedvr2_xpu.patch && \
-    pip install -r requirements.txt && \
-    cd /llm/ComfyUI/custom_nodes && \
-    git clone --depth 1 https://github.com/lihaoyun6/ComfyUI-FlashVSR_Ultra_Fast.git ComfyUI-FlashVSR_Ultra_Fast.disabled && \
-    cd ComfyUI-FlashVSR_Ultra_Fast.disabled && \
-    git fetch --depth 1 origin 4820b3f02347bddcbbb9a5a85ab7638fe976366e && \
-    git checkout 4820b3f02347bddcbbb9a5a85ab7638fe976366e && \
-    git apply /tmp/comfyui_flashvsr_ultra_fast_xpu.patch ; \
-    fi && \
-    rm -f /tmp/*.patch
+        cd /llm/ComfyUI/custom_nodes && \
+        git clone --depth 1 https://github.com/wildminder/ComfyUI-VoxCPM.git comfyui-voxcpm.disabled && \
+        cd comfyui-voxcpm.disabled && \
+        git fetch --depth 1 origin 7875a8a36a531b7efef8cac96dc74001d3cb5895 && \
+        git checkout 7875a8a36a531b7efef8cac96dc74001d3cb5895 && \
+        git apply /llm/patches/comfyui_voxcpm_for_xpu.patch && \
+        pip install -r requirements.txt && \
+        cd /llm/ComfyUI/custom_nodes && \
+        git clone --depth 1 https://github.com/billwuhao/ComfyUI_IndexTTS.git ComfyUI_IndexTTS.disabled && \
+        cd ComfyUI_IndexTTS.disabled && \
+        git apply /llm/patches/comfyui_indextts.patch && \
+        pip install -r requirements.txt torchcodec==0.9.0 && \
+        cd /llm/ComfyUI/custom_nodes && \
+        git clone --depth 1 https://github.com/visualbruno/ComfyUI-Hunyuan3d-2-1.git ComfyUI-Hunyuan3d-2-1.disabled && \
+        cd ComfyUI-Hunyuan3d-2-1.disabled && \
+        git fetch --depth 1 origin 9d7ef32509101495a7840b3ae8e718c8d1183305 && \
+        git checkout 9d7ef32509101495a7840b3ae8e718c8d1183305 && \
+        git apply /llm/patches/comfyui_hunyuan3d_for_xpu.patch && \
+        pip install rembg realesrgan -r requirements.txt && \
+        cd hy3dpaint/custom_rasterizer && python setup.py install && \
+        cd ../DifferentiableRenderer && python setup.py install && \
+        cd /llm/ComfyUI/custom_nodes && \
+        git clone --depth 1 https://github.com/jtydhr88/ComfyUI-HY-Motion1.git ComfyUI-HY-Motion1.disabled && \
+        cd ComfyUI-HY-Motion1.disabled && \
+        git fetch --depth 1 origin 47b1d0d96eeac6d4b99509ede91490eaba93440a && \
+        git checkout 47b1d0d96eeac6d4b99509ede91490eaba93440a && \
+        git apply /llm/patches/comfyui_hy_motion1.patch && \
+        pip install -r requirements.txt && \
+        cd /llm/ComfyUI/custom_nodes && \
+        git clone --depth 1 https://github.com/numz/ComfyUI-SeedVR2_VideoUpscaler.git ComfyUI-SeedVR2_VideoUpscaler.disabled && \
+        cd ComfyUI-SeedVR2_VideoUpscaler.disabled && \
+        git fetch --depth 1 origin 4490bd1f482e026674543386bb2a4d176da245b9 && \
+        git checkout 4490bd1f482e026674543386bb2a4d176da245b9 && \
+        git apply /llm/patches/comfyui_seedvr2_xpu.patch && \
+        pip install -r requirements.txt && \
+        cd /llm/ComfyUI/custom_nodes && \
+        git clone --depth 1 https://github.com/lihaoyun6/ComfyUI-FlashVSR_Ultra_Fast.git ComfyUI-FlashVSR_Ultra_Fast.disabled && \
+        cd ComfyUI-FlashVSR_Ultra_Fast.disabled && \
+        git fetch --depth 1 origin 4820b3f02347bddcbbb9a5a85ab7638fe976366e && \
+        git checkout 4820b3f02347bddcbbb9a5a85ab7638fe976366e && \
+        git apply /llm/patches/comfyui_flashvsr_ultra_fast_xpu.patch; \
+    fi
 
-COPY ./patches/xinference_device_utils.patch /tmp/
-
+# Xinference
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install "xinference[transformers]==1.15.0" \
         kokoro Jinja2==3.1.6 jieba ordered-set pypinyin cn2an pypinyin-dict && \
-    patch ${VIRTUAL_ENV}/lib/python${PYTHON_VERSION}/site-packages/xinference/device_utils.py \
-        < /tmp/xinference_device_utils.patch && \
-    rm -f /tmp/xinference_device_utils.patch
+    XINFERENCE_DEVICE_UTILS="$(python -c 'import pathlib, xinference; print(pathlib.Path(xinference.__file__).parent / "device_utils.py")')" && \
+    patch "${XINFERENCE_DEVICE_UTILS}" < /llm/patches/xinference_device_utils.patch
 
-COPY ./patches/sglang_diffusion_for_multi_arc.patch /tmp/
-
-ARG DPCPP_SYCL_TARGET=bmg
-ARG SGL_KERNEL_XPU_COMMIT=9aef6481524906d11956bf4b4ab8e243c5128b4e
-
+# SGLang Diffusion + sgl-kernel-xpu
+# Keep the checked-out sources and native build directory in /llm so the
+# kernel can be rebuilt and debugged inside a running container.
 RUN --mount=type=cache,target=/root/.cache/pip \
+    set -eo pipefail && \
     source /opt/intel/oneapi/setvars.sh --force && \
-    export TORCH_XPU_ARCH_LIST=${DPCPP_SYCL_TARGET} && \
-    export OMNI_XPU_DEVICE=${DPCPP_SYCL_TARGET} && \
     mkdir -p /wheels && \
     cd /llm && \
     git clone --depth 1 https://github.com/sgl-project/sglang.git && \
     cd sglang && \
     git fetch --depth 1 origin 1ae3218d036c554e6c109f18233d1f75bf775c1d && \
     git checkout 1ae3218d036c554e6c109f18233d1f75bf775c1d && \
-    git apply /tmp/sglang_diffusion_for_multi_arc.patch && \
+    git apply /llm/patches/sglang_diffusion_for_multi_arc.patch && \
     cp python/pyproject_xpu.toml python/pyproject.toml && \
     sed -i '/sgl-kernel/d' python/pyproject.toml && \
     sed -i 's/"transformers==[0-9.]*"/"transformers"/' python/pyproject.toml && \
@@ -228,8 +267,8 @@ RUN --mount=type=cache,target=/root/.cache/pip \
         'peft==0.19.1' && \
     pip install \
         torch==${TORCH_VERSION} \
-        torchvision \
-        torchaudio \
+        torchvision==${TORCHVISION_VERSION} \
+        torchaudio==${TORCHAUDIO_VERSION} \
         --index-url https://download.pytorch.org/whl/xpu && \
     pip install triton==3.5.0 && \
     pip install pytorch-triton-xpu==3.5.0 \
@@ -237,114 +276,152 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     cd /llm && \
     git clone --depth 1 https://github.com/sgl-project/sgl-kernel-xpu.git && \
     cd sgl-kernel-xpu && \
-    git fetch --depth 1 origin ${SGL_KERNEL_XPU_COMMIT} && \
-    git checkout ${SGL_KERNEL_XPU_COMMIT} && \
-    CMAKE_BUILD_PARALLEL_LEVEL=8 MAX_JOBS=8 pip wheel -v . \
+    git fetch --depth 1 origin ${SGL_KERNEL_COMMIT} && \
+    git checkout ${SGL_KERNEL_COMMIT} && \
+    pip wheel -v . \
         --config-settings=cmake.define.DPCPP_SYCL_TARGET=${DPCPP_SYCL_TARGET} \
         --wheel-dir /wheels --no-deps && \
     pip install --no-deps /wheels/sgl_kernel-*.whl && \
     cp -r /llm/sglang/python/sglang/multimodal_gen/apps/ComfyUI_SGLDiffusion \
-        /llm/ComfyUI/custom_nodes/ && \
-    rm -f /tmp/sglang_diffusion_for_multi_arc.patch
+        /llm/ComfyUI/custom_nodes/
+
+# omni_xpu_kernel (installed here so its cute FMHA ext can use sgl-kernel-xpu's
+# cutlass-sycl headers). CUTLASS_SYCL_ROOT points at the fetched tree; the cute
+# ext is AOT-compiled for OMNI_XPU_DEVICE (bmg = Arc B-series).
+# The setup.py source also contains the Torch-2.11/oneDNN include-order fix; the
+# resulting extension must reference dnnl_primitive_attr_set_zero_points
+# (without the _v2 suffix).
+ENV CUTLASS_SYCL_ROOT=/llm/sgl-kernel-xpu/build/_deps/repo-cutlass-sycl-src \
+    OMNI_XPU_REQUIRE_CUTE=1
 
 RUN --mount=type=cache,target=/root/.cache/pip \
+    set -eo pipefail && \
     source /opt/intel/oneapi/setvars.sh --force && \
-    export TORCH_XPU_ARCH_LIST=${DPCPP_SYCL_TARGET} && \
-    export CUTLASS_SYCL_ROOT=/llm/sgl-kernel-xpu/build/_deps/repo-cutlass-sycl-src && \
-    export OMNI_XPU_REQUIRE_CUTE=1 && \
-    export OMNI_XPU_DEVICE=${DPCPP_SYCL_TARGET} && \
-    cd /tmp/omni_xpu_kernel && \
+    cd /llm/omni_xpu_kernel && \
     grep -Fqx "__version__ = \"${IMAGE_TAG}\"" omni_xpu_kernel/_version.py && \
-    CMAKE_BUILD_PARALLEL_LEVEL=8 MAX_JOBS=8 \
-        pip wheel . --wheel-dir /wheels --no-deps --no-build-isolation && \
-    pip install --no-deps /wheels/omni_xpu_kernel-*.whl && \
-    rm -rf /tmp/omni_xpu_kernel
+    pip wheel -v . --wheel-dir /wheels --no-deps --no-build-isolation && \
+    pip install --no-deps --force-reinstall /wheels/omni_xpu_kernel-*.whl && \
+    EXT="$(find ${VIRTUAL_ENV}/lib/python${PYTHON_VERSION}/site-packages/omni_xpu_kernel -type f -name '_C*.so' | head -1)" && \
+    test -n "${EXT}" && \
+    nm -D "${EXT}" | grep -q ' U dnnl_primitive_attr_set_zero_points$' && \
+    ! nm -D "${EXT}" | grep -q 'dnnl_primitive_attr_set_zero_points_v2'
 
-RUN ls -lh /wheels/
+# Build-time smoke test.  GPU execution is tested after image creation with
+# /dev/dri mounted, but compiler availability and native-extension loading can
+# already be verified here without access to a physical XPU.
+RUN source /opt/intel/oneapi/setvars.sh --force >/dev/null 2>&1 && \
+    command -v icpx && \
+    command -v cmake && \
+    command -v ninja && \
+    test -f /llm/omni_xpu_kernel/setup.py && \
+    test -d /llm/sgl-kernel-xpu/build && \
+    python -c "import torch; from omni_xpu_kernel import _C; import sgl_kernel; print(torch.__version__); print('native kernel imports OK')"
 
+# ComfyUI-Manager dependencies
+# Install these during image build so a fresh/ephemeral container does not need
+# PyPI access or spend about one minute installing GitPython at startup.  This
+# deliberately comes after native kernel builds to preserve their expensive
+# Docker cache when Manager requirements change.
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install -r /llm/ComfyUI/custom_nodes/comfyui-manager/requirements.txt && \
+    python -c "import git; print('ComfyUI-Manager dependencies OK')"
+
+# Application files
 COPY ./workflows/* /llm/ComfyUI/user/default/workflows/
 COPY ./example_inputs/* /llm/ComfyUI/input/
 COPY ./tools/* /llm/tools/
 COPY ./entrypoints/* /llm/entrypoints/
 
-RUN pip freeze --exclude-editable --all | \
-    sed -E \
-        -e '/^(omni_xpu_kernel|sgl-kernel) @ file:/d' \
-        -e '/^(torch|torchaudio|torchvision|triton|triton-xpu|pytorch-triton-xpu)==/d' \
-        -e '/^(dpcpp-cpp-rt|impi-rt|intel-cmplr-lib-rt|intel-cmplr-lib-ur|intel-cmplr-lic-rt|intel-opencl-rt|intel-openmp|intel-pti|intel-sycl-rt|mkl|oneccl|oneccl-devel|onemkl-license|onemkl-sycl-blas|onemkl-sycl-dft|onemkl-sycl-lapack|onemkl-sycl-rng|onemkl-sycl-sparse|tbb|tcmlib|umf)==/d' \
-        -e '/^(pip|setuptools|wheel)==/d' \
-        > /runtime-requirements.txt && \
-    rm -rf /llm/sgl-kernel-xpu
+# Wheel inventory is useful in CI logs and remains available in the runtime.
+RUN ls -lh /wheels
 
-FROM ${RUNTIME_IMAGE} AS runtime
+# ======== Runtime Stage ========
+# This is intentionally OMIX devel rather than a compiler-free PyTorch runtime.
+# It supplies a maintained, coherent oneAPI compiler + GPU runtime environment
+# without manually selecting and copying individual native libraries.
+FROM ${BASE_IMAGE} AS runtime
 
 ARG https_proxy
 ARG http_proxy
-ARG no_proxy
+ARG no_proxy=localhost,127.0.0.1,::1,intel.com,.intel.com
 ARG PYTHON_VERSION
+ARG DPCPP_SYCL_TARGET
+ARG MAX_JOBS
 ARG IMAGE_TAG
-ARG DPCPP_SYCL_TARGET=bmg
 
-LABEL org.opencontainers.image.version="${IMAGE_TAG}"
+RUN test -n "${IMAGE_TAG}"
 
-COPY --from=builder /llm/ /llm/
-COPY --from=builder /runtime-requirements.txt /tmp/runtime-requirements.txt
-
-ENV http_proxy=${http_proxy} \
-    https_proxy=${https_proxy} \
-    no_proxy=${no_proxy} \
+ENV DEBIAN_FRONTEND=noninteractive \
+    VIRTUAL_ENV=/opt/venv \
+    PATH="/opt/venv/bin:/opt/intel/oneapi/compiler/latest/bin:${PATH}" \
     PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/xpu" \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     TORCH_XPU_ARCH_LIST=${DPCPP_SYCL_TARGET} \
     OMNI_XPU_DEVICE=${DPCPP_SYCL_TARGET} \
-    LD_LIBRARY_PATH="/usr/local/lib:/opt/venv/lib/python${PYTHON_VERSION}/site-packages/torch/lib:${LD_LIBRARY_PATH}" \
-    CCL_SYCL_ALLTOALL_ARC_LL=1 \
+    MAX_JOBS=${MAX_JOBS} \
+    CMAKE_BUILD_PARALLEL_LEVEL=${MAX_JOBS} \
+    CUTLASS_SYCL_ROOT=/llm/sgl-kernel-xpu/build/_deps/repo-cutlass-sycl-src \
+    OMNI_XPU_REQUIRE_CUTE=1
+
+ENV LD_LIBRARY_PATH="/opt/venv/lib:/opt/venv/lib/python${PYTHON_VERSION}/site-packages/torch/lib:/opt/intel/oneapi/compiler/latest/lib:/opt/intel/oneapi/dnnl/latest/lib:/opt/intel/oneapi/mkl/latest/lib:/opt/intel/oneapi/tbb/latest/lib:/opt/intel/oneapi/mpi/latest/lib:${LD_LIBRARY_PATH}"
+
+SHELL ["bash", "-c"]
+
+# System packages
+# Runtime applications and in-container source builds need the same OS-level
+# headers and build tools. oneAPI itself is already supplied by OMIX devel and
+# is intentionally not reinstalled from a separate apt repository.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends --fix-missing \
+        ca-certificates curl ffmpeg git patch \
+        python3-dev python3-venv python3-pip \
+        build-essential ninja-build cmake pkg-config \
+        libsndfile1 libsm6 libxext6 libgl1 \
+        lsb-release numactl wget vim linux-libc-dev \
+        libopengl0 libglx0 libxrender1 libxfixes3 libx11-dev \
+        libxi6 libxxf86vm1 libxcursor1 libxrandr2 libxinerama1 \
+        libxkbcommon0
+
+# Copy built artifacts from builder
+# Copy complete environments/trees, not a hand-maintained list of shared
+# libraries.  Editable installs continue to resolve because their /llm paths
+# are identical in builder and runtime.
+COPY --from=builder /opt/venv /opt/venv
+COPY --from=builder /llm /llm
+COPY --from=builder /wheels /wheels
+
+# Fix for multi-XPU support: copy SYCL native binary files to a common library path
+# The files already ship with this OMIX base; no files are removed.
+RUN cp /opt/intel/oneapi/compiler/latest/lib/libsycl-native-*.spv /usr/local/lib/
+
+LABEL org.opencontainers.image.version="${IMAGE_TAG}"
+
+ENV CCL_SYCL_ALLTOALL_ARC_LL=1 \
     CCL_SYCL_CCL_BARRIER=1 \
     OMNIXPU_INTERPOLATE_FIX=0 \
     OMNI_IMAGE_VERSION="${IMAGE_TAG}"
 
-SHELL ["bash", "-c"]
+# Final-image smoke test: prove that this stage—not only the builder—contains
+# the compiler, source/build trees, application installs, and loadable native
+# extensions.  Physical XPU and multi-card execution are validated after build.
+RUN source /opt/intel/oneapi/setvars.sh --force >/dev/null 2>&1 && \
+    command -v icpx && \
+    command -v cmake && \
+    command -v ninja && \
+    test -f /llm/omni_xpu_kernel/setup.py && \
+    test -d /llm/sgl-kernel-xpu/build && \
+    test -f /llm/ComfyUI/main.py && \
+    test -d /llm/sglang/python/sglang && \
+    EXT="$(find ${VIRTUAL_ENV}/lib/python${PYTHON_VERSION}/site-packages/omni_xpu_kernel -type f -name '_C*.so' | head -1)" && \
+    test -n "${EXT}" && \
+    nm -D "${EXT}" | grep -q ' U dnnl_primitive_attr_set_zero_points$' && \
+    ! nm -D "${EXT}" | grep -q 'dnnl_primitive_attr_set_zero_points_v2' && \
+    ! ldd "${EXT}" | grep -q 'not found' && \
+    python -c "import git; import torch; from omni_xpu_kernel import _C; import sgl_kernel; import sglang; print(torch.__version__); print('runtime development environment OK')"
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-    --mount=type=cache,target=/root/.cache/pip \
-    --mount=type=bind,from=builder,source=/wheels,target=/tmp/wheels \
-    apt-get update -y && \
-    apt-get install -y --no-install-recommends --fix-missing \
-        curl ffmpeg git libsndfile1 libsm6 libxext6 libgl1 numactl wget \
-        libopengl0 libglx0 libxrender1 libxfixes3 libxi6 libxxf86vm1 \
-        libxcursor1 libxrandr2 libxinerama1 libxkbcommon0 && \
-    pip install --no-deps -r /tmp/runtime-requirements.txt && \
-    pip install --no-deps \
-        /tmp/wheels/sgl_kernel-*.whl \
-        /tmp/wheels/omni_xpu_kernel-*.whl && \
-    pip install --no-deps -e /llm/long-context-attention && \
-    pip install --no-deps -e /llm/xDiT && \
-    pip install --no-deps -e /llm/nunchaku-torch && \
-    pip install --no-deps -e /llm/sglang/python && \
-    rm -f /tmp/runtime-requirements.txt && \
-    rm -rf /var/lib/apt/lists/* /root/.cmake /var/tmp/* && \
-    find /opt/venv -name '*.pyc' -delete && \
-    { find /opt/venv -name '__pycache__' -type d -exec rm -rf {} + 2>/dev/null || true; }
-
-# omni_xpu_kernel links against the oneDNN 3.9 ABI used during build.
-COPY --from=builder /opt/intel/oneapi/dnnl/2025.3/lib/libdnnl.so.3.9 /usr/local/lib/libdnnl.so.3.9
-
-RUN ln -sf libdnnl.so.3.9 /usr/local/lib/libdnnl.so.3 && \
-    ln -sf libdnnl.so.3.9 /usr/local/lib/libdnnl.so && \
-    ldconfig
-
-ENV LD_LIBRARY_PATH="/usr/local/lib:/opt/venv/lib:/opt/venv/lib/python3.12/site-packages/torch/lib"
-
-# Copy only the oneDNN runtime library required by omni_xpu_kernel.
-COPY --from=builder \
-    /opt/intel/oneapi/dnnl/2025.3/lib/libdnnl.so.3.9 \
-    /usr/local/lib/libdnnl.so.3.9
-
-RUN ln -sf libdnnl.so.3.9 /usr/local/lib/libdnnl.so.3 && \
-    ln -sf libdnnl.so.3.9 /usr/local/lib/libdnnl.so && \
-    ldconfig
-
-ENV LD_LIBRARY_PATH="/usr/local/lib:/opt/venv/lib:/opt/venv/lib/python3.12/site-packages/torch/lib:${LD_LIBRARY_PATH}"
-
+# No strip, source removal, build-directory removal, or compiler removal here.
+# The final image is intentionally a complete development image.
 WORKDIR /llm/entrypoints
+CMD ["/bin/bash"]

--- a/omni/docker/Dockerfile
+++ b/omni/docker/Dockerfile
@@ -67,7 +67,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update -y && \
     apt-get install -y --no-install-recommends --fix-missing \
         ca-certificates curl ffmpeg git patch \
-        python3-dev python3-venv python3-pip \
+        python${PYTHON_VERSION}-dev python${PYTHON_VERSION}-venv python3-pip \
         build-essential ninja-build cmake pkg-config \
         libsndfile1 libsm6 libxext6 libgl1 \
         lsb-release numactl wget vim linux-libc-dev \
@@ -77,7 +77,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 # Isolated Python environment.  This avoids modifying OMIX's system Python and
 # keeps every Python package used by the delivered image under /opt/venv.
-RUN python3 -m venv ${VIRTUAL_ENV} && \
+RUN python${PYTHON_VERSION} -m venv ${VIRTUAL_ENV} && \
     pip install --upgrade pip setuptools wheel
 
 # PyTorch
@@ -186,10 +186,8 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pip install -r requirements.txt && \
     pip install --no-deps kernels==0.14.0
 
-# ComfyUI disabled custom nodes (optional: --build-arg INSTALL_DISABLED_NODES=true)
-# SeedVR2 remains optional as requested; it is not installed in the default
-# image when INSTALL_DISABLED_NODES=false.
-ARG INSTALL_DISABLED_NODES=false
+
+ARG INSTALL_DISABLED_NODES=true
 RUN --mount=type=cache,target=/root/.cache/pip \
     if [ "${INSTALL_DISABLED_NODES}" = "true" ]; then \
         cd /llm/ComfyUI/custom_nodes && \
@@ -300,22 +298,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     cd /llm/omni_xpu_kernel && \
     grep -Fqx "__version__ = \"${IMAGE_TAG}\"" omni_xpu_kernel/_version.py && \
     pip wheel -v . --wheel-dir /wheels --no-deps --no-build-isolation && \
-    pip install --no-deps --force-reinstall /wheels/omni_xpu_kernel-*.whl && \
-    EXT="$(find ${VIRTUAL_ENV}/lib/python${PYTHON_VERSION}/site-packages/omni_xpu_kernel -type f -name '_C*.so' | head -1)" && \
-    test -n "${EXT}" && \
-    nm -D "${EXT}" | grep -q ' U dnnl_primitive_attr_set_zero_points$' && \
-    ! nm -D "${EXT}" | grep -q 'dnnl_primitive_attr_set_zero_points_v2'
-
-# Build-time smoke test.  GPU execution is tested after image creation with
-# /dev/dri mounted, but compiler availability and native-extension loading can
-# already be verified here without access to a physical XPU.
-RUN source /opt/intel/oneapi/setvars.sh --force >/dev/null 2>&1 && \
-    command -v icpx && \
-    command -v cmake && \
-    command -v ninja && \
-    test -f /llm/omni_xpu_kernel/setup.py && \
-    test -d /llm/sgl-kernel-xpu/build && \
-    python -c "import torch; from omni_xpu_kernel import _C; import sgl_kernel; print(torch.__version__); print('native kernel imports OK')"
+    pip install --no-deps --force-reinstall /wheels/omni_xpu_kernel-*.whl
 
 # ComfyUI-Manager dependencies
 # Install these during image build so a fresh/ephemeral container does not need
@@ -376,7 +359,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update -y && \
     apt-get install -y --no-install-recommends --fix-missing \
         ca-certificates curl ffmpeg git patch \
-        python3-dev python3-venv python3-pip \
+        python${PYTHON_VERSION}-dev python${PYTHON_VERSION}-venv python3-pip \
         build-essential ninja-build cmake pkg-config \
         libsndfile1 libsm6 libxext6 libgl1 \
         lsb-release numactl wget vim linux-libc-dev \
@@ -403,25 +386,6 @@ ENV CCL_SYCL_ALLTOALL_ARC_LL=1 \
     OMNIXPU_INTERPOLATE_FIX=0 \
     OMNI_IMAGE_VERSION="${IMAGE_TAG}"
 
-# Final-image smoke test: prove that this stage—not only the builder—contains
-# the compiler, source/build trees, application installs, and loadable native
-# extensions.  Physical XPU and multi-card execution are validated after build.
-RUN source /opt/intel/oneapi/setvars.sh --force >/dev/null 2>&1 && \
-    command -v icpx && \
-    command -v cmake && \
-    command -v ninja && \
-    test -f /llm/omni_xpu_kernel/setup.py && \
-    test -d /llm/sgl-kernel-xpu/build && \
-    test -f /llm/ComfyUI/main.py && \
-    test -d /llm/sglang/python/sglang && \
-    EXT="$(find ${VIRTUAL_ENV}/lib/python${PYTHON_VERSION}/site-packages/omni_xpu_kernel -type f -name '_C*.so' | head -1)" && \
-    test -n "${EXT}" && \
-    nm -D "${EXT}" | grep -q ' U dnnl_primitive_attr_set_zero_points$' && \
-    ! nm -D "${EXT}" | grep -q 'dnnl_primitive_attr_set_zero_points_v2' && \
-    ! ldd "${EXT}" | grep -q 'not found' && \
-    python -c "import git; import torch; from omni_xpu_kernel import _C; import sgl_kernel; import sglang; print(torch.__version__); print('runtime development environment OK')"
 
-# No strip, source removal, build-directory removal, or compiler removal here.
-# The final image is intentionally a complete development image.
 WORKDIR /llm/entrypoints
 CMD ["/bin/bash"]

--- a/omni/omni_xpu_kernel/setup.py
+++ b/omni/omni_xpu_kernel/setup.py
@@ -63,6 +63,30 @@ def get_icpx_path():
     return None
 
 
+def compiler_env_with_explicit_onednn(onednn_include):
+    """Remove duplicate oneDNN include paths injected by setvars.sh."""
+    env = os.environ.copy()
+    explicit_path = os.path.realpath(onednn_include)
+
+    for name in ("CPATH", "C_INCLUDE_PATH", "CPLUS_INCLUDE_PATH"):
+        value = env.get(name)
+        if not value:
+            continue
+
+        entries = value.split(os.pathsep)
+        entries = [
+            entry for entry in entries
+            if not entry or os.path.realpath(entry) != explicit_path
+        ]
+
+        if entries:
+            env[name] = os.pathsep.join(entries)
+        else:
+            env.pop(name, None)
+
+    return env
+
+
 class ICPXBuildExt(build_ext):
     """Build extension using Intel icpx compiler directly."""
     
@@ -268,13 +292,13 @@ class ICPXBuildExt(build_ext):
                     "-fPIC", "-shared",
                     "-std=c++17",
                     f"-I{python_include}",
-                    f"-I{torch_include}",
-                    f"-I{torch_include}/torch/csrc/api/include",
-                    f"-I{src_dir}",
                 ]
                 if has_onednn:
                     cmd.append(f"-I{onednn_include}")
                 cmd += [
+                    f"-I{torch_include}",
+                    f"-I{torch_include}/torch/csrc/api/include",
+                    f"-I{src_dir}",
                     f"-L{torch_lib}",
                     "-ltorch", "-ltorch_python", "-ltorch_cpu", "-ltorch_xpu", "-lc10", "-lc10_xpu",
                 ]
@@ -288,8 +312,17 @@ class ICPXBuildExt(build_ext):
         
         print(f"Compile command: {' '.join(cmd)}")
         
-        # Run compiler
-        result = subprocess.run(cmd, capture_output=True, text=True)
+        # Run compiler with the explicit oneDNN include taking precedence.
+        compiler_env = os.environ.copy()
+        if has_onednn and not is_cute:
+            compiler_env = compiler_env_with_explicit_onednn(onednn_include)
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            env=compiler_env,
+        )
         
         if result.returncode != 0:
             print("STDOUT:", result.stdout)


### PR DESCRIPTION
Rework the Omni Dockerfile so the runtime image keeps the full oneAPI compiler toolchain, per Xiangyu's requirement to preserve the ability to rebuild native kernels (omni_xpu_kernel, sgl-kernel-xpu) inside the final image.
Built and ran intel/llm-scaler-omni:0.1.0-b8-dev locally; verified native kernel imports (omni_xpu_kernel._C, sgl_kernel, sglang) and ComfyUI-Manager dependencies load correctly inside the container.