### PR TITLE
[XPU][FP8] Add block-scaled GDN decode fusions

### DIFF
--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_gemm.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_gemm.sycl
@@ -233,6 +233,9 @@ at::Tensor esimd_norm_gemv_fp8_blockscale(
                 "esimd_norm_gemv_fp8_blockscale: output must be fp16");
     TORCH_CHECK(V == 128 && K == HV * V && K % 128 == 0,
                 "esimd_norm_gemv_fp8_blockscale: requires V=128 and K=HV*V");
+    TORCH_CHECK(x.numel() == K && z.numel() == K &&
+                    norm_weight.numel() == V,
+                "esimd_norm_gemv_fp8_blockscale: input shape mismatch");
     TORCH_CHECK(gemv_scale.size(0) == (N + 127) / 128 &&
                     gemv_scale.size(1) == K / 128,
                 "esimd_norm_gemv_fp8_blockscale: scale shape mismatch");

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_gemm.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_gemm.sycl
@@ -15,6 +15,7 @@
 #include "esimd_kernels/fp8_GEMM_pert.h"
 #include "esimd_kernels/int4_GEMM.h"
 #include "esimd_kernels/fp8_GEMM_blockscale.h"
+#include "esimd_kernels/norm_gemv_fused.h"
 
 #define EXTRACT_PTR(var, tensor) auto var = reinterpret_cast<uint8_t*>(tensor.data_ptr())
 
@@ -134,5 +135,117 @@ at::Tensor esimd_gemm_fp8_blockscale(
         reinterpret_cast<fp16*>(p_out),
         (uint32_t)M, (uint32_t)N, (uint32_t)K,
         (uint32_t)block_n, (uint32_t)block_k, dpcpp_queue);
+    return output;
+}
+
+// ---- Fused dual FP8 block-scaled GEMV (decode M=1, shared input) ----
+at::Tensor esimd_gemv_fp8_blockscale_fused2(
+    at::Tensor input,
+    at::Tensor w0, at::Tensor s0, at::Tensor o0,
+    at::Tensor w1, at::Tensor s1, at::Tensor o1,
+    int64_t block_n, int64_t block_k) {
+    const int64_t K = w0.size(1);
+    const int64_t N0 = w0.size(0);
+    const int64_t N1 = w1.size(0);
+    TORCH_CHECK(input.scalar_type() == at::ScalarType::Half && input.size(0) == 1,
+                "esimd_gemv_fp8_blockscale_fused2: input must be fp16 [1,K]");
+    TORCH_CHECK(w0.scalar_type() == at::ScalarType::Float8_e4m3fn &&
+                    w1.scalar_type() == at::ScalarType::Float8_e4m3fn,
+                "esimd_gemv_fp8_blockscale_fused2: weights must be fp8_e4m3");
+    TORCH_CHECK(s0.scalar_type() == at::ScalarType::Float &&
+                    s1.scalar_type() == at::ScalarType::Float,
+                "esimd_gemv_fp8_blockscale_fused2: scales must be float32");
+    TORCH_CHECK(o0.scalar_type() == at::ScalarType::Half &&
+                    o1.scalar_type() == at::ScalarType::Half,
+                "esimd_gemv_fp8_blockscale_fused2: outputs must be fp16");
+    TORCH_CHECK(block_n == 128 && block_k == 128 && K % 128 == 0,
+                "esimd_gemv_fp8_blockscale_fused2: requires 128x128 blocks");
+    TORCH_CHECK(w1.size(1) == K && input.size(1) == K,
+                "esimd_gemv_fp8_blockscale_fused2: K mismatch");
+    const int64_t Kb = K / 128;
+    TORCH_CHECK(s0.size(0) == (N0 + 127) / 128 && s0.size(1) == Kb &&
+                    s1.size(0) == (N1 + 127) / 128 && s1.size(1) == Kb,
+                "esimd_gemv_fp8_blockscale_fused2: scale shape mismatch");
+    TORCH_CHECK(o0.numel() == N0 && o1.numel() == N1,
+                "esimd_gemv_fp8_blockscale_fused2: output shape mismatch");
+
+    EXTRACT_PTR(p_in, input);
+    EXTRACT_PTR(pw0, w0); EXTRACT_PTR(ps0, s0); EXTRACT_PTR(po0, o0);
+    EXTRACT_PTR(pw1, w1); EXTRACT_PTR(ps1, s1); EXTRACT_PTR(po1, o1);
+    auto& q = get_device_queue(input);
+    fp8_blockscale::gemv_fp8_blockscale_fused2_host(
+        reinterpret_cast<const fp16*>(p_in), pw0,
+        reinterpret_cast<const float*>(ps0), reinterpret_cast<fp16*>(po0),
+        (uint32_t)N0, pw1, reinterpret_cast<const float*>(ps1),
+        reinterpret_cast<fp16*>(po1), (uint32_t)N1, (uint32_t)K, q);
+    return o0;
+}
+
+at::Tensor esimd_gemv_fp8_blockscale_fp16_fused2(
+    at::Tensor input, at::Tensor w0, at::Tensor s0, at::Tensor o0,
+    at::Tensor w1, at::Tensor o1, int64_t block_n, int64_t block_k) {
+    const int64_t K = w0.size(1);
+    const int64_t N0 = w0.size(0);
+    const int64_t N1 = w1.size(0);
+    TORCH_CHECK(input.scalar_type() == at::ScalarType::Half && input.size(0) == 1,
+                "esimd_gemv_fp8_blockscale_fp16_fused2: input must be fp16 [1,K]");
+    TORCH_CHECK(w0.scalar_type() == at::ScalarType::Float8_e4m3fn &&
+                    w1.scalar_type() == at::ScalarType::Half,
+                "esimd_gemv_fp8_blockscale_fp16_fused2: weights must be e4m3/fp16");
+    TORCH_CHECK(s0.scalar_type() == at::ScalarType::Float,
+                "esimd_gemv_fp8_blockscale_fp16_fused2: scale must be float32");
+    TORCH_CHECK(o0.scalar_type() == at::ScalarType::Half &&
+                    o1.scalar_type() == at::ScalarType::Half,
+                "esimd_gemv_fp8_blockscale_fp16_fused2: outputs must be fp16");
+    TORCH_CHECK(block_n == 128 && block_k == 128 && K % 128 == 0,
+                "esimd_gemv_fp8_blockscale_fp16_fused2: requires 128x128 blocks");
+    TORCH_CHECK(w1.size(1) == K && input.size(1) == K,
+                "esimd_gemv_fp8_blockscale_fp16_fused2: K mismatch");
+    TORCH_CHECK(s0.size(0) == (N0 + 127) / 128 && s0.size(1) == K / 128,
+                "esimd_gemv_fp8_blockscale_fp16_fused2: scale shape mismatch");
+    TORCH_CHECK(o0.numel() == N0 && o1.numel() == N1,
+                "esimd_gemv_fp8_blockscale_fp16_fused2: output shape mismatch");
+    auto& q = get_device_queue(input);
+    fp8_blockscale::gemv_fp8_blockscale_fp16_fused2_host(
+        reinterpret_cast<const fp16*>(input.data_ptr()),
+        reinterpret_cast<const uint8_t*>(w0.data_ptr()), s0.data_ptr<float>(),
+        reinterpret_cast<fp16*>(o0.data_ptr()), (uint32_t)N0,
+        reinterpret_cast<const fp16*>(w1.data_ptr()),
+        reinterpret_cast<fp16*>(o1.data_ptr()), (uint32_t)N1, (uint32_t)K, q);
+    return o0;
+}
+
+at::Tensor esimd_norm_gemv_fp8_blockscale(
+    at::Tensor x, at::Tensor z, at::Tensor norm_weight,
+    at::Tensor gemv_weight, at::Tensor gemv_scale, at::Tensor output,
+    int64_t HV, int64_t V, double eps) {
+    const int64_t N = gemv_weight.size(0);
+    const int64_t K = gemv_weight.size(1);
+    TORCH_CHECK(x.scalar_type() == at::ScalarType::Half &&
+                    z.scalar_type() == at::ScalarType::Half &&
+                    norm_weight.scalar_type() == at::ScalarType::Half,
+                "esimd_norm_gemv_fp8_blockscale: norm inputs must be fp16");
+    TORCH_CHECK(gemv_weight.scalar_type() == at::ScalarType::Float8_e4m3fn,
+                "esimd_norm_gemv_fp8_blockscale: weight must be fp8_e4m3");
+    TORCH_CHECK(gemv_scale.scalar_type() == at::ScalarType::Float,
+                "esimd_norm_gemv_fp8_blockscale: scale must be float32");
+    TORCH_CHECK(output.scalar_type() == at::ScalarType::Half,
+                "esimd_norm_gemv_fp8_blockscale: output must be fp16");
+    TORCH_CHECK(V == 128 && K == HV * V && K % 128 == 0,
+                "esimd_norm_gemv_fp8_blockscale: requires V=128 and K=HV*V");
+    TORCH_CHECK(gemv_scale.size(0) == (N + 127) / 128 &&
+                    gemv_scale.size(1) == K / 128,
+                "esimd_norm_gemv_fp8_blockscale: scale shape mismatch");
+    TORCH_CHECK(output.numel() == N,
+                "esimd_norm_gemv_fp8_blockscale: output shape mismatch");
+    auto& q = get_device_queue(x);
+    norm_gemv_fp8_blockscale_host(
+        reinterpret_cast<const fp16*>(x.data_ptr()),
+        reinterpret_cast<const fp16*>(z.data_ptr()),
+        reinterpret_cast<const fp16*>(norm_weight.data_ptr()),
+        reinterpret_cast<const uint8_t*>(gemv_weight.data_ptr()),
+        gemv_scale.data_ptr<float>(),
+        reinterpret_cast<fp16*>(output.data_ptr()),
+        (int)N, (int)HV, (int)V, (float)eps, q);
     return output;
 }

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/fp8_GEMM_blockscale.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/fp8_GEMM_blockscale.h
@@ -237,6 +237,218 @@ inline void gemm_fp8_blockscale_host(const fp16* input, const uint8_t* weight,
   }
 }
 
+// Decode-only dual GEMV for two block-scaled weights sharing the same input.
+// A single grid spans both output-channel ranges, eliminating the second host
+// submission while preserving each matrix's independent [Nb, Kb] scale table.
+template <int VL, int K_SPLIT, int BK>
+struct gemv_block_fused2_bmg_kernel {
+  const fp16* input;
+  const uint8_t* weight0;
+  const float* scale0;
+  fp16* output0;
+  const uint8_t* weight1;
+  const float* scale1;
+  fp16* output1;
+  int N0, N1, K, Kb;
+
+  void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+    if constexpr (K_SPLIT > 1) slm_init<K_SPLIT * sizeof(float)>();
+    const int gn = item.get_group(0);
+    const int lid = item.get_local_id(0);
+    if (gn >= N0 + N1) return;
+
+    const bool second = gn >= N0;
+    const int n = second ? gn - N0 : gn;
+    const uint8_t* weight = second ? weight1 : weight0;
+    const float* scale = second ? scale1 : scale0;
+    fp16* output = second ? output1 : output0;
+    const uint8_t* w_row = weight + (size_t)n * K;
+    const float* s_row = scale + (size_t)(n / 128) * Kb;
+    const int kp = K / K_SPLIT;
+    const int ks = lid * kp;
+    float acc = 0.0f;
+
+    for (int k = ks; k < ks + kp; k += VL) {
+      simd<uint8_t, VL> raw = block_load<uint8_t, VL>(w_row + k);
+      simd<float, VL> wf = fp8e4m3_to_fp16<VL>(raw);
+#pragma unroll
+      for (int sb = 0; sb < VL / BK; sb++) {
+        const float sc = s_row[(k / BK) + sb];
+        wf.template select<BK, 1>(sb * BK) *= sc;
+      }
+      simd<float, VL> iv = block_load<fp16, VL>(input + k);
+      acc += reduce<float>(iv * wf, std::plus<>());
+    }
+
+    if constexpr (K_SPLIT == 1) {
+      output[n] = fp16(acc);
+    } else {
+      simd<float, 1> partial = acc;
+      slm_block_store<float, 1>(lid * sizeof(float), partial);
+      barrier();
+      if (lid == 0) {
+        simd<float, K_SPLIT> parts =
+            slm_block_load<float, K_SPLIT>(0);
+        output[n] = fp16(reduce<float>(parts, std::plus<>()));
+      }
+    }
+  }
+};
+
+template <int VL, int K_SPLIT>
+inline void launch_gemv_block_fused2(
+    const fp16* input, const uint8_t* weight0, const float* scale0,
+    fp16* output0, int N0, const uint8_t* weight1, const float* scale1,
+    fp16* output1, int N1, int K, sycl::queue& q) {
+  constexpr int BK = 128;
+  gemv_block_fused2_bmg_kernel<VL, K_SPLIT, BK> kern{
+      input, weight0, scale0, output0, weight1, scale1, output1,
+      N0, N1, K, K / BK};
+  const int groups = N0 + N1;
+  q.submit([&](handler& cgh) {
+    cgh.parallel_for(
+        sycl::nd_range<1>((size_t)groups * K_SPLIT, K_SPLIT), kern);
+  });
+}
+
+inline void gemv_fp8_blockscale_fused2_host(
+    const fp16* input, const uint8_t* weight0, const float* scale0,
+    fp16* output0, uint32_t N0, const uint8_t* weight1, const float* scale1,
+    fp16* output1, uint32_t N1, uint32_t K, sycl::queue& q) {
+  const int VL = (K % 256 == 0) ? 256 : 128;
+  const int total_n = (int)(N0 + N1);
+  int target = 1;
+  if (total_n * 8 <= 640) target = 8;
+  else if (total_n * 4 <= 640) target = 4;
+  else if (total_n * 2 <= 640) target = 2;
+  int ks = 1;
+  for (int s = target; s >= 1; s >>= 1) {
+    if (K % s == 0 && (K / s) % VL == 0) { ks = s; break; }
+  }
+#define BS_FUSED2_DISPATCH(V, S)                                               \
+  launch_gemv_block_fused2<V, S>(input, weight0, scale0, output0, (int)N0,    \
+                                  weight1, scale1, output1, (int)N1, (int)K, q)
+  if (VL == 256) {
+    switch (ks) {
+      case 8: BS_FUSED2_DISPATCH(256, 8); break;
+      case 4: BS_FUSED2_DISPATCH(256, 4); break;
+      case 2: BS_FUSED2_DISPATCH(256, 2); break;
+      default: BS_FUSED2_DISPATCH(256, 1); break;
+    }
+  } else {
+    switch (ks) {
+      case 8: BS_FUSED2_DISPATCH(128, 8); break;
+      case 4: BS_FUSED2_DISPATCH(128, 4); break;
+      case 2: BS_FUSED2_DISPATCH(128, 2); break;
+      default: BS_FUSED2_DISPATCH(128, 1); break;
+    }
+  }
+#undef BS_FUSED2_DISPATCH
+}
+
+// Qwen GDN input projection: block-scaled qkvz plus the intentionally-FP16 ba
+// projection share one input and one launch.
+template <int VL, int K_SPLIT>
+struct gemv_block_fp16_fused2_bmg_kernel {
+  const fp16* input;
+  const uint8_t* weight0;
+  const float* scale0;
+  fp16* output0;
+  const fp16* weight1;
+  fp16* output1;
+  int N0, N1, K, Kb;
+
+  void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+    if constexpr (K_SPLIT > 1) slm_init<K_SPLIT * sizeof(float)>();
+    const int gn = item.get_group(0);
+    const int lid = item.get_local_id(0);
+    if (gn >= N0 + N1) return;
+    const bool fp16_matrix = gn >= N0;
+    const int n = fp16_matrix ? gn - N0 : gn;
+    const int kp = K / K_SPLIT;
+    const int ks = lid * kp;
+    float acc = 0.0f;
+
+    for (int k = ks; k < ks + kp; k += VL) {
+      simd<float, VL> wf;
+      if (fp16_matrix) {
+        wf = block_load<fp16, VL>(weight1 + (size_t)n * K + k);
+      } else {
+        simd<uint8_t, VL> raw =
+            block_load<uint8_t, VL>(weight0 + (size_t)n * K + k);
+        wf = fp8e4m3_to_fp16<VL>(raw);
+        const float* s_row = scale0 + (size_t)(n / 128) * Kb;
+#pragma unroll
+        for (int sb = 0; sb < VL / 128; sb++) {
+          wf.template select<128, 1>(sb * 128) *= s_row[(k / 128) + sb];
+        }
+      }
+      simd<float, VL> iv = block_load<fp16, VL>(input + k);
+      acc += reduce<float>(iv * wf, std::plus<>());
+    }
+    fp16* output = fp16_matrix ? output1 : output0;
+    if constexpr (K_SPLIT == 1) {
+      output[n] = fp16(acc);
+    } else {
+      simd<float, 1> partial = acc;
+      slm_block_store<float, 1>(lid * sizeof(float), partial);
+      barrier();
+      if (lid == 0) {
+        simd<float, K_SPLIT> parts = slm_block_load<float, K_SPLIT>(0);
+        output[n] = fp16(reduce<float>(parts, std::plus<>()));
+      }
+    }
+  }
+};
+
+template <int VL, int K_SPLIT>
+inline void launch_gemv_block_fp16_fused2(
+    const fp16* input, const uint8_t* weight0, const float* scale0,
+    fp16* output0, int N0, const fp16* weight1, fp16* output1, int N1,
+    int K, sycl::queue& q) {
+  gemv_block_fp16_fused2_bmg_kernel<VL, K_SPLIT> kern{
+      input, weight0, scale0, output0, weight1, output1,
+      N0, N1, K, K / 128};
+  q.submit([&](handler& cgh) {
+    cgh.parallel_for(
+        sycl::nd_range<1>((size_t)(N0 + N1) * K_SPLIT, K_SPLIT), kern);
+  });
+}
+
+inline void gemv_fp8_blockscale_fp16_fused2_host(
+    const fp16* input, const uint8_t* weight0, const float* scale0,
+    fp16* output0, uint32_t N0, const fp16* weight1, fp16* output1,
+    uint32_t N1, uint32_t K, sycl::queue& q) {
+  const int VL = (K % 256 == 0) ? 256 : 128;
+  const int total_n = (int)(N0 + N1);
+  int target = total_n * 8 <= 640 ? 8 : total_n * 4 <= 640 ? 4
+                                  : total_n * 2 <= 640 ? 2 : 1;
+  int ks = 1;
+  for (int s = target; s >= 1; s >>= 1) {
+    if (K % s == 0 && (K / s) % VL == 0) { ks = s; break; }
+  }
+#define BS_FP16_FUSED2_DISPATCH(V, S)                                          \
+  launch_gemv_block_fp16_fused2<V, S>(                                        \
+      input, weight0, scale0, output0, (int)N0, weight1, output1, (int)N1,    \
+      (int)K, q)
+  if (VL == 256) {
+    switch (ks) {
+      case 8: BS_FP16_FUSED2_DISPATCH(256, 8); break;
+      case 4: BS_FP16_FUSED2_DISPATCH(256, 4); break;
+      case 2: BS_FP16_FUSED2_DISPATCH(256, 2); break;
+      default: BS_FP16_FUSED2_DISPATCH(256, 1); break;
+    }
+  } else {
+    switch (ks) {
+      case 8: BS_FP16_FUSED2_DISPATCH(128, 8); break;
+      case 4: BS_FP16_FUSED2_DISPATCH(128, 4); break;
+      case 2: BS_FP16_FUSED2_DISPATCH(128, 2); break;
+      default: BS_FP16_FUSED2_DISPATCH(128, 1); break;
+    }
+  }
+#undef BS_FP16_FUSED2_DISPATCH
+}
+
 #undef BS_WE
 #undef BS_WM
 

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/norm_gemv_fused.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/norm_gemv_fused.h
@@ -148,3 +148,59 @@ inline void norm_gemv_fp8_pert_host(
                 N, HV, V, eps, fp8_mode});
     });
 }
+
+/* Fused RMSNormGated + E4M3 block-scaled GEMV (128x128 scales). */
+struct NormGEMV_fp8_blockscale_kernel {
+    const fp16* x_ptr;
+    const fp16* z_ptr;
+    const fp16* norm_w_ptr;
+    const uint8_t* gemv_weight;
+    const float* gemv_scale;  // [ceil(N/128), K/128]
+    fp16* output;
+    int N;
+    int HV;
+    int V;
+    int Kb;
+    float eps;
+
+    void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+        const int n = item.get_group(0);
+        if (n >= N) return;
+        const int K = HV * V;
+        const float* scale_row = gemv_scale + (size_t)(n / 128) * Kb;
+        simd<float, 128> norm_w = block_load<fp16, 128>(norm_w_ptr);
+        simd<float, 128> acc = 0.0f;
+
+        for (int h = 0; h < HV; h++) {
+            const int offset = h * V;
+            simd<float, 128> x_f = block_load<fp16, 128>(x_ptr + offset);
+            simd<float, 128> z_f = block_load<fp16, 128>(z_ptr + offset);
+            const float mean_sq = reduce128(x_f * x_f) * (1.0f / V);
+            const float inv_rms = sycl::ext::intel::esimd::rsqrt(
+                simd<float, 8>(mean_sq + eps))[0];
+            simd<float, 128> normed = x_f * inv_rms * norm_w;
+            normed *= z_f / (1.0f + sycl::ext::intel::esimd::exp(-z_f));
+
+            simd<uint8_t, 128> w_raw = block_load<uint8_t, 128>(
+                gemv_weight + (size_t)n * K + offset);
+            simd<float, 128> w_f = fp8_dequant_norm<128>(w_raw, 0);
+            w_f *= scale_row[offset / 128];
+            acc += normed * w_f;
+        }
+        output[n] = fp16(reduce128(acc));
+    }
+};
+
+inline void norm_gemv_fp8_blockscale_host(
+    const fp16* x_ptr, const fp16* z_ptr, const fp16* norm_w_ptr,
+    const uint8_t* gemv_weight, const float* gemv_scale, fp16* output,
+    int N, int HV, int V, float eps, sycl::queue& q) {
+    const int Kb = HV * V / 128;
+    q.submit([&](sycl::handler& cgh) {
+        cgh.parallel_for(
+            sycl::nd_range<1>(N, 1),
+            NormGEMV_fp8_blockscale_kernel{
+                x_ptr, z_ptr, norm_w_ptr, gemv_weight, gemv_scale, output,
+                N, HV, V, Kb, eps});
+    });
+}

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/torch_extension_gemm.cc
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/torch_extension_gemm.cc
@@ -29,20 +29,20 @@ TORCH_LIBRARY_FRAGMENT(custom_esimd_kernels_vllm, m) {
   m.impl("esimd_gemm_fp8_blockscale", torch::kXPU, &esimd_gemm_fp8_blockscale);
 
   m.def("esimd_gemv_fp8_blockscale_fused2(Tensor input, "
-        "Tensor w0, Tensor s0, Tensor o0, Tensor w1, Tensor s1, Tensor o1, "
-        "int block_n, int block_k) -> Tensor");
+        "Tensor w0, Tensor s0, Tensor(a!) o0, Tensor w1, Tensor s1, "
+        "Tensor(b!) o1, int block_n, int block_k) -> Tensor(a!)");
   m.impl("esimd_gemv_fp8_blockscale_fused2", torch::kXPU,
          &esimd_gemv_fp8_blockscale_fused2);
 
   m.def("esimd_gemv_fp8_blockscale_fp16_fused2(Tensor input, "
-        "Tensor w0, Tensor s0, Tensor o0, Tensor w1, Tensor o1, "
-        "int block_n, int block_k) -> Tensor");
+        "Tensor w0, Tensor s0, Tensor(a!) o0, Tensor w1, Tensor(b!) o1, "
+        "int block_n, int block_k) -> Tensor(a!)");
   m.impl("esimd_gemv_fp8_blockscale_fp16_fused2", torch::kXPU,
          &esimd_gemv_fp8_blockscale_fp16_fused2);
 
   m.def("esimd_norm_gemv_fp8_blockscale(Tensor x, Tensor z, Tensor norm_weight, "
-        "Tensor gemv_weight, Tensor gemv_scale, Tensor output, int HV, int V, "
-        "float eps) -> Tensor");
+        "Tensor gemv_weight, Tensor gemv_scale, Tensor(a!) output, int HV, "
+        "int V, float eps) -> Tensor(a!)");
   m.impl("esimd_norm_gemv_fp8_blockscale", torch::kXPU,
          &esimd_norm_gemv_fp8_blockscale);
 }

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/torch_extension_gemm.cc
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/torch_extension_gemm.cc
@@ -27,6 +27,24 @@ TORCH_LIBRARY_FRAGMENT(custom_esimd_kernels_vllm, m) {
   m.def("esimd_gemm_fp8_blockscale(Tensor input, Tensor weight, Tensor weight_scale, "
         "Tensor output, int block_n, int block_k) -> Tensor");
   m.impl("esimd_gemm_fp8_blockscale", torch::kXPU, &esimd_gemm_fp8_blockscale);
+
+  m.def("esimd_gemv_fp8_blockscale_fused2(Tensor input, "
+        "Tensor w0, Tensor s0, Tensor o0, Tensor w1, Tensor s1, Tensor o1, "
+        "int block_n, int block_k) -> Tensor");
+  m.impl("esimd_gemv_fp8_blockscale_fused2", torch::kXPU,
+         &esimd_gemv_fp8_blockscale_fused2);
+
+  m.def("esimd_gemv_fp8_blockscale_fp16_fused2(Tensor input, "
+        "Tensor w0, Tensor s0, Tensor o0, Tensor w1, Tensor o1, "
+        "int block_n, int block_k) -> Tensor");
+  m.impl("esimd_gemv_fp8_blockscale_fp16_fused2", torch::kXPU,
+         &esimd_gemv_fp8_blockscale_fp16_fused2);
+
+  m.def("esimd_norm_gemv_fp8_blockscale(Tensor x, Tensor z, Tensor norm_weight, "
+        "Tensor gemv_weight, Tensor gemv_scale, Tensor output, int HV, int V, "
+        "float eps) -> Tensor");
+  m.impl("esimd_norm_gemv_fp8_blockscale", torch::kXPU,
+         &esimd_norm_gemv_fp8_blockscale);
 }
 
 PyMODINIT_FUNC PyInit_custom_esimd_kernels_gemm() {

--- a/vllm/custom-esimd-kernels-vllm/include/kernel_ops.h
+++ b/vllm/custom-esimd-kernels-vllm/include/kernel_ops.h
@@ -194,6 +194,11 @@ void esimd_norm_gemv_norm_fp16(
     at::Tensor router_logits, at::Tensor moe_input,
     double eps);
 
+at::Tensor esimd_norm_gemv_fp8_blockscale(
+    at::Tensor x, at::Tensor z, at::Tensor norm_weight,
+    at::Tensor gemv_weight, at::Tensor gemv_scale, at::Tensor output,
+    int64_t HV, int64_t V, double eps);
+
 void esimd_scaled_resadd_norm_gemv_fp8_pert(
     at::Tensor hidden_states, at::Tensor residual,
     at::Tensor norm_weight, at::Tensor qkv_weight,
@@ -264,6 +269,16 @@ at::Tensor esimd_gemm_fp8_pert(
 at::Tensor esimd_gemm_fp8_blockscale(
     at::Tensor input, at::Tensor weight, at::Tensor weight_scale,
     at::Tensor output, int64_t block_n, int64_t block_k);
+
+at::Tensor esimd_gemv_fp8_blockscale_fused2(
+    at::Tensor input,
+    at::Tensor w0, at::Tensor s0, at::Tensor o0,
+    at::Tensor w1, at::Tensor s1, at::Tensor o1,
+    int64_t block_n, int64_t block_k);
+
+at::Tensor esimd_gemv_fp8_blockscale_fp16_fused2(
+    at::Tensor input, at::Tensor w0, at::Tensor s0, at::Tensor o0,
+    at::Tensor w1, at::Tensor o1, int64_t block_n, int64_t block_k);
 
 // ======================== INT4 GEMV ========================
 // Symmetric INT4 weight GEMV with per-group scale (group_size=128).

--- a/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/__init__.py
+++ b/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/__init__.py
@@ -23,6 +23,8 @@ from custom_esimd_kernels_vllm.ops import (
     esimd_gemv_fp8_pert,
     esimd_gemv_fp16,
     esimd_gemv_fp8_pert_fused2,
+    esimd_gemv_fp8_blockscale_fused2,
+    esimd_gemv_fp8_blockscale_fp16_fused2,
     esimd_gemv_fp8_pert_fused3,
     # INT4 GEMV ops
     esimd_gemv_int4,
@@ -45,6 +47,7 @@ from custom_esimd_kernels_vllm.ops import (
     esimd_resadd_norm_gemv_int4_pert,
     esimd_resadd_norm_gemv2_fp8_pert,
     esimd_norm_gemv_fp8_pert,
+    esimd_norm_gemv_fp8_blockscale,
     esimd_norm_gemv_int4_pert,
     esimd_gdn_conv_fused_seq,
     esimd_moe_topk,

--- a/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/ops.py
+++ b/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/ops.py
@@ -96,7 +96,10 @@ def esimd_gemv_fp8_blockscale_fused2(
     w1: torch.Tensor, s1: torch.Tensor, o1: torch.Tensor,
     block_n: int = 128, block_k: int = 128,
 ) -> torch.Tensor:
-    """Decode dual GEMV for two E4M3 weights with 128x128 block scales."""
+    """Decode dual GEMV for two E4M3 weights with 128x128 block scales.
+
+    Results are written to ``o0`` and ``o1`` in place. Returns ``o0``.
+    """
     return _ops.esimd_gemv_fp8_blockscale_fused2(
         input, w0, s0, o0, w1, s1, o1, block_n, block_k)
 
@@ -107,7 +110,10 @@ def esimd_gemv_fp8_blockscale_fp16_fused2(
     w1: torch.Tensor, o1: torch.Tensor,
     block_n: int = 128, block_k: int = 128,
 ) -> torch.Tensor:
-    """Decode dual GEMV for block-E4M3 qkvz plus an FP16 ba weight."""
+    """Decode dual GEMV for block-E4M3 qkvz plus an FP16 ba weight.
+
+    Results are written to ``o0`` and ``o1`` in place. Returns ``o0``.
+    """
     return _ops.esimd_gemv_fp8_blockscale_fp16_fused2(
         input, w0, s0, o0, w1, o1, block_n, block_k)
 
@@ -511,7 +517,11 @@ def esimd_norm_gemv_fp8_blockscale(
     V: int,
     eps: float,
 ) -> torch.Tensor:
-    """Fused RMSNormGated + E4M3 GEMV with 128x128 weight scales."""
+    """Fused RMSNormGated + E4M3 GEMV with 128x128 weight scales.
+
+    The result is written to ``output`` in place and the same tensor is
+    returned.
+    """
     return _ops.esimd_norm_gemv_fp8_blockscale(
         x, z, norm_weight, gemv_weight, gemv_scale, output, HV, V, eps)
 

--- a/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/ops.py
+++ b/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/ops.py
@@ -90,6 +90,28 @@ def esimd_gemv_fp8_pert_fused2(
     return _ops.esimd_gemv_fp8_pert_fused2(input, w0, s0, o0, w1, s1, o1)
 
 
+def esimd_gemv_fp8_blockscale_fused2(
+    input: torch.Tensor,
+    w0: torch.Tensor, s0: torch.Tensor, o0: torch.Tensor,
+    w1: torch.Tensor, s1: torch.Tensor, o1: torch.Tensor,
+    block_n: int = 128, block_k: int = 128,
+) -> torch.Tensor:
+    """Decode dual GEMV for two E4M3 weights with 128x128 block scales."""
+    return _ops.esimd_gemv_fp8_blockscale_fused2(
+        input, w0, s0, o0, w1, s1, o1, block_n, block_k)
+
+
+def esimd_gemv_fp8_blockscale_fp16_fused2(
+    input: torch.Tensor,
+    w0: torch.Tensor, s0: torch.Tensor, o0: torch.Tensor,
+    w1: torch.Tensor, o1: torch.Tensor,
+    block_n: int = 128, block_k: int = 128,
+) -> torch.Tensor:
+    """Decode dual GEMV for block-E4M3 qkvz plus an FP16 ba weight."""
+    return _ops.esimd_gemv_fp8_blockscale_fp16_fused2(
+        input, w0, s0, o0, w1, o1, block_n, block_k)
+
+
 def esimd_gemv_fp8_pert_fused3(
     input: torch.Tensor,
     w0: torch.Tensor, s0: torch.Tensor, o0: torch.Tensor,
@@ -476,6 +498,22 @@ def esimd_norm_gemv_fp8_pert(
     return _ops.esimd_norm_gemv_fp8_pert(
         x, z, norm_weight, gemv_weight, gemv_scale, output,
         HV, V, eps)
+
+
+def esimd_norm_gemv_fp8_blockscale(
+    x: torch.Tensor,
+    z: torch.Tensor,
+    norm_weight: torch.Tensor,
+    gemv_weight: torch.Tensor,
+    gemv_scale: torch.Tensor,
+    output: torch.Tensor,
+    HV: int,
+    V: int,
+    eps: float,
+) -> torch.Tensor:
+    """Fused RMSNormGated + E4M3 GEMV with 128x128 weight scales."""
+    return _ops.esimd_norm_gemv_fp8_blockscale(
+        x, z, norm_weight, gemv_weight, gemv_scale, output, HV, V, eps)
 
 
 def esimd_norm_gemv_int4_pert(

--- a/vllm/custom-esimd-kernels-vllm/tests/test_fp8_blockscale_fusions.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/test_fp8_blockscale_fusions.py
@@ -1,0 +1,106 @@
+"""Correctness and microbenchmark for block-scaled GDN decode fusions."""
+
+import statistics
+import time
+
+import torch
+
+import custom_esimd_kernels_vllm as esimd
+from test_fp8_blockscale_gemm import dequant_weight, quantize_weight_block
+
+
+def error_stats(out: torch.Tensor, ref: torch.Tensor) -> tuple[float, float]:
+    out_f = out.float().flatten()
+    ref_f = ref.float().flatten()
+    rel = ((out_f - ref_f).abs().mean() / ref_f.abs().mean().clamp_min(1e-6)).item()
+    cos = torch.nn.functional.cosine_similarity(out_f, ref_f, dim=0).item()
+    return rel, cos
+
+
+def timed_ms(fn, warmup: int = 20, iterations: int = 100) -> float:
+    for _ in range(warmup):
+        fn()
+    torch.xpu.synchronize()
+    samples = []
+    for _ in range(iterations):
+        start = time.perf_counter()
+        fn()
+        torch.xpu.synchronize()
+        samples.append((time.perf_counter() - start) * 1e3)
+    return statistics.median(samples)
+
+
+def main() -> None:
+    torch.manual_seed(20260713)
+    dev = "xpu"
+
+    # Qwen3.6 TP2-like GDN input projections.
+    k, n0, n1 = 2048, 3072, 64
+    x = (torch.randn(1, k, device=dev) * 0.25).half()
+    w0, s0 = quantize_weight_block(torch.randn(n0, k, device=dev) * 0.2)
+    w1, s1 = quantize_weight_block(torch.randn(n1, k, device=dev) * 0.2)
+    o0 = torch.empty(1, n0, dtype=torch.float16, device=dev)
+    o1 = torch.empty(1, n1, dtype=torch.float16, device=dev)
+    esimd.esimd_gemv_fp8_blockscale_fused2(x, w0, s0, o0, w1, s1, o1)
+    torch.xpu.synchronize()
+    ref0 = x.float() @ dequant_weight(w0, s0).t()
+    ref1 = x.float() @ dequant_weight(w1, s1).t()
+    rel0, cos0 = error_stats(o0, ref0)
+    rel1, cos1 = error_stats(o1, ref1)
+    assert rel0 < 5e-3 and cos0 > 0.99999, (rel0, cos0)
+    assert rel1 < 5e-3 and cos1 > 0.99999, (rel1, cos1)
+
+    def separate_input_proj():
+        esimd.esimd_gemm_fp8_blockscale(x, w0, s0, o0)
+        esimd.esimd_gemm_fp8_blockscale(x, w1, s1, o1)
+
+    def fused_input_proj():
+        esimd.esimd_gemv_fp8_blockscale_fused2(x, w0, s0, o0, w1, s1, o1)
+
+    separate_ms = timed_ms(separate_input_proj)
+    fused_ms = timed_ms(fused_input_proj)
+
+    w1_fp16 = (torch.randn(n1, k, device=dev) * 0.2).half()
+    esimd.esimd_gemv_fp8_blockscale_fp16_fused2(
+        x, w0, s0, o0, w1_fp16, o1
+    )
+    torch.xpu.synchronize()
+    mixed_ref0 = x.float() @ dequant_weight(w0, s0).t()
+    mixed_ref1 = x.float() @ w1_fp16.float().t()
+    mixed_rel0, mixed_cos0 = error_stats(o0, mixed_ref0)
+    mixed_rel1, mixed_cos1 = error_stats(o1, mixed_ref1)
+    assert mixed_rel0 < 5e-3 and mixed_cos0 > 0.99999, (mixed_rel0, mixed_cos0)
+    assert mixed_rel1 < 5e-3 and mixed_cos1 > 0.99999, (mixed_rel1, mixed_cos1)
+
+    # Qwen3.6 TP2-like GDN gated norm + row-parallel output projection.
+    hv, v, n = 8, 128, 2048
+    core = (torch.randn(hv, v, device=dev) * 0.3).half()
+    gate = (torch.randn(hv, v, device=dev) * 0.3).half()
+    norm_w = (torch.randn(v, device=dev) * 0.1 + 1.0).half()
+    w_out, s_out = quantize_weight_block(torch.randn(n, hv * v, device=dev) * 0.2)
+    out = torch.empty(1, n, dtype=torch.float16, device=dev)
+    eps = 1e-6
+    esimd.esimd_norm_gemv_fp8_blockscale(
+        core, gate, norm_w, w_out, s_out, out, hv, v, eps
+    )
+    torch.xpu.synchronize()
+    core_f = core.float()
+    normed = core_f * torch.rsqrt(core_f.square().mean(-1, keepdim=True) + eps)
+    normed *= norm_w.float()
+    normed *= torch.nn.functional.silu(gate.float())
+    ref_out = normed.flatten().unsqueeze(0) @ dequant_weight(w_out, s_out).t()
+    rel_out, cos_out = error_stats(out, ref_out)
+    assert rel_out < 5e-3 and cos_out > 0.99999, (rel_out, cos_out)
+
+    print(f"dual_gemv: rel=({rel0:.3e},{rel1:.3e}) cos=({cos0:.8f},{cos1:.8f})")
+    print(f"dual_gemv_ms: separate={separate_ms:.4f} fused={fused_ms:.4f}")
+    print(
+        f"mixed_gemv: rel=({mixed_rel0:.3e},{mixed_rel1:.3e}) "
+        f"cos=({mixed_cos0:.8f},{mixed_cos1:.8f})"
+    )
+    print(f"norm_gemv: rel={rel_out:.3e} cos={cos_out:.8f}")
+    print("RESULT: ALL OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/custom-esimd-kernels-vllm/tests/test_fp8_blockscale_fusions.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/test_fp8_blockscale_fusions.py
@@ -1,11 +1,15 @@
 """Correctness and microbenchmark for block-scaled GDN decode fusions."""
 
 import statistics
+import sys
 import time
+from pathlib import Path
 
 import torch
 
 import custom_esimd_kernels_vllm as esimd
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 from test_fp8_blockscale_gemm import dequant_weight, quantize_weight_block
 
 
@@ -30,7 +34,7 @@ def timed_ms(fn, warmup: int = 20, iterations: int = 100) -> float:
     return statistics.median(samples)
 
 
-def main() -> None:
+def test_fp8_blockscale_fusions() -> None:
     torch.manual_seed(20260713)
     dev = "xpu"
 
@@ -103,4 +107,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    test_fp8_blockscale_fusions()


### PR DESCRIPTION
## Summary

Add the custom ESIMD kernel support required by the next block-scaled FP8 GDN decode stage.

This PR adds:

- block-scaled FP8 GDN decode fusion kernels;
- C++/Python operator bindings and exports;
- focused block-scale fusion tests.

This is the kernel dependency only. The framework integration will be submitted separately after this PR is reviewed and merged.

## Base

- `intel/llm-scaler` main: `6e0ee089`
- Includes the previously merged fused block-MoE decode kernel.

## Validation plan

1. Build and install the custom ESIMD wheel from this branch.
2. Run the focused kernel tests.
3. After merge, create the framework GDN integration PR from source commit `b431470ff`.
4. Validate the combined stack with per-block GSM8K 30x100 and exact 32K input / 2K output performance at batch 1 and 4.

The combined framework validation will use XPU 0,1, oneCCL 2021.15, no `ONECCL_VARS` override, and `VLLM_XPU_ALLREDUCE_RETRY_ON_NAN=0`.
