### PR TITLE
[XPU][FP8] Add block-scaled dense and grouped MoE kernels

### DIFF
--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_gemm.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_gemm.sycl
@@ -14,6 +14,7 @@
 
 #include "esimd_kernels/fp8_GEMM_pert.h"
 #include "esimd_kernels/int4_GEMM.h"
+#include "esimd_kernels/fp8_GEMM_blockscale.h"
 
 #define EXTRACT_PTR(var, tensor) auto var = reinterpret_cast<uint8_t*>(tensor.data_ptr())
 
@@ -85,5 +86,53 @@ at::Tensor esimd_gemm_int4_pgrp(
         reinterpret_cast<const fp16*>(p_sc),
         reinterpret_cast<fp16*>(p_out),
         (uint32_t)M, (uint32_t)N, (uint32_t)K, dpcpp_queue);
+    return output;
+}
+
+// ---- FP8 block-scaled GEMM (DeepSeek 128x128 weight block scale, w8a16) ----
+// input: [M, K] fp16, weight: [N, K] fp8_e4m3 (uint8 bits),
+// weight_scale: [ceil(N/block_n), ceil(K/block_k)] fp32 (== weight_scale_inv),
+// output: [M, N] fp16 pre-allocated. Activation stays fp16 (no act quant).
+at::Tensor esimd_gemm_fp8_blockscale(
+    at::Tensor input, at::Tensor weight, at::Tensor weight_scale,
+    at::Tensor output, int64_t block_n, int64_t block_k) {
+    int64_t M = input.size(0);
+    int64_t N = weight.size(0);
+    int64_t K = weight.size(1);
+
+    TORCH_CHECK(input.scalar_type() == at::ScalarType::Half,
+                "esimd_gemm_fp8_blockscale: input must be fp16");
+    TORCH_CHECK(weight.scalar_type() == at::ScalarType::Float8_e4m3fn ||
+                    weight.scalar_type() == at::ScalarType::Byte,
+                "esimd_gemm_fp8_blockscale: weight must be fp8_e4m3 (or uint8 bits)");
+    TORCH_CHECK(weight_scale.scalar_type() == at::ScalarType::Float,
+                "esimd_gemm_fp8_blockscale: weight_scale must be float32");
+    TORCH_CHECK(output.scalar_type() == at::ScalarType::Half,
+                "esimd_gemm_fp8_blockscale: output must be fp16");
+    TORCH_CHECK(block_n == 128 && block_k == 128,
+                "esimd_gemm_fp8_blockscale: only 128x128 weight blocks supported, got ",
+                block_n, "x", block_k);
+    TORCH_CHECK(K % block_k == 0,
+                "esimd_gemm_fp8_blockscale: K must be a multiple of block_k(128), got K=", K);
+    const int64_t Nb = (N + block_n - 1) / block_n;
+    const int64_t Kb = (K + block_k - 1) / block_k;
+    TORCH_CHECK(weight_scale.size(0) == Nb && weight_scale.size(1) == Kb,
+                "esimd_gemm_fp8_blockscale: weight_scale shape mismatch; expected [",
+                Nb, ", ", Kb, "], got [", weight_scale.size(0), ", ",
+                weight_scale.size(1), "]");
+    TORCH_CHECK(output.size(0) == M && output.size(1) == N,
+                "esimd_gemm_fp8_blockscale: output shape mismatch; expected [", M,
+                ", ", N, "]");
+
+    EXTRACT_PTR(p_in, input); EXTRACT_PTR(p_w, weight);
+    EXTRACT_PTR(p_sc, weight_scale); EXTRACT_PTR(p_out, output);
+    auto& dpcpp_queue = get_device_queue(input);
+    fp8_blockscale::gemm_fp8_blockscale_host(
+        reinterpret_cast<const fp16*>(p_in),
+        reinterpret_cast<const uint8_t*>(p_w),
+        reinterpret_cast<const float*>(p_sc),
+        reinterpret_cast<fp16*>(p_out),
+        (uint32_t)M, (uint32_t)N, (uint32_t)K,
+        (uint32_t)block_n, (uint32_t)block_k, dpcpp_queue);
     return output;
 }

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_moe.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_moe.sycl
@@ -14,6 +14,7 @@
 
 #include "esimd_kernels/moe_ops.h"
 #include "esimd_kernels/fp8_moe_gemm.h"
+#include "esimd_kernels/fp8_moe_gemm_blockscale.h"
 
 // Get queue for the specific device (multi-card safe)
 static inline sycl::queue& get_device_queue(const at::Tensor& tensor) {
@@ -145,6 +146,39 @@ at::Tensor esimd_moe_gemm_fp8(
         reinterpret_cast<fp16*>(output.data_ptr()),
         reinterpret_cast<const uint32_t*>(expert_idx.data_ptr()),
         (int)N, (int)K, (int)num_experts, (int)max_tokens_per_expert, q);
+    return output;
+}
+
+// MoE grouped block-scaled FP8 GEMM (DeepSeek 128x128 weight block, w8a16).
+// input [total_tokens, K] fp16, weight [E, N, K] fp8_e4m3 (uint8 bits),
+// weight_scale [E, ceil(N/128), ceil(K/128)] fp32 (== weight_scale_inv),
+// output [total_tokens, N] fp16, expert_idx [E+1] uint32 token start offsets.
+at::Tensor esimd_moe_gemm_fp8_blockscale(
+    at::Tensor input, at::Tensor weight, at::Tensor weight_scale,
+    at::Tensor output, at::Tensor expert_idx,
+    int64_t N, int64_t K, int64_t num_experts, int64_t block_n, int64_t block_k)
+{
+    TORCH_CHECK(input.scalar_type() == at::ScalarType::Half,
+                "esimd_moe_gemm_fp8_blockscale: input must be fp16");
+    TORCH_CHECK(weight.scalar_type() == at::ScalarType::Float8_e4m3fn ||
+                    weight.scalar_type() == at::ScalarType::Byte,
+                "esimd_moe_gemm_fp8_blockscale: weight must be fp8_e4m3 (or uint8 bits)");
+    TORCH_CHECK(weight_scale.scalar_type() == at::ScalarType::Float,
+                "esimd_moe_gemm_fp8_blockscale: weight_scale must be float32");
+    TORCH_CHECK(output.scalar_type() == at::ScalarType::Half,
+                "esimd_moe_gemm_fp8_blockscale: output must be fp16");
+    TORCH_CHECK(block_n == 128 && block_k == 128,
+                "esimd_moe_gemm_fp8_blockscale: only 128x128 weight blocks supported");
+    TORCH_CHECK(K % block_k == 0,
+                "esimd_moe_gemm_fp8_blockscale: K must be a multiple of block_k(128)");
+    auto& q = get_device_queue(input);
+    fp8_moe_blockscale::moe_gemm_fp8_blockscale_host(
+        reinterpret_cast<const fp16*>(input.data_ptr()),
+        reinterpret_cast<const uint8_t*>(weight.data_ptr()),
+        weight_scale.data_ptr<float>(),
+        reinterpret_cast<fp16*>(output.data_ptr()),
+        reinterpret_cast<const uint32_t*>(expert_idx.data_ptr()),
+        (int)N, (int)K, (int)num_experts, (int)block_n, (int)block_k, q);
     return output;
 }
 

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_moe.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_moe.sycl
@@ -172,12 +172,29 @@ at::Tensor esimd_moe_gemm_fp8_blockscale(
     TORCH_CHECK(K % block_k == 0,
                 "esimd_moe_gemm_fp8_blockscale: K must be a multiple of block_k(128)");
     auto& q = get_device_queue(input);
+
+    // Active-experts-only grid: only min(num_experts, total_tokens) experts can
+    // be non-empty this call. Compact their ids so the main grid launches
+    // n_active*N work-groups instead of num_experts*N (~99% empty at decode).
+    const int64_t total_tokens = input.size(0);
+    const int n_active =
+        (int)std::min<int64_t>(num_experts, total_tokens);
+    auto active_experts = at::full(
+        {std::max(n_active, 1)}, (int64_t)num_experts,
+        input.options().dtype(at::kInt));
+    if (n_active > 0) {
+        fp8_moe_blockscale::build_active_experts(
+            reinterpret_cast<const uint32_t*>(expert_idx.data_ptr()),
+            active_experts.data_ptr<int32_t>(), (int)num_experts, q);
+    }
+
     fp8_moe_blockscale::moe_gemm_fp8_blockscale_host(
         reinterpret_cast<const fp16*>(input.data_ptr()),
         reinterpret_cast<const uint8_t*>(weight.data_ptr()),
         weight_scale.data_ptr<float>(),
         reinterpret_cast<fp16*>(output.data_ptr()),
         reinterpret_cast<const uint32_t*>(expert_idx.data_ptr()),
+        active_experts.data_ptr<int32_t>(), n_active,
         (int)N, (int)K, (int)num_experts, (int)block_n, (int)block_k, q);
     return output;
 }

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/fp8_GEMM_blockscale.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/fp8_GEMM_blockscale.h
@@ -1,0 +1,243 @@
+/* fp8_GEMM_blockscale.h — w8a16 block-scaled FP8 GEMM (DeepSeek-style).
+ *
+ * Computes  output[M, N] = input[M, K] @ dequant(weight[N, K])^T
+ * where the fp8_e4m3 weight is dequantized on the fly with a 2D block scale:
+ *   weight_scale[nb, kb]  applies to  weight[nb*BN : nb*BN+BN, kb*BK : kb*BK+BK]
+ * i.e. DeepSeek 128x128 weight block scale. The activation stays fp16 (w8a16):
+ * no activation quantization is performed, which keeps decode-path accuracy high
+ * and avoids a separate per-token-group quant launch.
+ *
+ * Layouts (all row-major, contiguous):
+ *   input        [M, K]                         fp16
+ *   weight       [N, K]                         uint8 (fp8_e4m3 bits)
+ *   weight_scale [ceil(N/BN), ceil(K/BK)]       float32   (== weight_scale_inv)
+ *   output       [M, N]                         fp16  (pre-allocated)
+ *
+ * Derived from the proven GEMV_a16_wfp8_block (sglang fp8_GEMV.h): the batch/
+ * "absorb" dimension is dropped (linear layers are batch-1), the block scale is
+ * read as float32 (checkpoint weight_scale_inv is fp32, not fp16), and the dot
+ * product accumulates in fp32 for tighter agreement with a bf16/fp32 reference.
+ *
+ * The kernel is a K-split GEMV: NT threads per work-group each own an HD-wide
+ * slice of K, reduce partials through SLM. It is bandwidth-bound and tuned for
+ * small M (decode). The host launcher tiles M so any M is handled correctly;
+ * large-M prefill is functional but not throughput-optimal (see K4).
+ */
+#pragma once
+
+#include "utils.h"
+#include <cstdint>
+
+namespace fp8_blockscale {
+
+// fp8_e4m3 field widths.
+#define BS_WE 4
+#define BS_WM 3
+
+// Vectorized fp8_e4m3 (fn) -> fp16 conversion (handles zero + subnormals; NaN
+// inputs are not expected in weights and are not special-cased). Mirrors the
+// bit manipulation in GEMV_a16_wfp8_block.
+template <uint32_t N>
+inline simd<fp16, N> fp8e4m3_to_fp16(simd<uint8_t, N> x) {
+  constexpr uint16_t weo = 5;   // fp16 exponent bits
+  constexpr uint16_t wmo = 10;  // fp16 mantissa bits
+
+  auto is_zero = (x == 0);
+
+  simd<uint16_t, N> mantissa = x & ((1 << BS_WM) - 1);
+  simd<uint16_t, N> exponent = (x & 0x7F) >> BS_WM;
+
+  auto zero_exponent = (exponent == 0);
+  simd<uint16_t, N> mantissa_subnormal = mantissa;
+  simd<uint16_t, N> exponent_subnormal = exponent;
+  {
+    // Re-normalize subnormal fp8 mantissa: count leading zeros via the exponent
+    // of (float)mantissa, then shift into a normalized fp16 representation.
+    simd<uint16_t, N> vec = mantissa;
+    simd<float, N> vec_float = vec;
+    simd<uint32_t, N> vec_uint = vec_float.template bit_cast_view<uint32_t>();
+    simd<uint32_t, N> exponent_tmp = (vec_uint >> 23) & 0xFF;
+    simd<uint32_t, N> lz = 158 - exponent_tmp;  // 158 = 127 + 31
+    simd<uint16_t, N> renorm_shift = lz;
+
+    simd<uint16_t, N> sh = 1 + renorm_shift - (32 - BS_WM);
+    mantissa_subnormal <<= sh;
+    exponent_subnormal += 1 - sh;
+    mantissa_subnormal &= ((1 << BS_WM) - 1);
+  }
+
+  mantissa.merge(mantissa_subnormal, zero_exponent);
+  exponent.merge(exponent_subnormal, zero_exponent);
+
+  const uint16_t exp_low_cutoff = (1 << (weo - 1)) - (1 << (BS_WE - 1));
+  exponent += exp_low_cutoff;
+  mantissa <<= wmo - BS_WM;
+
+  simd<uint16_t, N> sign = x >> 7;
+  simd<uint16_t, N> retval = (sign << 15) | (exponent << 10) | mantissa;
+  retval.merge(0, is_zero);
+
+  return retval.template bit_cast_view<fp16>();
+}
+
+// Block-scaled FP8 GEMV, BMG-tuned (modeled on GEMV_fp8_pert_bmg_kernel).
+//
+// One work-group per output channel n; K_SPLIT threads cooperate on the K
+// reduction (chosen for HW-thread occupancy). Each thread streams its K-slice in
+// VL-wide coalesced loads, dequantizes the fp8 weight once, folds the per-128
+// block scale into the weight vector (block_k=128 divides VL), and accumulates a
+// dot product for every one of the M activation rows -- so the weight load is
+// amortized across the (small) decode batch. Only K_SPLIT partials per row pass
+// through SLM. This mirrors the near-peak-bandwidth per-tensor decode kernel.
+//   VL       K elements loaded per iteration (multiple of BK=128)
+//   K_SPLIT  threads per work-group (K reduction fan-in)
+//   BK       weight scale K-block (128)
+//   MAX_M    compile-time upper bound on rows handled per launch
+template <int VL, int K_SPLIT, int BK, int MAX_M>
+struct gemv_block_bmg_kernel {
+  const fp16* input;      // [M, K]
+  const uint8_t* weight;  // [N, K] fp8_e4m3 bits
+  const float* wscale;    // [Nb, Kb]  (Kb = K/BK)
+  fp16* output;           // [M, N]
+  int M, N, K, Kb;
+
+  void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+    if constexpr (K_SPLIT > 1) {
+      slm_init<K_SPLIT * MAX_M * sizeof(float)>();
+    }
+    const int n = item.get_group(0);
+    const int lid = item.get_local_id(0);
+    if (n >= N) return;
+
+    const int kp = K / K_SPLIT;   // per-thread K span (multiple of VL)
+    const int ks = lid * kp;
+    const uint8_t* w_row = weight + (size_t)n * K;
+    const float* s_row = wscale + (size_t)(n / 128) * Kb;
+
+    simd<float, MAX_M> acc = 0.0f;
+
+    for (int k = ks; k < ks + kp; k += VL) {
+      // Load + dequant the weight slice once, fold in the per-128 block scale.
+      simd<uint8_t, VL> raw = block_load<uint8_t, VL>(w_row + k);
+      simd<float, VL> wf = fp8e4m3_to_fp16<VL>(raw);
+#pragma unroll
+      for (int sb = 0; sb < VL / BK; sb++) {
+        const float sc = s_row[(k / BK) + sb];
+        wf.template select<BK, 1>(sb * BK) = wf.template select<BK, 1>(sb * BK) * sc;
+      }
+      // Reuse the scaled weight across all M activation rows.
+#pragma unroll
+      for (int m = 0; m < MAX_M; m++) {
+        if (m < M) {
+          simd<fp16, VL> iv = block_load<fp16, VL>(input + (size_t)m * K + k);
+          simd<float, VL> ivf = iv;
+          acc[m] += reduce<float>(ivf * wf, std::plus<>());
+        }
+      }
+    }
+
+    if constexpr (K_SPLIT == 1) {
+#pragma unroll
+      for (int m = 0; m < MAX_M; m++) {
+        if (m < M) output[(size_t)m * N + n] = fp16(acc[m]);
+      }
+    } else {
+      slm_block_store<float, MAX_M>(lid * MAX_M * sizeof(float),
+                                    acc.template select<MAX_M, 1>(0));
+      barrier();
+      if (lid == 0) {
+        simd<float, K_SPLIT * MAX_M> parts =
+            slm_block_load<float, K_SPLIT * MAX_M>(0);
+#pragma unroll
+        for (int m = 0; m < MAX_M; m++) {
+          if (m < M) {
+            // parts layout: [lid][m]; sum over lid (stride MAX_M).
+            simd<float, K_SPLIT> col =
+                parts.template select<K_SPLIT, MAX_M>(m);
+            output[(size_t)m * N + n] = fp16(reduce<float>(col, std::plus<>()));
+          }
+        }
+      }
+    }
+  }
+};
+
+template <int VL, int K_SPLIT, int MAX_M>
+inline void launch_gemv_block_bmg(const fp16* input, const uint8_t* weight,
+                                  const float* wscale, fp16* output, int M, int N,
+                                  int K, sycl::queue& q) {
+  constexpr int BK = 128;
+  const int Kb = K / BK;
+  gemv_block_bmg_kernel<VL, K_SPLIT, BK, MAX_M> kern{
+      input, weight, wscale, output, M, N, K, Kb};
+  sycl::range<1> global(static_cast<size_t>(N) * K_SPLIT);
+  sycl::range<1> local(K_SPLIT);
+  q.submit([&](handler& cgh) {
+    cgh.parallel_for(sycl::nd_range<1>(global, local), kern);
+  });
+}
+
+// Dispatch (VL, K_SPLIT) for one M-tile. VL prefers 256; K_SPLIT is raised to
+// keep ~640 HW threads busy for small N, subject to K/K_SPLIT staying a multiple
+// of VL.
+template <int MAX_M>
+inline void dispatch_gemv_block_bmg(const fp16* input, const uint8_t* weight,
+                                    const float* wscale, fp16* output, int M,
+                                    int N, int K, sycl::queue& q) {
+  const int VL = (K % 256 == 0) ? 256 : 128;
+
+  // Target K_SPLIT so that N*K_SPLIT >= 640 (BMG occupancy), K%ks==0 and
+  // (K/ks)%VL==0.
+  int target = 1;
+  if (N * 8 <= 640) target = 8;
+  else if (N * 4 <= 640) target = 4;
+  else if (N * 2 <= 640) target = 2;
+  int ks = 1;
+  for (int s = target; s >= 1; s >>= 1) {
+    if (K % s == 0 && (K / s) % VL == 0) { ks = s; break; }
+  }
+
+#define BS_DISPATCH(V, S)                                                      \
+  launch_gemv_block_bmg<V, S, MAX_M>(input, weight, wscale, output, M, N, K, q)
+  if (VL == 256) {
+    switch (ks) {
+      case 8: BS_DISPATCH(256, 8); break;
+      case 4: BS_DISPATCH(256, 4); break;
+      case 2: BS_DISPATCH(256, 2); break;
+      default: BS_DISPATCH(256, 1); break;
+    }
+  } else {
+    switch (ks) {
+      case 8: BS_DISPATCH(128, 8); break;
+      case 4: BS_DISPATCH(128, 4); break;
+      case 2: BS_DISPATCH(128, 2); break;
+      default: BS_DISPATCH(128, 1); break;
+    }
+  }
+#undef BS_DISPATCH
+}
+
+// Host launcher. block_n/block_k must be 128. Handles any M by tiling into
+// groups of TILE rows (weight is reloaded per tile but reused across the tile).
+inline void gemm_fp8_blockscale_host(const fp16* input, const uint8_t* weight,
+                                     const float* weight_scale, fp16* output,
+                                     uint32_t M, uint32_t N, uint32_t K,
+                                     uint32_t block_n, uint32_t block_k,
+                                     sycl::queue& q) {
+  if (M == 1) {
+    dispatch_gemv_block_bmg<1>(input, weight, weight_scale, output, 1, (int)N,
+                               (int)K, q);
+    return;
+  }
+  constexpr uint32_t TILE = 8;
+  for (uint32_t m0 = 0; m0 < M; m0 += TILE) {
+    const int mt = (M - m0 < TILE) ? (int)(M - m0) : (int)TILE;
+    dispatch_gemv_block_bmg<TILE>(input + (size_t)m0 * K, weight, weight_scale,
+                                  output + (size_t)m0 * N, mt, (int)N, (int)K, q);
+  }
+}
+
+#undef BS_WE
+#undef BS_WM
+
+}  // namespace fp8_blockscale

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/fp8_moe_gemm_blockscale.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/fp8_moe_gemm_blockscale.h
@@ -1,0 +1,129 @@
+/* fp8_moe_gemm_blockscale.h — grouped (MoE) w8a16 block-scaled FP8 GEMM.
+ *
+ * The routed-expert analogue of fp8_GEMM_blockscale.h: computes, per expert e,
+ *   output[t, :] = input[t, :] @ dequant(weight[e])^T   for tokens t of expert e
+ * where weight[e] is fp8_e4m3 dequantized on the fly with a DeepSeek 128x128
+ * block scale (weight_scale_inv[e, nb, kb]). The activation stays fp16 (w8a16,
+ * matching the dense XPUFp8BlockScaledMMKernel) — no per-token-group act quant.
+ *
+ * Tokens are assumed pre-scattered/grouped by expert (as produced by
+ * torch.ops._moe_C.remap_hidden_states): expert e owns the contiguous input
+ * rows [expert_idx[e], expert_idx[e+1]).
+ *
+ * Layouts (all row-major, contiguous):
+ *   input        [total_tokens, K]                fp16   (scattered, expert-grouped)
+ *   weight       [E, N, K]                        uint8  (fp8_e4m3 bits)
+ *   weight_scale [E, ceil(N/BN), ceil(K/BK)]      float32 (== weight_scale_inv)
+ *   output       [total_tokens, N]                fp16   (pre-allocated)
+ *   expert_idx   [E + 1]                          uint32 (token start offsets)
+ *
+ * Grid: E * N work-groups, one thread each (K_SPLIT=1). Since E*N is large the
+ * occupancy comes from the grid, not from K-splitting. Each WG owns one output
+ * channel n of one expert e; it streams the K row once per M-tile, dequantizes
+ * + folds the per-128 block scale into the weight (as in the dense kernel), and
+ * reduces a dot product for each of its expert's tokens. Experts with no tokens
+ * return immediately. Bandwidth-bound, tuned for the small per-expert token
+ * counts of decode; large-M prefill is functional (weight reloaded per M-tile).
+ */
+#pragma once
+
+#include "fp8_GEMM_blockscale.h"  // fp8_blockscale::fp8e4m3_to_fp16
+#include <cstdint>
+
+namespace fp8_moe_blockscale {
+
+using fp8_blockscale::fp8e4m3_to_fp16;
+
+// One WG per (expert, output-channel n). MAX_M tokens handled per inner tile.
+template <int VL, int BK, int MAX_M>
+struct moe_gemv_block_kernel {
+  const fp16* input;          // [total_tokens, K]
+  const uint8_t* weight;      // [E, N, K] fp8_e4m3 bits
+  const float* wscale;        // [E, Nb, Kb]
+  fp16* output;               // [total_tokens, N]
+  const uint32_t* expert_idx; // [E + 1]
+  int N, K, Nb, Kb, num_experts;
+
+  void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+    const int gid = item.get_group(0);
+    const int e = gid / N;
+    const int n = gid - e * N;
+    if (e >= num_experts) return;
+
+    const uint32_t ts = expert_idx[e];
+    const uint32_t te = expert_idx[e + 1];
+    const int Me = (int)(te - ts);
+    if (Me <= 0) return;
+
+    const uint8_t* w_row = weight + ((size_t)e * N + n) * K;
+    const float* s_row = wscale + ((size_t)e * Nb + (n / BK)) * Kb;
+
+    for (int m0 = 0; m0 < Me; m0 += MAX_M) {
+      simd<float, MAX_M> acc = 0.0f;
+
+      for (int k = 0; k < K; k += VL) {
+        // Load + dequant the weight slice once, fold in the per-128 block scale.
+        simd<uint8_t, VL> raw = block_load<uint8_t, VL>(w_row + k);
+        simd<float, VL> wf = fp8e4m3_to_fp16<VL>(raw);
+#pragma unroll
+        for (int sb = 0; sb < VL / BK; sb++) {
+          const float sc = s_row[(k / BK) + sb];
+          wf.template select<BK, 1>(sb * BK) =
+              wf.template select<BK, 1>(sb * BK) * sc;
+        }
+        // Reuse the scaled weight slice across this tile's tokens.
+#pragma unroll
+        for (int mm = 0; mm < MAX_M; mm++) {
+          if (m0 + mm < Me) {
+            simd<fp16, VL> iv =
+                block_load<fp16, VL>(input + (size_t)(ts + m0 + mm) * K + k);
+            simd<float, VL> ivf = iv;
+            acc[mm] += reduce<float>(ivf * wf, std::plus<>());
+          }
+        }
+      }
+
+#pragma unroll
+      for (int mm = 0; mm < MAX_M; mm++) {
+        if (m0 + mm < Me)
+          output[(size_t)(ts + m0 + mm) * N + n] = fp16(acc[mm]);
+      }
+    }
+  }
+};
+
+template <int VL, int MAX_M>
+inline void launch_moe_gemv_block(const fp16* input, const uint8_t* weight,
+                                  const float* wscale, fp16* output,
+                                  const uint32_t* expert_idx, int N, int K,
+                                  int Nb, int Kb, int num_experts,
+                                  sycl::queue& q) {
+  constexpr int BK = 128;
+  moe_gemv_block_kernel<VL, BK, MAX_M> kern{
+      input, weight, wscale, output, expert_idx, N, K, Nb, Kb, num_experts};
+  sycl::range<1> global(static_cast<size_t>(num_experts) * N);
+  sycl::range<1> local(1);
+  q.submit([&](handler& cgh) {
+    cgh.parallel_for(sycl::nd_range<1>(global, local), kern);
+  });
+}
+
+// Host launcher. block_n/block_k must be 128. Handles any per-expert token
+// count by tiling into groups of MAX_M rows inside the kernel.
+inline void moe_gemm_fp8_blockscale_host(
+    const fp16* input, const uint8_t* weight, const float* weight_scale,
+    fp16* output, const uint32_t* expert_idx, int N, int K, int num_experts,
+    int block_n, int block_k, sycl::queue& q) {
+  const int Nb = (N + block_n - 1) / block_n;
+  const int Kb = (K + block_k - 1) / block_k;
+  constexpr int MAX_M = 8;
+  const int VL = (K % 256 == 0) ? 256 : 128;
+  if (VL == 256)
+    launch_moe_gemv_block<256, MAX_M>(input, weight, weight_scale, output,
+                                      expert_idx, N, K, Nb, Kb, num_experts, q);
+  else
+    launch_moe_gemv_block<128, MAX_M>(input, weight, weight_scale, output,
+                                      expert_idx, N, K, Nb, Kb, num_experts, q);
+}
+
+}  // namespace fp8_moe_blockscale

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/fp8_moe_gemm_blockscale.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/fp8_moe_gemm_blockscale.h
@@ -24,30 +24,72 @@
  * reduces a dot product for each of its expert's tokens. Experts with no tokens
  * return immediately. Bandwidth-bound, tuned for the small per-expert token
  * counts of decode; large-M prefill is functional (weight reloaded per M-tile).
+ *
+ * Active-experts-only grid: at decode only topk*num_tokens (<= total_tokens)
+ * experts are non-empty, but there are E=256 of them, so an E*N grid launches
+ * ~99% empty work-groups (pure dispatch overhead, which dominates the small
+ * down-projection GEMV). A tiny prep kernel first compacts the non-empty expert
+ * ids into active_experts[], and the main grid is launched over
+ * min(E, total_tokens) * N work-groups: WG slot s handles expert
+ * active_experts[s] (sentinel == num_experts for the unused tail slots, which
+ * return early). total_tokens is known on the host (input rows), so no
+ * device->host sync is needed.
  */
 #pragma once
 
 #include "fp8_GEMM_blockscale.h"  // fp8_blockscale::fp8e4m3_to_fp16
+#include <algorithm>
 #include <cstdint>
 
 namespace fp8_moe_blockscale {
 
 using fp8_blockscale::fp8e4m3_to_fp16;
 
-// One WG per (expert, output-channel n). MAX_M tokens handled per inner tile.
+// Compact the ids of experts that own >=1 token into active_experts[0..count).
+// active_experts must be pre-filled with the sentinel value `num_experts` so
+// the unused tail slots make their work-groups return early. Single thread
+// (num_experts is small, e.g. 256); deterministic order, no atomics.
+struct build_active_experts_kernel {
+  const uint32_t* expert_idx;  // [E + 1]
+  int32_t* active_experts;     // [bound] (pre-filled with num_experts)
+  int num_experts;
+
+  void operator()(sycl::id<1>) const {
+    int idx = 0;
+    for (int e = 0; e < num_experts; e++) {
+      if (expert_idx[e + 1] > expert_idx[e]) {
+        active_experts[idx++] = e;
+      }
+    }
+  }
+};
+
+inline void build_active_experts(const uint32_t* expert_idx,
+                                 int32_t* active_experts, int num_experts,
+                                 sycl::queue& q) {
+  q.submit([&](handler& cgh) {
+    cgh.parallel_for(sycl::range<1>(1),
+                     build_active_experts_kernel{expert_idx, active_experts,
+                                                 num_experts});
+  });
+}
+
+// One WG per (active-expert slot, output-channel n). MAX_M tokens per inner tile.
 template <int VL, int BK, int MAX_M>
 struct moe_gemv_block_kernel {
-  const fp16* input;          // [total_tokens, K]
-  const uint8_t* weight;      // [E, N, K] fp8_e4m3 bits
-  const float* wscale;        // [E, Nb, Kb]
-  fp16* output;               // [total_tokens, N]
-  const uint32_t* expert_idx; // [E + 1]
+  const fp16* input;             // [total_tokens, K]
+  const uint8_t* weight;         // [E, N, K] fp8_e4m3 bits
+  const float* wscale;           // [E, Nb, Kb]
+  fp16* output;                  // [total_tokens, N]
+  const uint32_t* expert_idx;    // [E + 1]
+  const int32_t* active_experts; // [bound] compacted non-empty expert ids
   int N, K, Nb, Kb, num_experts;
 
   void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
     const int gid = item.get_group(0);
-    const int e = gid / N;
-    const int n = gid - e * N;
+    const int slot = gid / N;
+    const int n = gid - slot * N;
+    const int e = active_experts[slot];   // sentinel num_experts for tail slots
     if (e >= num_experts) return;
 
     const uint32_t ts = expert_idx[e];
@@ -95,13 +137,15 @@ struct moe_gemv_block_kernel {
 template <int VL, int MAX_M>
 inline void launch_moe_gemv_block(const fp16* input, const uint8_t* weight,
                                   const float* wscale, fp16* output,
-                                  const uint32_t* expert_idx, int N, int K,
-                                  int Nb, int Kb, int num_experts,
+                                  const uint32_t* expert_idx,
+                                  const int32_t* active_experts, int n_active,
+                                  int N, int K, int Nb, int Kb, int num_experts,
                                   sycl::queue& q) {
   constexpr int BK = 128;
   moe_gemv_block_kernel<VL, BK, MAX_M> kern{
-      input, weight, wscale, output, expert_idx, N, K, Nb, Kb, num_experts};
-  sycl::range<1> global(static_cast<size_t>(num_experts) * N);
+      input,      weight, wscale, output,      expert_idx,
+      active_experts, N,  K,      Nb,          Kb,         num_experts};
+  sycl::range<1> global(static_cast<size_t>(n_active) * N);
   sycl::range<1> local(1);
   q.submit([&](handler& cgh) {
     cgh.parallel_for(sycl::nd_range<1>(global, local), kern);
@@ -109,21 +153,28 @@ inline void launch_moe_gemv_block(const fp16* input, const uint8_t* weight,
 }
 
 // Host launcher. block_n/block_k must be 128. Handles any per-expert token
-// count by tiling into groups of MAX_M rows inside the kernel.
+// count by tiling into groups of MAX_M rows inside the kernel. `active_experts`
+// (length >= n_active) holds the compacted non-empty expert ids (built via
+// build_active_experts); n_active = min(num_experts, total_tokens) caps the
+// grid to the experts that can be non-empty this call.
 inline void moe_gemm_fp8_blockscale_host(
     const fp16* input, const uint8_t* weight, const float* weight_scale,
-    fp16* output, const uint32_t* expert_idx, int N, int K, int num_experts,
-    int block_n, int block_k, sycl::queue& q) {
+    fp16* output, const uint32_t* expert_idx, const int32_t* active_experts,
+    int n_active, int N, int K, int num_experts, int block_n, int block_k,
+    sycl::queue& q) {
+  if (n_active <= 0) return;
   const int Nb = (N + block_n - 1) / block_n;
   const int Kb = (K + block_k - 1) / block_k;
   constexpr int MAX_M = 8;
   const int VL = (K % 256 == 0) ? 256 : 128;
   if (VL == 256)
     launch_moe_gemv_block<256, MAX_M>(input, weight, weight_scale, output,
-                                      expert_idx, N, K, Nb, Kb, num_experts, q);
+                                      expert_idx, active_experts, n_active, N, K,
+                                      Nb, Kb, num_experts, q);
   else
     launch_moe_gemv_block<128, MAX_M>(input, weight, weight_scale, output,
-                                      expert_idx, N, K, Nb, Kb, num_experts, q);
+                                      expert_idx, active_experts, n_active, N, K,
+                                      Nb, Kb, num_experts, q);
 }
 
 }  // namespace fp8_moe_blockscale

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/torch_extension_gemm.cc
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/torch_extension_gemm.cc
@@ -20,6 +20,13 @@ TORCH_LIBRARY_FRAGMENT(custom_esimd_kernels_vllm, m) {
   m.def("esimd_gemm_int4_pgrp(Tensor input, Tensor weight, Tensor weight_scale, "
         "Tensor output) -> Tensor");
   m.impl("esimd_gemm_int4_pgrp", torch::kXPU, &esimd_gemm_int4_pgrp);
+
+  // FP8 block-scaled GEMM: DeepSeek 128x128 weight block scale + fp16 activation.
+  // input [M, K] fp16, weight [N, K] fp8_e4m3, weight_scale [ceil(N/128), ceil(K/128)]
+  // fp32, output [M, N] fp16 pre-allocated.
+  m.def("esimd_gemm_fp8_blockscale(Tensor input, Tensor weight, Tensor weight_scale, "
+        "Tensor output, int block_n, int block_k) -> Tensor");
+  m.impl("esimd_gemm_fp8_blockscale", torch::kXPU, &esimd_gemm_fp8_blockscale);
 }
 
 PyMODINIT_FUNC PyInit_custom_esimd_kernels_gemm() {

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/torch_extension_moe.cc
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/torch_extension_moe.cc
@@ -48,6 +48,12 @@ TORCH_LIBRARY_FRAGMENT(custom_esimd_kernels_vllm, m) {
         "Tensor output, Tensor expert_idx, "
         "int N, int K, int num_experts, int max_tokens_per_expert) -> Tensor");
   m.impl("esimd_moe_gemm_fp8_pert", torch::kXPU, &esimd_moe_gemm_fp8_pert);
+
+  m.def("esimd_moe_gemm_fp8_blockscale(Tensor input, Tensor weight, "
+        "Tensor weight_scale, Tensor output, Tensor expert_idx, "
+        "int N, int K, int num_experts, int block_n, int block_k) -> Tensor");
+  m.impl("esimd_moe_gemm_fp8_blockscale", torch::kXPU,
+         &esimd_moe_gemm_fp8_blockscale);
 }
 
 PyMODINIT_FUNC PyInit_custom_esimd_kernels_moe() {

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/torch_extension_moe.cc
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/torch_extension_moe.cc
@@ -50,8 +50,8 @@ TORCH_LIBRARY_FRAGMENT(custom_esimd_kernels_vllm, m) {
   m.impl("esimd_moe_gemm_fp8_pert", torch::kXPU, &esimd_moe_gemm_fp8_pert);
 
   m.def("esimd_moe_gemm_fp8_blockscale(Tensor input, Tensor weight, "
-        "Tensor weight_scale, Tensor output, Tensor expert_idx, "
-        "int N, int K, int num_experts, int block_n, int block_k) -> Tensor");
+        "Tensor weight_scale, Tensor(a!) output, Tensor expert_idx, "
+        "int N, int K, int num_experts, int block_n, int block_k) -> Tensor(a!)");
   m.impl("esimd_moe_gemm_fp8_blockscale", torch::kXPU,
          &esimd_moe_gemm_fp8_blockscale);
 }

--- a/vllm/custom-esimd-kernels-vllm/include/kernel_ops.h
+++ b/vllm/custom-esimd-kernels-vllm/include/kernel_ops.h
@@ -248,6 +248,14 @@ at::Tensor esimd_gemm_fp8_pert(
     at::Tensor input, at::Tensor weight, at::Tensor weight_scale,
     at::Tensor output);
 
+// FP8 block-scaled GEMM (DeepSeek-style 128x128 weight block scale, w8a16):
+// input [M, K] fp16, weight [N, K] fp8_e4m3, weight_scale [ceil(N/128), ceil(K/128)]
+// fp32 (== weight_scale_inv), output [M, N] fp16. Activation stays fp16 (no
+// activation quantization). M, N, K auto-detected from tensor shapes.
+at::Tensor esimd_gemm_fp8_blockscale(
+    at::Tensor input, at::Tensor weight, at::Tensor weight_scale,
+    at::Tensor output, int64_t block_n, int64_t block_k);
+
 // ======================== INT4 GEMV ========================
 // Symmetric INT4 weight GEMV with per-group scale (group_size=128).
 // Optimized for decode (M=1). FP32 accumulation → fp16 output.

--- a/vllm/custom-esimd-kernels-vllm/include/kernel_ops.h
+++ b/vllm/custom-esimd-kernels-vllm/include/kernel_ops.h
@@ -242,6 +242,15 @@ at::Tensor esimd_moe_gemm_fp8(
     at::Tensor output, at::Tensor expert_idx,
     int64_t N, int64_t K, int64_t num_experts, int64_t max_tokens_per_expert);
 
+// MoE grouped block-scaled FP8 GEMM (DeepSeek 128x128 weight block, w8a16):
+// input [total_tokens, K] fp16, weight [E, N, K] fp8_e4m3, weight_scale
+// [E, ceil(N/128), ceil(K/128)] fp32 (== weight_scale_inv), output
+// [total_tokens, N] fp16, expert_idx [E+1] uint32 token start offsets.
+at::Tensor esimd_moe_gemm_fp8_blockscale(
+    at::Tensor input, at::Tensor weight, at::Tensor weight_scale,
+    at::Tensor output, at::Tensor expert_idx,
+    int64_t N, int64_t K, int64_t num_experts, int64_t block_n, int64_t block_k);
+
 // FP8 GEMM per-tensor scale: input [M, K] fp16, weight [N, K] fp8, output [M, N] fp16
 // Auto-dispatches: M<=3 → batched GEMV, M>=2 E4M3 → DPAS V9, else → WS
 at::Tensor esimd_gemm_fp8_pert(

--- a/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/__init__.py
+++ b/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/__init__.py
@@ -54,6 +54,7 @@ from custom_esimd_kernels_vllm.ops import (
     moe_forward_full_gelu_tanh,
     esimd_moe_gather,
     esimd_moe_gemm_fp8,
+    esimd_moe_gemm_fp8_blockscale,
     esimd_moe_gemm_fp8_pert,
     esimd_gemm_fp8_pert,
     esimd_gemm_fp8_blockscale,

--- a/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/__init__.py
+++ b/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/__init__.py
@@ -56,6 +56,7 @@ from custom_esimd_kernels_vllm.ops import (
     esimd_moe_gemm_fp8,
     esimd_moe_gemm_fp8_pert,
     esimd_gemm_fp8_pert,
+    esimd_gemm_fp8_blockscale,
     # Eagle ops
     eagle_gdn,
     eagle_page_attn_decode,

--- a/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/ops.py
+++ b/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/ops.py
@@ -682,6 +682,32 @@ def esimd_moe_gemm_fp8(
         N, K, num_experts, max_tokens_per_expert)
 
 
+def esimd_moe_gemm_fp8_blockscale(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    output: torch.Tensor,
+    expert_idx: torch.Tensor,
+    N: int,
+    K: int,
+    num_experts: int,
+    block_n: int = 128,
+    block_k: int = 128,
+) -> torch.Tensor:
+    """MoE grouped block-scaled FP8 GEMM (DeepSeek 128x128 weight block, w8a16).
+
+    input:        [total_tokens, K] fp16   (expert-grouped/scattered rows)
+    weight:       [num_experts, N, K] fp8_e4m3 (or uint8 bits)
+    weight_scale: [num_experts, ceil(N/128), ceil(K/128)] float32 (weight_scale_inv)
+    output:       [total_tokens, N] fp16
+    expert_idx:   [num_experts+1] uint32/int32 — token start offsets per expert
+    Activation stays fp16 (no per-token-group act quant).
+    """
+    return _ops.esimd_moe_gemm_fp8_blockscale(
+        input, weight, weight_scale, output, expert_idx,
+        N, K, num_experts, block_n, block_k)
+
+
 def esimd_gemm_fp8_pert(
     input: torch.Tensor, weight: torch.Tensor, weight_scale: torch.Tensor,
     output: torch.Tensor,

--- a/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/ops.py
+++ b/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/ops.py
@@ -698,6 +698,29 @@ def esimd_gemm_fp8_pert(
     return _ops.esimd_gemm_fp8_pert(input, weight, weight_scale, output)
 
 
+def esimd_gemm_fp8_blockscale(
+    input: torch.Tensor, weight: torch.Tensor, weight_scale: torch.Tensor,
+    output: torch.Tensor, block_n: int = 128, block_k: int = 128,
+) -> torch.Tensor:
+    """FP8 block-scaled GEMM (DeepSeek-style), w8a16 (fp16 activation).
+
+    Computes: output[M, N] = input[M, K] @ dequant(weight[N, K])^T
+    where the fp8_e4m3 weight is dequantized with a 2D 128x128 block scale
+    (weight_scale[nb, kb] scales the 128x128 weight block). The activation is
+    NOT quantized — it is consumed in fp16 directly.
+
+    input:        [M, K]                         fp16
+    weight:       [N, K]                         fp8_e4m3 (or uint8 bits)
+    weight_scale: [ceil(N/128), ceil(K/128)]     float32  (== weight_scale_inv)
+    output:       [M, N]                         fp16 — pre-allocated
+
+    M, N, K inferred from tensor shapes. K must be a multiple of block_k (128).
+    Only block_n == block_k == 128 is currently supported.
+    """
+    return _ops.esimd_gemm_fp8_blockscale(
+        input, weight, weight_scale, output, block_n, block_k)
+
+
 def esimd_moe_gemm_fp8_pert(
     input: torch.Tensor,
     weight: torch.Tensor,

--- a/vllm/custom-esimd-kernels-vllm/setup_moecore_only.py
+++ b/vllm/custom-esimd-kernels-vllm/setup_moecore_only.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+
+from setuptools import find_packages, setup
+from torch.utils.cpp_extension import SyclExtension
+from esimd_build_extention import BuildExtension
+
+root = Path(__file__).parent.resolve()
+
+import torch
+torch_include = str(Path(torch.__file__).parent / "include")
+
+setup(
+    name="custom-esimd-kernels-vllm-moecore-only",
+    version="0.1.0",
+    packages=find_packages(where="python"),
+    package_dir={"": "python"},
+    ext_modules=[
+        SyclExtension(
+            name="custom_esimd_kernels_vllm.custom_esimd_kernels_moe",
+            sources=[
+                "csrc/xpu/esimd_kernel_moe.sycl",
+                "csrc/xpu/torch_extension_moe.cc",
+            ],
+            include_dirs=[
+                root / "include",
+                root / "csrc",
+            ],
+            extra_compile_args={
+                "cxx": ["-O3", "-std=c++17"],
+                "sycl": ["-ffast-math", "-fsycl-device-code-split=per_kernel",
+                         f"-I{torch_include}"],
+            },
+            extra_link_args=["-Wl,-rpath,$ORIGIN/../../torch/lib"],
+            py_limited_api=False,
+        )
+    ],
+    cmdclass={"build_ext": BuildExtension.with_options(use_ninja=True)},
+)

--- a/vllm/custom-esimd-kernels-vllm/tests/bench_fp8_blockscale_gemm.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/bench_fp8_blockscale_gemm.py
@@ -1,0 +1,69 @@
+"""Microbenchmark esimd_gemm_fp8_blockscale across decode (M=1) and prefill M.
+
+    ZE_AFFINITY_MASK=4,5 python3 tests/bench_fp8_blockscale_gemm.py
+"""
+import time
+import torch
+import custom_esimd_kernels_vllm as esimd
+
+BN = BK = 128
+DEV = "xpu"
+
+# Representative Qwen3.6-27B (TP=2) per-rank linear shapes (N, K):
+#   qkv_proj, o_proj, gate_up, down. TP=2 splits N (col-parallel) or K (row-parallel).
+SHAPES = [
+    ("qkv_proj", 4096, 5120),    # (6144+1024+1024)/... approx per-rank; use round
+    ("o_proj",   5120, 3072),
+    ("gate_up",  17408, 5120),
+    ("down",     5120, 8704),
+]
+# keep K a multiple of 128
+SHAPES = [(n, N - N % 128, K - K % 128) for (n, N, K) in SHAPES]
+
+
+def make_weight(N, K):
+    w = (torch.randn(N, K, device=DEV) * 0.2)
+    Nb, Kb = (N + BN - 1) // BN, (K + BK - 1) // BK
+    wq = torch.empty(N, K, dtype=torch.float8_e4m3fn, device=DEV)
+    ws = torch.empty(Nb, Kb, dtype=torch.float32, device=DEV)
+    for i in range(Nb):
+        blk = w[i * BN:(i + 1) * BN]
+        for j in range(Kb):
+            b = blk[:, j * BK:(j + 1) * BK]
+            s = (b.abs().max() / 448).clamp(min=1e-12)
+            ws[i, j] = s
+            wq[i * BN:(i + 1) * BN, j * BK:(j + 1) * BK] = (b / s).to(torch.float8_e4m3fn)
+    return wq, ws
+
+
+def bench(M, N, K, wq, ws, iters=30, warmup=10):
+    a = (torch.randn(M, K, device=DEV) * 0.5).to(torch.float16)
+    out = torch.empty(M, N, dtype=torch.float16, device=DEV)
+    for _ in range(warmup):
+        esimd.esimd_gemm_fp8_blockscale(a, wq, ws, out, BN, BK)
+    torch.xpu.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        esimd.esimd_gemm_fp8_blockscale(a, wq, ws, out, BN, BK)
+    torch.xpu.synchronize()
+    dt = (time.perf_counter() - t0) / iters
+    # bytes: weight fp8 (N*K) dominant for decode; + activation + scale
+    wbytes = N * K + (N // BN) * (K // BK) * 4 + M * K * 2 + M * N * 2
+    flops = 2.0 * M * N * K
+    return dt * 1e3, wbytes / dt / 1e9, flops / dt / 1e12
+
+
+def main():
+    for name, N, K in SHAPES:
+        wq, ws = make_weight(N, K)
+        print(f"\n== {name}  N={N} K={K} ==")
+        for M in (1, 2, 4, 8, 64, 512, 2048, 4096, 8192):
+            try:
+                ms, gbps, tflops = bench(M, N, K, wq, ws)
+                print(f"  M={M:<5} {ms:8.3f} ms   {gbps:7.1f} GB/s   {tflops:6.2f} TFLOP/s")
+            except Exception as e:
+                print(f"  M={M:<5} ERROR {type(e).__name__}: {str(e)[:80]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/custom-esimd-kernels-vllm/tests/test_fp8_blockscale_gemm.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/test_fp8_blockscale_gemm.py
@@ -1,0 +1,83 @@
+"""Unit test: esimd_gemm_fp8_blockscale vs a dequant->fp32 matmul reference.
+
+Run under the allowed cards, e.g.:
+    ZE_AFFINITY_MASK=4,5 python3 tests/test_fp8_blockscale_gemm.py
+"""
+import torch
+import custom_esimd_kernels_vllm as esimd
+
+FP8_MAX = 448.0  # float8_e4m3fn max magnitude
+BN = BK = 128
+
+
+def quantize_weight_block(w_f32, bn=BN, bk=BK):
+    """Quantize [N,K] fp32 -> (fp8_e4m3 weight, fp32 weight_scale_inv[Nb,Kb])."""
+    N, K = w_f32.shape
+    Nb, Kb = (N + bn - 1) // bn, (K + bk - 1) // bk
+    wq = torch.empty(N, K, dtype=torch.float8_e4m3fn, device=w_f32.device)
+    ws = torch.empty(Nb, Kb, dtype=torch.float32, device=w_f32.device)
+    for i in range(Nb):
+        for j in range(Kb):
+            blk = w_f32[i * bn:(i + 1) * bn, j * bk:(j + 1) * bk]
+            amax = blk.abs().max().clamp(min=1e-12)
+            scale = (amax / FP8_MAX).to(torch.float32)
+            ws[i, j] = scale
+            wq[i * bn:(i + 1) * bn, j * bk:(j + 1) * bk] = (
+                (blk / scale).to(torch.float8_e4m3fn)
+            )
+    return wq, ws
+
+
+def dequant_weight(wq, ws, bn=BN, bk=BK):
+    """[N,K] fp8 + [Nb,Kb] fp32 -> [N,K] fp32 dequantized weight."""
+    N, K = wq.shape
+    wf = wq.to(torch.float32)
+    scale_full = ws.repeat_interleave(bn, 0)[:N].repeat_interleave(bk, 1)[:, :K]
+    return wf * scale_full
+
+
+def run_case(M, N, K, dev):
+    torch.manual_seed(1234 + M * 131 + N + K)
+    w = (torch.randn(N, K, device=dev) * 0.3)
+    wq, ws = quantize_weight_block(w)
+    w_deq = dequant_weight(wq, ws)
+
+    a = (torch.randn(M, K, device=dev) * 0.5).to(torch.float16)
+    ref = a.to(torch.float32) @ w_deq.t()  # [M, N]
+
+    out = torch.empty(M, N, dtype=torch.float16, device=dev)
+    esimd.esimd_gemm_fp8_blockscale(a, wq, ws, out, BN, BK)
+    torch.xpu.synchronize()
+
+    o = out.to(torch.float32)
+    denom = ref.abs().mean().clamp(min=1e-6)
+    rel = (o - ref).abs().mean() / denom
+    max_rel = ((o - ref).abs() / ref.abs().clamp(min=1e-3)).max()
+    cos = torch.nn.functional.cosine_similarity(
+        o.flatten(), ref.flatten(), dim=0
+    )
+    ok = rel < 5e-2 and cos > 0.999
+    print(f"M={M:<5} N={N:<6} K={K:<6} mean_rel={rel:.4e} "
+          f"max_rel={max_rel:.3e} cos={cos:.6f}  {'OK' if ok else 'FAIL'}")
+    return ok
+
+
+def main():
+    dev = "xpu"
+    torch.xpu.synchronize()
+    all_ok = True
+    for K in (5120, 6144, 17408):
+        for N in (1024, 5120, 6144):
+            all_ok &= run_case(1, N, K, dev)      # decode
+    # M>1 tiled path + remainder tile
+    for M in (2, 7, 8, 9, 33, 64):
+        all_ok &= run_case(M, 5120, 5120, dev)
+    # N not a multiple of PPG (scalar tail store path)
+    all_ok &= run_case(1, 1000, 5120, dev)
+    all_ok &= run_case(4, 1000, 5120, dev)
+    print("\nRESULT:", "ALL OK" if all_ok else "FAILURES PRESENT")
+    raise SystemExit(0 if all_ok else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Add the ESIMD kernel foundation for offline FP8 block quantization on Intel XPU.

## Changes

- Add `esimd_gemm_fp8_blockscale` for dense linear layers with 128x128 weight block scales.
- Add `esimd_moe_gemm_fp8_blockscale` for grouped routed-expert GEMM.
- Compact the grouped MoE launch grid to active experts only.
- Register the native operators and Python wrappers.
- Add dense correctness coverage and a microbenchmark script.

## Quantization contract

- Weight: FP8 E4M3 with 128x128 block scales.
- Activation: FP16 for the w8a16 path.
- MoE weight layout: `[E, N, K]` with scales `[E, N/128, K/128]`.

## Framework dependency

The corresponding vLLM XPU integration is submitted separately and depends on this PR.

## Validation

The split PR has not been rerun after rebasing onto the latest `main`. Existing development validation covered dense correctness, grouped MoE correctness against per-expert dequantization, and end-to-end TP2 model execution.

## Out of scope

- Fused block MoE decode.
- Block-scaled attention and GDN decode fusions.
- Block MoE prefill optimization.
- PIECEWISE graph deployment.
