### PR TITLE
[XPU][FP8] Add fused block MoE decode kernel

### DIFF
--- a/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe.sycl
@@ -6,6 +6,8 @@
 #include <sycl/ext/intel/esimd.hpp>
 #include <sycl/ext/intel/experimental/esimd/memory.hpp>
 
+#include <array>
+
 #include "moe_topk.h"
 #include "moe_decode_gemv.h"
 #include "../xpu/esimd_kernels/moe_ops.h"
@@ -1493,6 +1495,244 @@ static void ensure_moe_buffers(int n_tokens, int top_k, int num_shared_experts,
     }
 }
 
+// FP8-block BSZ=1 path. The checkpoint layout is the native vLLM layout:
+//   routed gate_up [E, 2I, H], scale [E, ceil(2I/128), ceil(H/128)]
+//   routed down    [E, H, I],  scale [E, ceil(H/128), ceil(I/128)]
+// Shared-expert weights omit the leading expert dimension. Activations remain
+// FP16; FP8 values are converted to FP16/FP32 and multiplied by the 128x128
+// block scale before accumulation. This path does not use FP8 matrix multiply.
+void moe_up_fp8_block_bsz1_kernel(
+    const fp16* x,
+    const uint8_t* gate_up_weight, const float* gate_up_scale,
+    const uint8_t* shared_gate_up_weight, const float* shared_gate_up_scale,
+    const int* selected_experts, fp16* intermediates,
+    const int hidden_size, const int intermediate_size, const int top_k,
+    const torch::Device& device) {
+    const int two_inter = 2 * intermediate_size;
+    const int scale_nb = (two_inter + 127) / 128;
+    const int scale_kb = (hidden_size + 127) / 128;
+
+    auto cgf = [&](sycl::handler& cgh) {
+        cgh.parallel_for<class MoeUpFP8BlockBSZ1>(
+            sycl::range<2>(top_k + 1, intermediate_size),
+            [=](sycl::id<2> idx) SYCL_ESIMD_KERNEL {
+                const int route = (int)idx[0];
+                const int row = (int)idx[1];
+                const bool shared = route == top_k;
+                const int eid = shared ? 0 : selected_experts[route];
+                const uint8_t* weight = shared ? shared_gate_up_weight
+                    : gate_up_weight + (size_t)eid * two_inter * hidden_size;
+                const float* scales = shared ? shared_gate_up_scale
+                    : gate_up_scale + (size_t)eid * scale_nb * scale_kb;
+                const uint8_t* gate_w = weight + (size_t)row * hidden_size;
+                const uint8_t* up_w =
+                    weight + (size_t)(intermediate_size + row) * hidden_size;
+                const float* gate_s = scales + (size_t)(row / 128) * scale_kb;
+                const float* up_s = scales
+                    + (size_t)((intermediate_size + row) / 128) * scale_kb;
+
+                simd<float, 64> gate_acc(0.f), up_acc(0.f);
+                for (int k = 0; k < hidden_size; k += 64) {
+                    simd<float, 64> xv =
+                        block_load<fp16, 64>(x + k);
+                    simd<float, 64> gw = fp8e4m3_to_half<64>(
+                        block_load<uint8_t, 64>(gate_w + k));
+                    simd<float, 64> uw = fp8e4m3_to_half<64>(
+                        block_load<uint8_t, 64>(up_w + k));
+                    gate_acc += xv * (gw * gate_s[k / 128]);
+                    up_acc += xv * (uw * up_s[k / 128]);
+                }
+
+                float gate = sycl::ext::intel::esimd::detail::sum<
+                    float, float, 64>(gate_acc);
+                float up = sycl::ext::intel::esimd::detail::sum<
+                    float, float, 64>(up_acc);
+                float silu = gate / (1.f + sycl::exp(-gate));
+                intermediates[(size_t)route * intermediate_size + row] =
+                    fp16(silu * up);
+            });
+    };
+    submit_kernel(cgf, device, "moe up fp8 block bsz1");
+}
+
+void moe_down_finalize_fp8_block_bsz1_kernel(
+    const fp16* x, const fp16* intermediates,
+    const uint8_t* down_weight, const float* down_scale,
+    const uint8_t* shared_down_weight, const float* shared_down_scale,
+    const fp16* shared_expert_gate_weight,
+    const fp16* routing_weights, const int* selected_experts,
+    fp16* final_output, const int hidden_size, const int intermediate_size,
+    const int top_k, const torch::Device& device) {
+    const int scale_nb = (hidden_size + 127) / 128;
+    const int scale_kb = (intermediate_size + 127) / 128;
+
+    auto cgf = [&](sycl::handler& cgh) {
+        cgh.parallel_for<class MoeDownFinalizeFP8BlockBSZ1>(
+            sycl::range<1>(hidden_size),
+            [=](sycl::id<1> idx) SYCL_ESIMD_KERNEL {
+                const int out = (int)idx[0];
+                float result = 0.f;
+
+                for (int route = 0; route < top_k; route++) {
+                    const int eid = selected_experts[route];
+                    const fp16* input =
+                        intermediates + (size_t)route * intermediate_size;
+                    const uint8_t* weight = down_weight
+                        + ((size_t)eid * hidden_size + out) * intermediate_size;
+                    const float* scales = down_scale
+                        + ((size_t)eid * scale_nb + out / 128) * scale_kb;
+                    simd<float, 64> acc(0.f);
+                    for (int k = 0; k < intermediate_size; k += 64) {
+                        simd<float, 64> iv =
+                            block_load<fp16, 64>(input + k);
+                        simd<float, 64> wv = fp8e4m3_to_half<64>(
+                            block_load<uint8_t, 64>(weight + k));
+                        acc += iv * (wv * scales[k / 128]);
+                    }
+                    result += sycl::ext::intel::esimd::detail::sum<
+                        float, float, 64>(acc) * (float)routing_weights[route];
+                }
+
+                simd<float, 64> gate_acc(0.f);
+                for (int k = 0; k < hidden_size; k += 64) {
+                    simd<float, 64> xv = block_load<fp16, 64>(x + k);
+                    simd<float, 64> gw = block_load<fp16, 64>(
+                        shared_expert_gate_weight + k);
+                    gate_acc += xv * gw;
+                }
+                float gate = sycl::ext::intel::esimd::detail::sum<
+                    float, float, 64>(gate_acc);
+                gate = 1.f / (1.f + sycl::exp(-gate));
+
+                const fp16* shared_input =
+                    intermediates + (size_t)top_k * intermediate_size;
+                const uint8_t* shared_weight =
+                    shared_down_weight + (size_t)out * intermediate_size;
+                const float* shared_scales = shared_down_scale
+                    + (size_t)(out / 128) * scale_kb;
+                simd<float, 64> shared_acc(0.f);
+                for (int k = 0; k < intermediate_size; k += 64) {
+                    simd<float, 64> iv =
+                        block_load<fp16, 64>(shared_input + k);
+                    simd<float, 64> wv = fp8e4m3_to_half<64>(
+                        block_load<uint8_t, 64>(shared_weight + k));
+                    shared_acc += iv * (wv * shared_scales[k / 128]);
+                }
+                result += gate * sycl::ext::intel::esimd::detail::sum<
+                    float, float, 64>(shared_acc);
+                final_output[out] = fp16(result);
+            });
+    };
+    submit_kernel(cgf, device, "moe down finalize fp8 block bsz1");
+}
+
+static thread_local torch::Tensor s_block_topk_idx, s_block_topk_weight;
+static thread_local torch::Tensor s_block_intermediates;
+static thread_local std::array<torch::Tensor, 2> s_block_final_outputs;
+static thread_local int s_block_cached_topk = -1;
+static thread_local int s_block_cached_hidden = -1;
+static thread_local int s_block_cached_intermediate = -1;
+static thread_local int s_block_output_index = 0;
+
+static void ensure_moe_block_buffers(int top_k, int hidden_size,
+                                     int intermediate_size,
+                                     const torch::Device& dev) {
+    if (s_block_cached_topk != top_k ||
+        s_block_cached_hidden != hidden_size ||
+        s_block_cached_intermediate != intermediate_size) {
+        s_block_topk_idx = torch::empty(
+            {1, top_k}, torch::device(dev).dtype(torch::kInt32));
+        s_block_topk_weight = torch::empty(
+            {1, top_k}, torch::device(dev).dtype(torch::kHalf));
+        s_block_intermediates = torch::empty(
+            {top_k + 1, intermediate_size},
+            torch::device(dev).dtype(torch::kHalf));
+        for (auto& output : s_block_final_outputs) {
+            output = torch::empty(
+                {1, hidden_size}, torch::device(dev).dtype(torch::kHalf));
+        }
+        s_block_cached_topk = top_k;
+        s_block_cached_hidden = hidden_size;
+        s_block_cached_intermediate = intermediate_size;
+        s_block_output_index = 0;
+    }
+}
+
+torch::Tensor moe_forward_full_fp8_block(
+    torch::Tensor x, torch::Tensor logits,
+    torch::Tensor gate_up_weight, torch::Tensor gate_up_scale,
+    torch::Tensor shared_gate_up_weight, torch::Tensor shared_gate_up_scale,
+    torch::Tensor down_weight, torch::Tensor down_scale,
+    torch::Tensor shared_down_weight, torch::Tensor shared_down_scale,
+    torch::Tensor shared_expert_gate_weight,
+    int64_t top_k, int64_t num_shared_experts,
+    int64_t n_routed_experts) {
+    TORCH_CHECK(x.dim() == 2 && x.size(0) == 1,
+                "moe_forward_full_fp8_block currently supports batch size 1");
+    TORCH_CHECK(x.is_contiguous() && x.scalar_type() == torch::kHalf);
+    TORCH_CHECK(logits.dim() == 2 && logits.size(0) == 1 &&
+                logits.size(1) == n_routed_experts);
+    TORCH_CHECK(logits.scalar_type() == torch::kHalf);
+    TORCH_CHECK(num_shared_experts == 1,
+                "moe_forward_full_fp8_block requires one shared expert");
+    TORCH_CHECK(gate_up_weight.scalar_type() == at::kFloat8_e4m3fn &&
+                down_weight.scalar_type() == at::kFloat8_e4m3fn &&
+                shared_gate_up_weight.scalar_type() == at::kFloat8_e4m3fn &&
+                shared_down_weight.scalar_type() == at::kFloat8_e4m3fn,
+                "moe_forward_full_fp8_block requires e4m3 weights");
+    TORCH_CHECK(gate_up_scale.scalar_type() == torch::kFloat32 &&
+                down_scale.scalar_type() == torch::kFloat32 &&
+                shared_gate_up_scale.scalar_type() == torch::kFloat32 &&
+                shared_down_scale.scalar_type() == torch::kFloat32);
+
+    const int hidden_size = x.size(1);
+    TORCH_CHECK(gate_up_weight.dim() == 3 &&
+                gate_up_weight.size(0) == n_routed_experts &&
+                gate_up_weight.size(2) == hidden_size);
+    const int intermediate_size = gate_up_weight.size(1) / 2;
+    TORCH_CHECK(gate_up_weight.size(1) == 2 * intermediate_size);
+    TORCH_CHECK(down_weight.sizes() ==
+                torch::IntArrayRef({n_routed_experts, hidden_size,
+                                    intermediate_size}));
+    TORCH_CHECK(shared_gate_up_weight.sizes() ==
+                torch::IntArrayRef({2 * intermediate_size, hidden_size}));
+    TORCH_CHECK(shared_down_weight.sizes() ==
+                torch::IntArrayRef({hidden_size, intermediate_size}));
+    TORCH_CHECK(hidden_size % 128 == 0 && intermediate_size % 128 == 0);
+
+    ensure_moe_block_buffers(top_k, hidden_size, intermediate_size, x.device());
+    // Alternate outputs so the next decoder layer can safely pass the
+    // preceding layer's returned buffer back as x.
+    torch::Tensor final_output = s_block_final_outputs[s_block_output_index];
+    s_block_output_index ^= 1;
+    dispatch_moe_topk_forward<class MoeTopKFP8BlockBSZ1>(
+        (const fp16*)logits.data_ptr(), s_block_topk_idx.data_ptr<int>(),
+        (fp16*)s_block_topk_weight.data_ptr(), 1, (int)n_routed_experts,
+        (int)top_k, /*norm=*/true, logits.device());
+
+    moe_up_fp8_block_bsz1_kernel(
+        (const fp16*)x.data_ptr(),
+        (const uint8_t*)gate_up_weight.data_ptr(), gate_up_scale.data_ptr<float>(),
+        (const uint8_t*)shared_gate_up_weight.data_ptr(),
+        shared_gate_up_scale.data_ptr<float>(),
+        s_block_topk_idx.data_ptr<int>(),
+        (fp16*)s_block_intermediates.data_ptr(), hidden_size,
+        intermediate_size, top_k, x.device());
+
+    moe_down_finalize_fp8_block_bsz1_kernel(
+        (const fp16*)x.data_ptr(),
+        (const fp16*)s_block_intermediates.data_ptr(),
+        (const uint8_t*)down_weight.data_ptr(), down_scale.data_ptr<float>(),
+        (const uint8_t*)shared_down_weight.data_ptr(),
+        shared_down_scale.data_ptr<float>(),
+        (const fp16*)shared_expert_gate_weight.data_ptr(),
+        (const fp16*)s_block_topk_weight.data_ptr(),
+        s_block_topk_idx.data_ptr<int>(),
+        (fp16*)final_output.data_ptr(), hidden_size,
+        intermediate_size, top_k, x.device());
+    return final_output;
+}
+
 torch::Tensor moe_forward_full(
     torch::Tensor x, torch::Tensor logits,
     torch::Tensor gate_up_weight, torch::Tensor gate_up_scale,
@@ -2066,6 +2306,7 @@ TORCH_LIBRARY_FRAGMENT(moe_ops, m) {
     m.def("moe_up_fp8_grouped(Tensor x, Tensor gate_up_weight, Tensor gate_up_scale, Tensor expert_offsets, Tensor expert_tokens, int top_k, int n_routed_experts) -> Tensor");
     m.def("moe_down_fp8_grouped(Tensor intermediate, Tensor down_weight, Tensor down_scale, Tensor routing_weights, Tensor expert_offsets, Tensor expert_tokens, int top_k, int n_routed_experts) -> Tensor");
     m.def("moe_forward_full(Tensor x, Tensor logits, Tensor gate_up_weight, Tensor gate_up_scale, Tensor shared_gate_up_weight, Tensor shared_gate_up_scale, Tensor down_weight, Tensor down_scale, Tensor shared_down_weight, Tensor shared_down_scale, Tensor shared_expert_gate_weight, int top_k, int num_shared_experts, int n_routed_experts) -> Tensor");
+    m.def("moe_forward_full_fp8_block(Tensor x, Tensor logits, Tensor gate_up_weight, Tensor gate_up_scale, Tensor shared_gate_up_weight, Tensor shared_gate_up_scale, Tensor down_weight, Tensor down_scale, Tensor shared_down_weight, Tensor shared_down_scale, Tensor shared_expert_gate_weight, int top_k, int num_shared_experts, int n_routed_experts) -> Tensor");
     m.def("moe_forward_full_v2(Tensor x, Tensor logits, Tensor gate_up_weight, Tensor gate_up_scale, Tensor shared_gate_up_weight, Tensor shared_gate_up_scale, Tensor down_weight, Tensor down_scale, Tensor shared_down_weight, Tensor shared_down_scale, Tensor shared_expert_gate_weight, int top_k, int num_shared_experts, int n_routed_experts) -> Tensor");
 }
 
@@ -2084,6 +2325,7 @@ TORCH_LIBRARY_IMPL(moe_ops, XPU, m) {
     m.impl("moe_forward_full_gelu_tanh_routed_no_accum", &moe_forward_full_gelu_tanh_routed_no_accum);
     m.impl("moe_forward_fused", &moe_forward_fused);
     m.impl("moe_forward_full", &moe_forward_full);
+    m.impl("moe_forward_full_fp8_block", &moe_forward_full_fp8_block);
     m.impl("moe_forward_full_v2", &moe_forward_full_v2);
 }
 
@@ -2095,5 +2337,6 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("moe_topk", &moe_topk);
     m.def("moe_forward_fused", &moe_forward_fused);
     m.def("moe_forward_full", &moe_forward_full);
+    m.def("moe_forward_full_fp8_block", &moe_forward_full_fp8_block);
     m.def("moe_forward_full_v2", &moe_forward_full_v2);
 }

--- a/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe.sycl
@@ -1497,8 +1497,8 @@ static void ensure_moe_buffers(int n_tokens, int top_k, int num_shared_experts,
 }
 
 // FP8-block small-batch path. The checkpoint layout is the native vLLM layout:
-//   routed gate_up [E, 2I, H], scale [E, ceil(2I/128), ceil(H/128)]
-//   routed down    [E, H, I],  scale [E, ceil(H/128), ceil(I/128)]
+//   routed gate_up [E, 2I, H], scale [E, 2I/128, H/128]
+//   routed down    [E, H, I],  scale [E, H/128, I/128]
 // Shared-expert weights omit the leading expert dimension. Activations remain
 // FP16; FP8 values are converted to FP16/FP32 and multiplied by the 128x128
 // block scale before accumulation. This path does not use FP8 matrix multiply.
@@ -1653,6 +1653,10 @@ struct MoeBlockBuffers {
 // Capture and serving commonly alternate among 1..4 decode tokens. Keep one
 // persistent slot per token count so switching shapes does not reallocate all
 // intermediate tensors. The memory cost is tiny for these decode-only buffers.
+// This cache follows vLLM's single model-compute-stream-per-TP-worker contract;
+// concurrent use from multiple compute streams is unsupported. If that
+// execution model changes, use per-stream caches rather than synchronizing the
+// decode hot path on every stream change.
 static thread_local std::array<MoeBlockBuffers, 4> s_block_buffers;
 
 static MoeBlockBuffers& ensure_moe_block_buffers(

--- a/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe.sycl
@@ -1495,31 +1495,35 @@ static void ensure_moe_buffers(int n_tokens, int top_k, int num_shared_experts,
     }
 }
 
-// FP8-block BSZ=1 path. The checkpoint layout is the native vLLM layout:
+// FP8-block small-batch path. The checkpoint layout is the native vLLM layout:
 //   routed gate_up [E, 2I, H], scale [E, ceil(2I/128), ceil(H/128)]
 //   routed down    [E, H, I],  scale [E, ceil(H/128), ceil(I/128)]
 // Shared-expert weights omit the leading expert dimension. Activations remain
 // FP16; FP8 values are converted to FP16/FP32 and multiplied by the 128x128
 // block scale before accumulation. This path does not use FP8 matrix multiply.
-void moe_up_fp8_block_bsz1_kernel(
+void moe_up_fp8_block_batched_kernel(
     const fp16* x,
     const uint8_t* gate_up_weight, const float* gate_up_scale,
     const uint8_t* shared_gate_up_weight, const float* shared_gate_up_scale,
     const int* selected_experts, fp16* intermediates,
-    const int hidden_size, const int intermediate_size, const int top_k,
+    const int num_tokens, const int hidden_size,
+    const int intermediate_size, const int top_k,
     const torch::Device& device) {
     const int two_inter = 2 * intermediate_size;
     const int scale_nb = (two_inter + 127) / 128;
     const int scale_kb = (hidden_size + 127) / 128;
 
     auto cgf = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class MoeUpFP8BlockBSZ1>(
-            sycl::range<2>(top_k + 1, intermediate_size),
-            [=](sycl::id<2> idx) SYCL_ESIMD_KERNEL {
-                const int route = (int)idx[0];
-                const int row = (int)idx[1];
+        cgh.parallel_for<class MoeUpFP8BlockBatched>(
+            sycl::range<3>(num_tokens, top_k + 1, intermediate_size),
+            [=](sycl::id<3> idx) SYCL_ESIMD_KERNEL {
+                const int token = (int)idx[0];
+                const int route = (int)idx[1];
+                const int row = (int)idx[2];
                 const bool shared = route == top_k;
-                const int eid = shared ? 0 : selected_experts[route];
+                const int eid = shared ? 0
+                    : selected_experts[token * top_k + route];
+                const fp16* token_x = x + (size_t)token * hidden_size;
                 const uint8_t* weight = shared ? shared_gate_up_weight
                     : gate_up_weight + (size_t)eid * two_inter * hidden_size;
                 const float* scales = shared ? shared_gate_up_scale
@@ -1534,7 +1538,7 @@ void moe_up_fp8_block_bsz1_kernel(
                 simd<float, 64> gate_acc(0.f), up_acc(0.f);
                 for (int k = 0; k < hidden_size; k += 64) {
                     simd<float, 64> xv =
-                        block_load<fp16, 64>(x + k);
+                        block_load<fp16, 64>(token_x + k);
                     simd<float, 64> gw = fp8e4m3_to_half<64>(
                         block_load<uint8_t, 64>(gate_w + k));
                     simd<float, 64> uw = fp8e4m3_to_half<64>(
@@ -1548,35 +1552,43 @@ void moe_up_fp8_block_bsz1_kernel(
                 float up = sycl::ext::intel::esimd::detail::sum<
                     float, float, 64>(up_acc);
                 float silu = gate / (1.f + sycl::exp(-gate));
-                intermediates[(size_t)route * intermediate_size + row] =
+                const size_t intermediate_offset =
+                    ((size_t)token * (top_k + 1) + route)
+                    * intermediate_size + row;
+                intermediates[intermediate_offset] =
                     fp16(silu * up);
             });
     };
-    submit_kernel(cgf, device, "moe up fp8 block bsz1");
+    submit_kernel(cgf, device, "moe up fp8 block batched");
 }
 
-void moe_down_finalize_fp8_block_bsz1_kernel(
+void moe_down_finalize_fp8_block_batched_kernel(
     const fp16* x, const fp16* intermediates,
     const uint8_t* down_weight, const float* down_scale,
     const uint8_t* shared_down_weight, const float* shared_down_scale,
     const fp16* shared_expert_gate_weight,
     const fp16* routing_weights, const int* selected_experts,
-    fp16* final_output, const int hidden_size, const int intermediate_size,
-    const int top_k, const torch::Device& device) {
+    fp16* final_output, const int num_tokens, const int hidden_size,
+    const int intermediate_size, const int top_k,
+    const torch::Device& device) {
     const int scale_nb = (hidden_size + 127) / 128;
     const int scale_kb = (intermediate_size + 127) / 128;
 
     auto cgf = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class MoeDownFinalizeFP8BlockBSZ1>(
-            sycl::range<1>(hidden_size),
-            [=](sycl::id<1> idx) SYCL_ESIMD_KERNEL {
-                const int out = (int)idx[0];
+        cgh.parallel_for<class MoeDownFinalizeFP8BlockBatched>(
+            sycl::range<2>(num_tokens, hidden_size),
+            [=](sycl::id<2> idx) SYCL_ESIMD_KERNEL {
+                const int token = (int)idx[0];
+                const int out = (int)idx[1];
+                const fp16* token_x = x + (size_t)token * hidden_size;
                 float result = 0.f;
 
                 for (int route = 0; route < top_k; route++) {
-                    const int eid = selected_experts[route];
-                    const fp16* input =
-                        intermediates + (size_t)route * intermediate_size;
+                    const int route_offset = token * top_k + route;
+                    const int eid = selected_experts[route_offset];
+                    const fp16* input = intermediates
+                        + ((size_t)token * (top_k + 1) + route)
+                        * intermediate_size;
                     const uint8_t* weight = down_weight
                         + ((size_t)eid * hidden_size + out) * intermediate_size;
                     const float* scales = down_scale
@@ -1590,12 +1602,13 @@ void moe_down_finalize_fp8_block_bsz1_kernel(
                         acc += iv * (wv * scales[k / 128]);
                     }
                     result += sycl::ext::intel::esimd::detail::sum<
-                        float, float, 64>(acc) * (float)routing_weights[route];
+                        float, float, 64>(acc)
+                        * (float)routing_weights[route_offset];
                 }
 
                 simd<float, 64> gate_acc(0.f);
                 for (int k = 0; k < hidden_size; k += 64) {
-                    simd<float, 64> xv = block_load<fp16, 64>(x + k);
+                    simd<float, 64> xv = block_load<fp16, 64>(token_x + k);
                     simd<float, 64> gw = block_load<fp16, 64>(
                         shared_expert_gate_weight + k);
                     gate_acc += xv * gw;
@@ -1605,7 +1618,9 @@ void moe_down_finalize_fp8_block_bsz1_kernel(
                 gate = 1.f / (1.f + sycl::exp(-gate));
 
                 const fp16* shared_input =
-                    intermediates + (size_t)top_k * intermediate_size;
+                    intermediates
+                    + ((size_t)token * (top_k + 1) + top_k)
+                    * intermediate_size;
                 const uint8_t* shared_weight =
                     shared_down_weight + (size_t)out * intermediate_size;
                 const float* shared_scales = shared_down_scale
@@ -1620,10 +1635,10 @@ void moe_down_finalize_fp8_block_bsz1_kernel(
                 }
                 result += gate * sycl::ext::intel::esimd::detail::sum<
                     float, float, 64>(shared_acc);
-                final_output[out] = fp16(result);
+                final_output[(size_t)token * hidden_size + out] = fp16(result);
             });
     };
-    submit_kernel(cgf, device, "moe down finalize fp8 block bsz1");
+    submit_kernel(cgf, device, "moe down finalize fp8 block batched");
 }
 
 static thread_local torch::Tensor s_block_topk_idx, s_block_topk_weight;
@@ -1632,28 +1647,32 @@ static thread_local std::array<torch::Tensor, 2> s_block_final_outputs;
 static thread_local int s_block_cached_topk = -1;
 static thread_local int s_block_cached_hidden = -1;
 static thread_local int s_block_cached_intermediate = -1;
+static thread_local int s_block_cached_tokens = -1;
 static thread_local int s_block_output_index = 0;
 
-static void ensure_moe_block_buffers(int top_k, int hidden_size,
+static void ensure_moe_block_buffers(int num_tokens, int top_k, int hidden_size,
                                      int intermediate_size,
                                      const torch::Device& dev) {
-    if (s_block_cached_topk != top_k ||
+    if (s_block_cached_tokens != num_tokens ||
+        s_block_cached_topk != top_k ||
         s_block_cached_hidden != hidden_size ||
         s_block_cached_intermediate != intermediate_size) {
         s_block_topk_idx = torch::empty(
-            {1, top_k}, torch::device(dev).dtype(torch::kInt32));
+            {num_tokens, top_k}, torch::device(dev).dtype(torch::kInt32));
         s_block_topk_weight = torch::empty(
-            {1, top_k}, torch::device(dev).dtype(torch::kHalf));
+            {num_tokens, top_k}, torch::device(dev).dtype(torch::kHalf));
         s_block_intermediates = torch::empty(
-            {top_k + 1, intermediate_size},
+            {num_tokens, top_k + 1, intermediate_size},
             torch::device(dev).dtype(torch::kHalf));
         for (auto& output : s_block_final_outputs) {
             output = torch::empty(
-                {1, hidden_size}, torch::device(dev).dtype(torch::kHalf));
+                {num_tokens, hidden_size},
+                torch::device(dev).dtype(torch::kHalf));
         }
         s_block_cached_topk = top_k;
         s_block_cached_hidden = hidden_size;
         s_block_cached_intermediate = intermediate_size;
+        s_block_cached_tokens = num_tokens;
         s_block_output_index = 0;
     }
 }
@@ -1667,10 +1686,11 @@ torch::Tensor moe_forward_full_fp8_block(
     torch::Tensor shared_expert_gate_weight,
     int64_t top_k, int64_t num_shared_experts,
     int64_t n_routed_experts) {
-    TORCH_CHECK(x.dim() == 2 && x.size(0) == 1,
-                "moe_forward_full_fp8_block currently supports batch size 1");
+    TORCH_CHECK(x.dim() == 2 && x.size(0) >= 1 && x.size(0) <= 4,
+                "moe_forward_full_fp8_block supports 1 to 4 tokens");
     TORCH_CHECK(x.is_contiguous() && x.scalar_type() == torch::kHalf);
-    TORCH_CHECK(logits.dim() == 2 && logits.size(0) == 1 &&
+    const int num_tokens = x.size(0);
+    TORCH_CHECK(logits.dim() == 2 && logits.size(0) == num_tokens &&
                 logits.size(1) == n_routed_experts);
     TORCH_CHECK(logits.scalar_type() == torch::kHalf);
     TORCH_CHECK(num_shared_experts == 1,
@@ -1700,26 +1720,28 @@ torch::Tensor moe_forward_full_fp8_block(
                 torch::IntArrayRef({hidden_size, intermediate_size}));
     TORCH_CHECK(hidden_size % 128 == 0 && intermediate_size % 128 == 0);
 
-    ensure_moe_block_buffers(top_k, hidden_size, intermediate_size, x.device());
+    ensure_moe_block_buffers(
+        num_tokens, top_k, hidden_size, intermediate_size, x.device());
     // Alternate outputs so the next decoder layer can safely pass the
     // preceding layer's returned buffer back as x.
     torch::Tensor final_output = s_block_final_outputs[s_block_output_index];
     s_block_output_index ^= 1;
-    dispatch_moe_topk_forward<class MoeTopKFP8BlockBSZ1>(
+    dispatch_moe_topk_forward<class MoeTopKFP8BlockBatched>(
         (const fp16*)logits.data_ptr(), s_block_topk_idx.data_ptr<int>(),
-        (fp16*)s_block_topk_weight.data_ptr(), 1, (int)n_routed_experts,
+        (fp16*)s_block_topk_weight.data_ptr(), num_tokens,
+        (int)n_routed_experts,
         (int)top_k, /*norm=*/true, logits.device());
 
-    moe_up_fp8_block_bsz1_kernel(
+    moe_up_fp8_block_batched_kernel(
         (const fp16*)x.data_ptr(),
         (const uint8_t*)gate_up_weight.data_ptr(), gate_up_scale.data_ptr<float>(),
         (const uint8_t*)shared_gate_up_weight.data_ptr(),
         shared_gate_up_scale.data_ptr<float>(),
         s_block_topk_idx.data_ptr<int>(),
-        (fp16*)s_block_intermediates.data_ptr(), hidden_size,
+        (fp16*)s_block_intermediates.data_ptr(), num_tokens, hidden_size,
         intermediate_size, top_k, x.device());
 
-    moe_down_finalize_fp8_block_bsz1_kernel(
+    moe_down_finalize_fp8_block_batched_kernel(
         (const fp16*)x.data_ptr(),
         (const fp16*)s_block_intermediates.data_ptr(),
         (const uint8_t*)down_weight.data_ptr(), down_scale.data_ptr<float>(),
@@ -1728,7 +1750,7 @@ torch::Tensor moe_forward_full_fp8_block(
         (const fp16*)shared_expert_gate_weight.data_ptr(),
         (const fp16*)s_block_topk_weight.data_ptr(),
         s_block_topk_idx.data_ptr<int>(),
-        (fp16*)final_output.data_ptr(), hidden_size,
+        (fp16*)final_output.data_ptr(), num_tokens, hidden_size,
         intermediate_size, top_k, x.device());
     return final_output;
 }

--- a/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe.sycl
@@ -1641,40 +1641,48 @@ void moe_down_finalize_fp8_block_batched_kernel(
     submit_kernel(cgf, device, "moe down finalize fp8 block batched");
 }
 
-static thread_local torch::Tensor s_block_topk_idx, s_block_topk_weight;
-static thread_local torch::Tensor s_block_intermediates;
-static thread_local std::array<torch::Tensor, 2> s_block_final_outputs;
-static thread_local int s_block_cached_topk = -1;
-static thread_local int s_block_cached_hidden = -1;
-static thread_local int s_block_cached_intermediate = -1;
-static thread_local int s_block_cached_tokens = -1;
-static thread_local int s_block_output_index = 0;
+struct MoeBlockBuffers {
+    torch::Tensor topk_idx, topk_weight, intermediates;
+    std::array<torch::Tensor, 2> final_outputs;
+    int cached_topk = -1;
+    int cached_hidden = -1;
+    int cached_intermediate = -1;
+    int cached_device = -1;
+    int output_index = 0;
+};
 
-static void ensure_moe_block_buffers(int num_tokens, int top_k, int hidden_size,
-                                     int intermediate_size,
-                                     const torch::Device& dev) {
-    if (s_block_cached_tokens != num_tokens ||
-        s_block_cached_topk != top_k ||
-        s_block_cached_hidden != hidden_size ||
-        s_block_cached_intermediate != intermediate_size) {
-        s_block_topk_idx = torch::empty(
+// Capture and serving commonly alternate among 1..4 decode tokens. Keep one
+// persistent slot per token count so switching shapes does not reallocate all
+// intermediate tensors. The memory cost is tiny for these decode-only buffers.
+static thread_local std::array<MoeBlockBuffers, 4> s_block_buffers;
+
+static MoeBlockBuffers& ensure_moe_block_buffers(
+        int num_tokens, int top_k, int hidden_size, int intermediate_size,
+        const torch::Device& dev) {
+    auto& buffers = s_block_buffers[num_tokens - 1];
+    if (buffers.cached_topk != top_k ||
+        buffers.cached_hidden != hidden_size ||
+        buffers.cached_intermediate != intermediate_size ||
+        buffers.cached_device != dev.index()) {
+        buffers.topk_idx = torch::empty(
             {num_tokens, top_k}, torch::device(dev).dtype(torch::kInt32));
-        s_block_topk_weight = torch::empty(
+        buffers.topk_weight = torch::empty(
             {num_tokens, top_k}, torch::device(dev).dtype(torch::kHalf));
-        s_block_intermediates = torch::empty(
+        buffers.intermediates = torch::empty(
             {num_tokens, top_k + 1, intermediate_size},
             torch::device(dev).dtype(torch::kHalf));
-        for (auto& output : s_block_final_outputs) {
+        for (auto& output : buffers.final_outputs) {
             output = torch::empty(
                 {num_tokens, hidden_size},
                 torch::device(dev).dtype(torch::kHalf));
         }
-        s_block_cached_topk = top_k;
-        s_block_cached_hidden = hidden_size;
-        s_block_cached_intermediate = intermediate_size;
-        s_block_cached_tokens = num_tokens;
-        s_block_output_index = 0;
+        buffers.cached_topk = top_k;
+        buffers.cached_hidden = hidden_size;
+        buffers.cached_intermediate = intermediate_size;
+        buffers.cached_device = dev.index();
+        buffers.output_index = 0;
     }
+    return buffers;
 }
 
 torch::Tensor moe_forward_full_fp8_block(
@@ -1720,15 +1728,16 @@ torch::Tensor moe_forward_full_fp8_block(
                 torch::IntArrayRef({hidden_size, intermediate_size}));
     TORCH_CHECK(hidden_size % 128 == 0 && intermediate_size % 128 == 0);
 
-    ensure_moe_block_buffers(
+    auto& buffers = ensure_moe_block_buffers(
         num_tokens, top_k, hidden_size, intermediate_size, x.device());
     // Alternate outputs so the next decoder layer can safely pass the
     // preceding layer's returned buffer back as x.
-    torch::Tensor final_output = s_block_final_outputs[s_block_output_index];
-    s_block_output_index ^= 1;
+    torch::Tensor final_output =
+        buffers.final_outputs[buffers.output_index];
+    buffers.output_index ^= 1;
     dispatch_moe_topk_forward<class MoeTopKFP8BlockBatched>(
-        (const fp16*)logits.data_ptr(), s_block_topk_idx.data_ptr<int>(),
-        (fp16*)s_block_topk_weight.data_ptr(), num_tokens,
+        (const fp16*)logits.data_ptr(), buffers.topk_idx.data_ptr<int>(),
+        (fp16*)buffers.topk_weight.data_ptr(), num_tokens,
         (int)n_routed_experts,
         (int)top_k, /*norm=*/true, logits.device());
 
@@ -1737,19 +1746,19 @@ torch::Tensor moe_forward_full_fp8_block(
         (const uint8_t*)gate_up_weight.data_ptr(), gate_up_scale.data_ptr<float>(),
         (const uint8_t*)shared_gate_up_weight.data_ptr(),
         shared_gate_up_scale.data_ptr<float>(),
-        s_block_topk_idx.data_ptr<int>(),
-        (fp16*)s_block_intermediates.data_ptr(), num_tokens, hidden_size,
+        buffers.topk_idx.data_ptr<int>(),
+        (fp16*)buffers.intermediates.data_ptr(), num_tokens, hidden_size,
         intermediate_size, top_k, x.device());
 
     moe_down_finalize_fp8_block_batched_kernel(
         (const fp16*)x.data_ptr(),
-        (const fp16*)s_block_intermediates.data_ptr(),
+        (const fp16*)buffers.intermediates.data_ptr(),
         (const uint8_t*)down_weight.data_ptr(), down_scale.data_ptr<float>(),
         (const uint8_t*)shared_down_weight.data_ptr(),
         shared_down_scale.data_ptr<float>(),
         (const fp16*)shared_expert_gate_weight.data_ptr(),
-        (const fp16*)s_block_topk_weight.data_ptr(),
-        s_block_topk_idx.data_ptr<int>(),
+        (const fp16*)buffers.topk_weight.data_ptr(),
+        buffers.topk_idx.data_ptr<int>(),
         (fp16*)final_output.data_ptr(), num_tokens, hidden_size,
         intermediate_size, top_k, x.device());
     return final_output;

--- a/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe.sycl
@@ -2,6 +2,7 @@
 #include <torch/extension.h>
 #include <cstdlib>
 #include <algorithm>
+#include <utility>
 #include <c10/xpu/XPUStream.h>
 #include <sycl/ext/intel/esimd.hpp>
 #include <sycl/ext/intel/experimental/esimd/memory.hpp>
@@ -1643,12 +1644,10 @@ void moe_down_finalize_fp8_block_batched_kernel(
 
 struct MoeBlockBuffers {
     torch::Tensor topk_idx, topk_weight, intermediates;
-    std::array<torch::Tensor, 2> final_outputs;
     int cached_topk = -1;
     int cached_hidden = -1;
     int cached_intermediate = -1;
     int cached_device = -1;
-    int output_index = 0;
 };
 
 // Capture and serving commonly alternate among 1..4 decode tokens. Keep one
@@ -1671,22 +1670,16 @@ static MoeBlockBuffers& ensure_moe_block_buffers(
         buffers.intermediates = torch::empty(
             {num_tokens, top_k + 1, intermediate_size},
             torch::device(dev).dtype(torch::kHalf));
-        for (auto& output : buffers.final_outputs) {
-            output = torch::empty(
-                {num_tokens, hidden_size},
-                torch::device(dev).dtype(torch::kHalf));
-        }
         buffers.cached_topk = top_k;
         buffers.cached_hidden = hidden_size;
         buffers.cached_intermediate = intermediate_size;
         buffers.cached_device = dev.index();
-        buffers.output_index = 0;
     }
     return buffers;
 }
 
 torch::Tensor moe_forward_full_fp8_block(
-    torch::Tensor x, torch::Tensor logits,
+    torch::Tensor x, torch::Tensor logits, torch::Tensor output,
     torch::Tensor gate_up_weight, torch::Tensor gate_up_scale,
     torch::Tensor shared_gate_up_weight, torch::Tensor shared_gate_up_scale,
     torch::Tensor down_weight, torch::Tensor down_scale,
@@ -1700,9 +1693,17 @@ torch::Tensor moe_forward_full_fp8_block(
     const int num_tokens = x.size(0);
     TORCH_CHECK(logits.dim() == 2 && logits.size(0) == num_tokens &&
                 logits.size(1) == n_routed_experts);
+    TORCH_CHECK(output.sizes() == x.sizes() &&
+                output.scalar_type() == torch::kHalf);
+    TORCH_CHECK(output.data_ptr() != x.data_ptr(),
+                "moe_forward_full_fp8_block output must not alias x");
     TORCH_CHECK(logits.scalar_type() == torch::kHalf);
     TORCH_CHECK(num_shared_experts == 1,
                 "moe_forward_full_fp8_block requires one shared expert");
+    TORCH_CHECK(n_routed_experts > 0 && top_k > 0 &&
+                top_k <= n_routed_experts,
+                "moe_forward_full_fp8_block requires 0 < top_k <= "
+                "n_routed_experts");
     TORCH_CHECK(gate_up_weight.scalar_type() == at::kFloat8_e4m3fn &&
                 down_weight.scalar_type() == at::kFloat8_e4m3fn &&
                 shared_gate_up_weight.scalar_type() == at::kFloat8_e4m3fn &&
@@ -1719,6 +1720,7 @@ torch::Tensor moe_forward_full_fp8_block(
                 gate_up_weight.size(2) == hidden_size);
     const int intermediate_size = gate_up_weight.size(1) / 2;
     TORCH_CHECK(gate_up_weight.size(1) == 2 * intermediate_size);
+    TORCH_CHECK(hidden_size % 128 == 0 && intermediate_size % 128 == 0);
     TORCH_CHECK(down_weight.sizes() ==
                 torch::IntArrayRef({n_routed_experts, hidden_size,
                                     intermediate_size}));
@@ -1726,15 +1728,48 @@ torch::Tensor moe_forward_full_fp8_block(
                 torch::IntArrayRef({2 * intermediate_size, hidden_size}));
     TORCH_CHECK(shared_down_weight.sizes() ==
                 torch::IntArrayRef({hidden_size, intermediate_size}));
-    TORCH_CHECK(hidden_size % 128 == 0 && intermediate_size % 128 == 0);
+    TORCH_CHECK(
+        gate_up_scale.sizes() ==
+        torch::IntArrayRef({n_routed_experts, 2 * intermediate_size / 128,
+                            hidden_size / 128}));
+    TORCH_CHECK(
+        down_scale.sizes() ==
+        torch::IntArrayRef({n_routed_experts, hidden_size / 128,
+                            intermediate_size / 128}));
+    TORCH_CHECK(
+        shared_gate_up_scale.sizes() ==
+        torch::IntArrayRef({2 * intermediate_size / 128,
+                            hidden_size / 128}));
+    TORCH_CHECK(
+        shared_down_scale.sizes() ==
+        torch::IntArrayRef({hidden_size / 128, intermediate_size / 128}));
+    TORCH_CHECK(
+        shared_expert_gate_weight.sizes() ==
+        torch::IntArrayRef({1, hidden_size}) &&
+        shared_expert_gate_weight.scalar_type() == torch::kHalf);
+
+    const auto device = x.device();
+    const std::pair<const char*, const torch::Tensor*> tensors[] = {
+        {"logits", &logits},
+        {"output", &output},
+        {"gate_up_weight", &gate_up_weight},
+        {"gate_up_scale", &gate_up_scale},
+        {"shared_gate_up_weight", &shared_gate_up_weight},
+        {"shared_gate_up_scale", &shared_gate_up_scale},
+        {"down_weight", &down_weight},
+        {"down_scale", &down_scale},
+        {"shared_down_weight", &shared_down_weight},
+        {"shared_down_scale", &shared_down_scale},
+        {"shared_expert_gate_weight", &shared_expert_gate_weight},
+    };
+    for (const auto& [name, tensor] : tensors) {
+        TORCH_CHECK(tensor->device() == device, name,
+                    " must be on the same device as x");
+        TORCH_CHECK(tensor->is_contiguous(), name, " must be contiguous");
+    }
 
     auto& buffers = ensure_moe_block_buffers(
         num_tokens, top_k, hidden_size, intermediate_size, x.device());
-    // Alternate outputs so the next decoder layer can safely pass the
-    // preceding layer's returned buffer back as x.
-    torch::Tensor final_output =
-        buffers.final_outputs[buffers.output_index];
-    buffers.output_index ^= 1;
     dispatch_moe_topk_forward<class MoeTopKFP8BlockBatched>(
         (const fp16*)logits.data_ptr(), buffers.topk_idx.data_ptr<int>(),
         (fp16*)buffers.topk_weight.data_ptr(), num_tokens,
@@ -1759,9 +1794,9 @@ torch::Tensor moe_forward_full_fp8_block(
         (const fp16*)shared_expert_gate_weight.data_ptr(),
         (const fp16*)buffers.topk_weight.data_ptr(),
         buffers.topk_idx.data_ptr<int>(),
-        (fp16*)final_output.data_ptr(), num_tokens, hidden_size,
+        (fp16*)output.data_ptr(), num_tokens, hidden_size,
         intermediate_size, top_k, x.device());
-    return final_output;
+    return output;
 }
 
 torch::Tensor moe_forward_full(
@@ -2337,7 +2372,7 @@ TORCH_LIBRARY_FRAGMENT(moe_ops, m) {
     m.def("moe_up_fp8_grouped(Tensor x, Tensor gate_up_weight, Tensor gate_up_scale, Tensor expert_offsets, Tensor expert_tokens, int top_k, int n_routed_experts) -> Tensor");
     m.def("moe_down_fp8_grouped(Tensor intermediate, Tensor down_weight, Tensor down_scale, Tensor routing_weights, Tensor expert_offsets, Tensor expert_tokens, int top_k, int n_routed_experts) -> Tensor");
     m.def("moe_forward_full(Tensor x, Tensor logits, Tensor gate_up_weight, Tensor gate_up_scale, Tensor shared_gate_up_weight, Tensor shared_gate_up_scale, Tensor down_weight, Tensor down_scale, Tensor shared_down_weight, Tensor shared_down_scale, Tensor shared_expert_gate_weight, int top_k, int num_shared_experts, int n_routed_experts) -> Tensor");
-    m.def("moe_forward_full_fp8_block(Tensor x, Tensor logits, Tensor gate_up_weight, Tensor gate_up_scale, Tensor shared_gate_up_weight, Tensor shared_gate_up_scale, Tensor down_weight, Tensor down_scale, Tensor shared_down_weight, Tensor shared_down_scale, Tensor shared_expert_gate_weight, int top_k, int num_shared_experts, int n_routed_experts) -> Tensor");
+    m.def("moe_forward_full_fp8_block(Tensor x, Tensor logits, Tensor(a!) output, Tensor gate_up_weight, Tensor gate_up_scale, Tensor shared_gate_up_weight, Tensor shared_gate_up_scale, Tensor down_weight, Tensor down_scale, Tensor shared_down_weight, Tensor shared_down_scale, Tensor shared_expert_gate_weight, int top_k, int num_shared_experts, int n_routed_experts) -> Tensor(a!)");
     m.def("moe_forward_full_v2(Tensor x, Tensor logits, Tensor gate_up_weight, Tensor gate_up_scale, Tensor shared_gate_up_weight, Tensor shared_gate_up_scale, Tensor down_weight, Tensor down_scale, Tensor shared_down_weight, Tensor shared_down_scale, Tensor shared_expert_gate_weight, int top_k, int num_shared_experts, int n_routed_experts) -> Tensor");
 }
 

--- a/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/__init__.py
+++ b/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/__init__.py
@@ -69,6 +69,7 @@ from custom_esimd_kernels_vllm.ops import (
     moe_accumulate,
     moe_forward_fused,
     moe_forward_full,
+    moe_forward_full_fp8_block,
     # MoE INT4 Batch ops
     moe_router_forward_int4,
     moe_router_topk_int4,

--- a/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/ops.py
+++ b/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/ops.py
@@ -1019,9 +1019,13 @@ def moe_forward_full_fp8_block(
 ) -> torch.Tensor:
     """Small-batch MoE decode for 128x128 offline FP8 block weights.
 
-    Activations stay fp16. Routed scales have layout ``[E, N/128, K/128]``;
-    shared-expert scales omit the leading expert dimension. Supports 1 to 4
-    tokens.
+    Supports 1 to 4 tokens and exactly one shared expert. Activations and the
+    caller-owned output are contiguous fp16 tensors. Weights are contiguous
+    ``float8_e4m3fn`` tensors with contiguous fp32 128x128 block scales;
+    hidden and intermediate dimensions must both be divisible by 128. All
+    tensors must be on the same XPU device. Routed scales have layout
+    ``[E, N/128, K/128]``; shared-expert scales omit the leading expert
+    dimension.
     """
     output = torch.empty_like(x)
     return _moe_batch.moe_forward_full_fp8_block(

--- a/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/ops.py
+++ b/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/ops.py
@@ -1017,13 +1017,15 @@ def moe_forward_full_fp8_block(
     num_shared_experts: int,
     n_routed_experts: int,
 ) -> torch.Tensor:
-    """Batch-1 full MoE decode for 128x128 offline FP8 block weights.
+    """Small-batch MoE decode for 128x128 offline FP8 block weights.
 
     Activations stay fp16. Routed scales have layout ``[E, N/128, K/128]``;
-    shared-expert scales omit the leading expert dimension.
+    shared-expert scales omit the leading expert dimension. Supports 1 to 4
+    tokens.
     """
+    output = torch.empty_like(x)
     return _moe_batch.moe_forward_full_fp8_block(
-        x, logits, gate_up_weight, gate_up_scale,
+        x, logits, output, gate_up_weight, gate_up_scale,
         shared_gate_up_weight, shared_gate_up_scale,
         down_weight, down_scale,
         shared_down_weight, shared_down_scale,

--- a/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/ops.py
+++ b/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/ops.py
@@ -1001,6 +1001,36 @@ def moe_forward_full(
         top_k, num_shared_experts, n_routed_experts)
 
 
+def moe_forward_full_fp8_block(
+    x: torch.Tensor,
+    logits: torch.Tensor,
+    gate_up_weight: torch.Tensor,
+    gate_up_scale: torch.Tensor,
+    shared_gate_up_weight: torch.Tensor,
+    shared_gate_up_scale: torch.Tensor,
+    down_weight: torch.Tensor,
+    down_scale: torch.Tensor,
+    shared_down_weight: torch.Tensor,
+    shared_down_scale: torch.Tensor,
+    shared_expert_gate_weight: torch.Tensor,
+    top_k: int,
+    num_shared_experts: int,
+    n_routed_experts: int,
+) -> torch.Tensor:
+    """Batch-1 full MoE decode for 128x128 offline FP8 block weights.
+
+    Activations stay fp16. Routed scales have layout ``[E, N/128, K/128]``;
+    shared-expert scales omit the leading expert dimension.
+    """
+    return _moe_batch.moe_forward_full_fp8_block(
+        x, logits, gate_up_weight, gate_up_scale,
+        shared_gate_up_weight, shared_gate_up_scale,
+        down_weight, down_scale,
+        shared_down_weight, shared_down_scale,
+        shared_expert_gate_weight,
+        top_k, num_shared_experts, n_routed_experts)
+
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # MoE INT4 Batch ops
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/vllm/custom-esimd-kernels-vllm/tests/test_moe_forward_full_fp8_block.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/test_moe_forward_full_fp8_block.py
@@ -1,8 +1,9 @@
-"""Correctness test for the batch-1 FP8-block fused MoE decode op."""
+"""Correctness tests for the small-batch FP8-block fused MoE decode op."""
 
+import pytest
 import torch
 
-import custom_esimd_kernels_vllm as esimd
+import custom_esimd_kernels_vllm  # noqa: F401
 
 
 FP8_MAX = 448.0
@@ -79,36 +80,77 @@ def reference(
     return out
 
 
-def main():
+@pytest.mark.parametrize("batch_size", [1, 4, 2, 3])
+@pytest.mark.parametrize("seed", range(3))
+def test_moe_forward_full_fp8_block(batch_size: int, seed: int):
     device = "xpu"
     experts, hidden, intermediate, top_k = 16, 256, 128, 4
-    # Alternate all supported token counts so the per-shape persistent buffer
-    # cache is exercised instead of only testing long same-shape runs.
-    cases = [
-        (batch_size, seed)
-        for seed in range(3)
-        for batch_size in (1, 4, 2, 3)
-    ]
-    for batch_size, seed in cases:
-        torch.manual_seed(seed)
-        x = (torch.randn(batch_size, hidden, device=device) * 0.2).half()
-        logits = (torch.randn(batch_size, experts, device=device) * 0.4).half()
-        w13, s13 = quantize_block(
-            torch.randn(experts, 2 * intermediate, hidden, device=device) * 0.15
-        )
-        w2, s2 = quantize_block(
-            torch.randn(experts, hidden, intermediate, device=device) * 0.15
-        )
-        shared_w13, shared_s13 = quantize_block(
-            torch.randn(2 * intermediate, hidden, device=device) * 0.15
-        )
-        shared_w2, shared_s2 = quantize_block(
-            torch.randn(hidden, intermediate, device=device) * 0.15
-        )
-        shared_gate = (torch.randn(1, hidden, device=device) * 0.1).half()
+    torch.manual_seed(seed)
+    x = (torch.randn(batch_size, hidden, device=device) * 0.2).half()
+    logits = (torch.randn(batch_size, experts, device=device) * 0.4).half()
+    w13, s13 = quantize_block(
+        torch.randn(experts, 2 * intermediate, hidden, device=device) * 0.15
+    )
+    w2, s2 = quantize_block(
+        torch.randn(experts, hidden, intermediate, device=device) * 0.15
+    )
+    shared_w13, shared_s13 = quantize_block(
+        torch.randn(2 * intermediate, hidden, device=device) * 0.15
+    )
+    shared_w2, shared_s2 = quantize_block(
+        torch.randn(hidden, intermediate, device=device) * 0.15
+    )
+    shared_gate = (torch.randn(1, hidden, device=device) * 0.1).half()
 
-        expected = reference(
-            x,
+    expected = reference(
+        x,
+        logits,
+        w13,
+        s13,
+        shared_w13,
+        shared_s13,
+        w2,
+        s2,
+        shared_w2,
+        shared_s2,
+        shared_gate,
+        top_k,
+    )
+    output = torch.empty_like(x)
+    actual_half = torch.ops.moe_ops.moe_forward_full_fp8_block(
+        x,
+        logits,
+        output,
+        w13,
+        s13,
+        shared_w13,
+        shared_s13,
+        w2,
+        s2,
+        shared_w2,
+        shared_s2,
+        shared_gate,
+        top_k,
+        1,
+        experts,
+    )
+    assert actual_half.data_ptr() == output.data_ptr()
+    actual = actual_half.float()
+    torch.xpu.synchronize()
+    mean_rel = (actual - expected).abs().mean() / expected.abs().mean()
+    cosine = torch.nn.functional.cosine_similarity(
+        actual.flatten(), expected.flatten(), dim=0
+    )
+    print(
+        f"batch={batch_size} seed={seed} mean_rel={mean_rel.item():.6e} "
+        f"cos={cosine.item():.8f}"
+    )
+    assert mean_rel < 3e-3
+    assert cosine > 0.9999
+
+    if batch_size == 4 and seed == 0:
+        chained_expected = reference(
+            actual_half,
             logits,
             w13,
             s13,
@@ -121,9 +163,11 @@ def main():
             shared_gate,
             top_k,
         )
-        actual_half = esimd.moe_forward_full_fp8_block(
-            x,
+        chained_output = torch.empty_like(x)
+        chained_actual = torch.ops.moe_ops.moe_forward_full_fp8_block(
+            actual_half,
             logits,
+            chained_output,
             w13,
             s13,
             shared_w13,
@@ -136,66 +180,17 @@ def main():
             top_k,
             1,
             experts,
-        )
-        actual = actual_half.float()
+        ).float()
         torch.xpu.synchronize()
-        mean_rel = (actual - expected).abs().mean() / expected.abs().mean()
-        cosine = torch.nn.functional.cosine_similarity(
-            actual.flatten(), expected.flatten(), dim=0
+        chained_mean_rel = (
+            chained_actual - chained_expected
+        ).abs().mean() / chained_expected.abs().mean()
+        chained_cosine = torch.nn.functional.cosine_similarity(
+            chained_actual.flatten(), chained_expected.flatten(), dim=0
         )
         print(
-            f"batch={batch_size} seed={seed} mean_rel={mean_rel.item():.6e} "
-            f"cos={cosine.item():.8f}"
+            f"chained mean_rel={chained_mean_rel.item():.6e} "
+            f"cos={chained_cosine.item():.8f}"
         )
-        assert mean_rel < 3e-3
-        assert cosine > 0.9999
-
-        if batch_size == 4 and seed == 0:
-            chained_expected = reference(
-                actual_half,
-                logits,
-                w13,
-                s13,
-                shared_w13,
-                shared_s13,
-                w2,
-                s2,
-                shared_w2,
-                shared_s2,
-                shared_gate,
-                top_k,
-            )
-            chained_actual = esimd.moe_forward_full_fp8_block(
-                actual_half,
-                logits,
-                w13,
-                s13,
-                shared_w13,
-                shared_s13,
-                w2,
-                s2,
-                shared_w2,
-                shared_s2,
-                shared_gate,
-                top_k,
-                1,
-                experts,
-            ).float()
-            torch.xpu.synchronize()
-            chained_mean_rel = (
-                chained_actual - chained_expected
-            ).abs().mean() / chained_expected.abs().mean()
-            chained_cosine = torch.nn.functional.cosine_similarity(
-                chained_actual.flatten(), chained_expected.flatten(), dim=0
-            )
-            print(
-                f"chained mean_rel={chained_mean_rel.item():.6e} "
-                f"cos={chained_cosine.item():.8f}"
-            )
-            assert chained_mean_rel < 3e-3
-            assert chained_cosine > 0.9999
-    print("ALL_PASS")
-
-
-if __name__ == "__main__":
-    main()
+        assert chained_mean_rel < 3e-3
+        assert chained_cosine > 0.9999

--- a/vllm/custom-esimd-kernels-vllm/tests/test_moe_forward_full_fp8_block.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/test_moe_forward_full_fp8_block.py
@@ -1,0 +1,190 @@
+"""Correctness test for the batch-1 FP8-block fused MoE decode op."""
+
+import torch
+
+import custom_esimd_kernels_vllm as esimd
+
+
+FP8_MAX = 448.0
+BLOCK = 128
+
+
+def quantize_block(weight: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    leading = weight.shape[:-2]
+    n, k = weight.shape[-2:]
+    flat = weight.reshape(-1, n, k)
+    q = torch.empty_like(flat, dtype=torch.float8_e4m3fn)
+    scale = torch.empty(
+        (flat.shape[0], (n + BLOCK - 1) // BLOCK, (k + BLOCK - 1) // BLOCK),
+        dtype=torch.float32,
+        device=weight.device,
+    )
+    for e in range(flat.shape[0]):
+        for nb in range(scale.shape[1]):
+            for kb in range(scale.shape[2]):
+                block = flat[
+                    e,
+                    nb * BLOCK : (nb + 1) * BLOCK,
+                    kb * BLOCK : (kb + 1) * BLOCK,
+                ]
+                s = block.abs().max().clamp_min(1e-12) / FP8_MAX
+                scale[e, nb, kb] = s
+                q[
+                    e,
+                    nb * BLOCK : (nb + 1) * BLOCK,
+                    kb * BLOCK : (kb + 1) * BLOCK,
+                ] = (block / s).to(torch.float8_e4m3fn)
+    return q.reshape(*leading, n, k), scale.reshape(
+        *leading, scale.shape[-2], scale.shape[-1]
+    )
+
+
+def dequant(q: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    n, k = q.shape[-2:]
+    expanded = scale.repeat_interleave(BLOCK, -2).repeat_interleave(BLOCK, -1)
+    return q.float() * expanded[..., :n, :k]
+
+
+def reference(
+    x,
+    logits,
+    w13,
+    s13,
+    shared_w13,
+    shared_s13,
+    w2,
+    s2,
+    shared_w2,
+    shared_s2,
+    shared_gate,
+    top_k,
+):
+    scores = torch.softmax(logits.float(), dim=-1)
+    top_weights, top_ids = torch.topk(scores, top_k, dim=-1)
+    top_weights /= top_weights.sum(dim=-1, keepdim=True)
+    x32 = x.float()
+    out = torch.zeros_like(x32)
+    dw13 = dequant(w13, s13)
+    dw2 = dequant(w2, s2)
+    for route in range(top_k):
+        eid = int(top_ids[0, route])
+        gate, up = (x32 @ dw13[eid].t()).chunk(2, dim=-1)
+        inter = torch.nn.functional.silu(gate) * up
+        out += top_weights[0, route] * (inter @ dw2[eid].t())
+    shared_gate_v = torch.sigmoid(x32 @ shared_gate.float().t())
+    gate, up = (x32 @ dequant(shared_w13, shared_s13).t()).chunk(2, dim=-1)
+    shared_inter = torch.nn.functional.silu(gate) * up
+    out += shared_gate_v * (shared_inter @ dequant(shared_w2, shared_s2).t())
+    return out
+
+
+def main():
+    device = "xpu"
+    experts, hidden, intermediate, top_k = 16, 256, 128, 4
+    for seed in range(5):
+        torch.manual_seed(seed)
+        x = (torch.randn(1, hidden, device=device) * 0.2).half()
+        logits = (torch.randn(1, experts, device=device) * 0.4).half()
+        w13, s13 = quantize_block(
+            torch.randn(experts, 2 * intermediate, hidden, device=device) * 0.15
+        )
+        w2, s2 = quantize_block(
+            torch.randn(experts, hidden, intermediate, device=device) * 0.15
+        )
+        shared_w13, shared_s13 = quantize_block(
+            torch.randn(2 * intermediate, hidden, device=device) * 0.15
+        )
+        shared_w2, shared_s2 = quantize_block(
+            torch.randn(hidden, intermediate, device=device) * 0.15
+        )
+        shared_gate = (torch.randn(1, hidden, device=device) * 0.1).half()
+
+        expected = reference(
+            x,
+            logits,
+            w13,
+            s13,
+            shared_w13,
+            shared_s13,
+            w2,
+            s2,
+            shared_w2,
+            shared_s2,
+            shared_gate,
+            top_k,
+        )
+        actual_half = esimd.moe_forward_full_fp8_block(
+            x,
+            logits,
+            w13,
+            s13,
+            shared_w13,
+            shared_s13,
+            w2,
+            s2,
+            shared_w2,
+            shared_s2,
+            shared_gate,
+            top_k,
+            1,
+            experts,
+        )
+        actual = actual_half.float()
+        torch.xpu.synchronize()
+        mean_rel = (actual - expected).abs().mean() / expected.abs().mean()
+        cosine = torch.nn.functional.cosine_similarity(
+            actual.flatten(), expected.flatten(), dim=0
+        )
+        print(f"seed={seed} mean_rel={mean_rel.item():.6e} cos={cosine.item():.8f}")
+        assert mean_rel < 3e-3
+        assert cosine > 0.9999
+
+        if seed == 0:
+            chained_expected = reference(
+                actual_half,
+                logits,
+                w13,
+                s13,
+                shared_w13,
+                shared_s13,
+                w2,
+                s2,
+                shared_w2,
+                shared_s2,
+                shared_gate,
+                top_k,
+            )
+            chained_actual = esimd.moe_forward_full_fp8_block(
+                actual_half,
+                logits,
+                w13,
+                s13,
+                shared_w13,
+                shared_s13,
+                w2,
+                s2,
+                shared_w2,
+                shared_s2,
+                shared_gate,
+                top_k,
+                1,
+                experts,
+            ).float()
+            torch.xpu.synchronize()
+            chained_mean_rel = (
+                chained_actual - chained_expected
+            ).abs().mean() / chained_expected.abs().mean()
+            chained_cosine = torch.nn.functional.cosine_similarity(
+                chained_actual.flatten(), chained_expected.flatten(), dim=0
+            )
+            print(
+                f"chained mean_rel={chained_mean_rel.item():.6e} "
+                f"cos={chained_cosine.item():.8f}"
+            )
+            assert chained_mean_rel < 3e-3
+            assert chained_cosine > 0.9999
+    print("ALL_PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/custom-esimd-kernels-vllm/tests/test_moe_forward_full_fp8_block.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/test_moe_forward_full_fp8_block.py
@@ -82,7 +82,13 @@ def reference(
 def main():
     device = "xpu"
     experts, hidden, intermediate, top_k = 16, 256, 128, 4
-    cases = [(1, seed) for seed in range(3)] + [(4, seed) for seed in range(3)]
+    # Alternate all supported token counts so the per-shape persistent buffer
+    # cache is exercised instead of only testing long same-shape runs.
+    cases = [
+        (batch_size, seed)
+        for seed in range(3)
+        for batch_size in (1, 4, 2, 3)
+    ]
     for batch_size, seed in cases:
         torch.manual_seed(seed)
         x = (torch.randn(batch_size, hidden, device=device) * 0.2).half()

--- a/vllm/custom-esimd-kernels-vllm/tests/test_moe_forward_full_fp8_block.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/test_moe_forward_full_fp8_block.py
@@ -66,11 +66,12 @@ def reference(
     out = torch.zeros_like(x32)
     dw13 = dequant(w13, s13)
     dw2 = dequant(w2, s2)
-    for route in range(top_k):
-        eid = int(top_ids[0, route])
-        gate, up = (x32 @ dw13[eid].t()).chunk(2, dim=-1)
-        inter = torch.nn.functional.silu(gate) * up
-        out += top_weights[0, route] * (inter @ dw2[eid].t())
+    for token in range(x.shape[0]):
+        for route in range(top_k):
+            eid = int(top_ids[token, route])
+            gate, up = (x32[token] @ dw13[eid].t()).chunk(2, dim=-1)
+            inter = torch.nn.functional.silu(gate) * up
+            out[token] += top_weights[token, route] * (inter @ dw2[eid].t())
     shared_gate_v = torch.sigmoid(x32 @ shared_gate.float().t())
     gate, up = (x32 @ dequant(shared_w13, shared_s13).t()).chunk(2, dim=-1)
     shared_inter = torch.nn.functional.silu(gate) * up
@@ -81,10 +82,11 @@ def reference(
 def main():
     device = "xpu"
     experts, hidden, intermediate, top_k = 16, 256, 128, 4
-    for seed in range(5):
+    cases = [(1, seed) for seed in range(3)] + [(4, seed) for seed in range(3)]
+    for batch_size, seed in cases:
         torch.manual_seed(seed)
-        x = (torch.randn(1, hidden, device=device) * 0.2).half()
-        logits = (torch.randn(1, experts, device=device) * 0.4).half()
+        x = (torch.randn(batch_size, hidden, device=device) * 0.2).half()
+        logits = (torch.randn(batch_size, experts, device=device) * 0.4).half()
         w13, s13 = quantize_block(
             torch.randn(experts, 2 * intermediate, hidden, device=device) * 0.15
         )
@@ -135,11 +137,14 @@ def main():
         cosine = torch.nn.functional.cosine_similarity(
             actual.flatten(), expected.flatten(), dim=0
         )
-        print(f"seed={seed} mean_rel={mean_rel.item():.6e} cos={cosine.item():.8f}")
+        print(
+            f"batch={batch_size} seed={seed} mean_rel={mean_rel.item():.6e} "
+            f"cos={cosine.item():.8f}"
+        )
         assert mean_rel < 3e-3
         assert cosine > 0.9999
 
-        if seed == 0:
+        if batch_size == 4 and seed == 0:
             chained_expected = reference(
                 actual_half,
                 logits,


### PR DESCRIPTION
## Summary

- add the fused block-FP8 MoE full-forward decode kernel
- support decode batches from 1 through 4 tokens
- cache per-shape intermediate buffers while using caller-owned output storage
- declare the output as mutation/alias in the dispatcher schema
- validate tensor dtype, device, layout, shape, and routing bounds before launch
- expose the kernel through the Python extension and add pytest numerical coverage

## Scope

This is the kernel-only PR for Stage 1 of the block-FP8 XPU port. It builds on the Stage 0 foundation merged in #555.

The vLLM framework dispatch and capability gating are intentionally excluded. They will be submitted as a separate dependent PR after this kernel PR is reviewed and merged.

The fast path intentionally covers 1 to 4 decode tokens. Larger decode batches continue through the existing modular block-MoE path in the dependent framework integration.

## Source commits

- `84c9d4e` Add fused block MoE decode kernel
- `af1a760` Extend fused block MoE decode to batch 4
- `5cc5e13` Cache per-shape block MoE decode buffers

## Validation

The PR includes pytest-collected fused-vs-reference numerical coverage for batch sizes 1 through 4, verifies the caller-owned output alias contract, and exercises chained invocation. End-to-end validation will be performed with the dependent framework PR because the merged framework does not dispatch this new op yet.