### PR TITLE
Fix #533: guard out_proj.weight access in GDN out-projection ESIMD probes

### DIFF
--- a/vllm/patches/vllm_for_multi_arc.patch
+++ b/vllm/patches/vllm_for_multi_arc.patch
@@ -2765,7 +2765,7 @@ index 4493ee783..fb0e235c7 100644
 +
 +        ok = False
 +        if ESIMD_AVAILABLE and not disable_esimd_gdn_outproj():
-+            w = self.out_proj.weight
++            w = getattr(self.out_proj, "weight", None)
 +            ws = getattr(self.out_proj, "weight_scale", None)
 +            ok = (
 +                w is not None
@@ -2798,7 +2798,7 @@ index 4493ee783..fb0e235c7 100644
 +
 +        ok = False
 +        if ESIMD_AVAILABLE and not disable_esimd_gdn_outproj():
-+            w = self.out_proj.weight
++            w = getattr(self.out_proj, "weight", None)
 +            ws = getattr(self.out_proj, "weight_scale", None)
 +            ok = (
 +                w is not None


### PR DESCRIPTION
## Problem

Both GDN out-projection eligibility probes read `self.out_proj.weight` unconditionally. Quantized `RowParallelLinear` layers expose `.qweight`, not `.weight`, so hybrid GDN+MoE models loaded with GPTQ/AWQ crash on the first forward pass with `AttributeError: 'RowParallelLinear' object has no attribute 'weight'`.

## Fix

`w = getattr(self.out_proj, "weight", None)` in both `_gdn_outproj_esimd_eligible` and `_gdn_outproj_batched_esimd_eligible` (in `gdn_linear_attn.py`, applied through `vllm/patches/vllm_for_multi_arc.patch`).

The existing check `ok = (w is not None and ...)` already short-circuits: when `w` is `None`, `ok` becomes `False` and execution falls through to the generic `self.out_proj(core_attn_out)` call, which already dispatches GPTQ/AWQ correctly through `int4_gemm_w4a16`. For fp8 layers, `getattr` returns the same tensor object as the direct attribute access, so that path is unchanged.

## Testing

Ran on an Intel Arc Pro B70 (32GB, Battlemage G21) with `intel/llm-scaler-vllm:0.21.0-b1`.

Before: `palmfuture/Qwen3.6-35B-A3B-GPTQ-Int4` loads and starts the server, then crashes on the first inference request with the #533 AttributeError.

After: the same model loads, serves, and generates correct output end to end at 15.9 tok/s (single-request decode, GPTQ path). Re-checked the sym_int4 and fp8 out-projection paths on the same card afterward; both still pass.

Closes #533.
