### PR TITLE
[XPU][FP8] Add block-scaled MoE prefill GEMM

### DIFF
--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_moe.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_moe.sycl
@@ -173,10 +173,35 @@ at::Tensor esimd_moe_gemm_fp8_blockscale(
                 "esimd_moe_gemm_fp8_blockscale: K must be a multiple of block_k(128)");
     auto& q = get_device_queue(input);
 
-    // Active-experts-only grid: only min(num_experts, total_tokens) experts can
-    // be non-empty this call. Compact their ids so the main grid launches
-    // n_active*N work-groups instead of num_experts*N (~99% empty at decode).
     const int64_t total_tokens = input.size(0);
+    if (total_tokens >= 128) {
+        // Large-M prefill path. Build compact 64-row expert-tile descriptors on
+        // device; the capacity bound avoids a max(rows_per_expert) host sync.
+        const int64_t tile_capacity =
+            (total_tokens + 63) / 64 + num_experts;
+        auto tile_experts = at::full(
+            {tile_capacity}, (int64_t)num_experts,
+            input.options().dtype(at::kInt));
+        auto tile_rows = at::empty(
+            {tile_capacity}, input.options().dtype(at::kInt));
+        fp8_moe_blockscale::build_expert_m_tiles(
+            reinterpret_cast<const uint32_t*>(expert_idx.data_ptr()),
+            tile_experts.data_ptr<int32_t>(), tile_rows.data_ptr<int32_t>(),
+            (int)num_experts, q);
+        fp8_moe_blockscale::moe_gemm_fp8_blockscale_prefill_host(
+            reinterpret_cast<const fp16*>(input.data_ptr()),
+            reinterpret_cast<const uint8_t*>(weight.data_ptr()),
+            weight_scale.data_ptr<float>(),
+            reinterpret_cast<fp16*>(output.data_ptr()),
+            reinterpret_cast<const uint32_t*>(expert_idx.data_ptr()),
+            tile_experts.data_ptr<int32_t>(), tile_rows.data_ptr<int32_t>(),
+            (int)total_tokens, (int)tile_capacity, (int)N, (int)K,
+            (int)num_experts, (int)block_n, (int)block_k, q);
+        return output;
+    }
+
+    // Decode path: only min(num_experts, total_tokens) experts can be non-empty.
+    // Compact their ids so the grid avoids empty expert/output-channel groups.
     const int n_active =
         (int)std::min<int64_t>(num_experts, total_tokens);
     auto active_experts = at::full(

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/fp8_moe_gemm_blockscale.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/fp8_moe_gemm_blockscale.h
@@ -301,6 +301,10 @@ inline void moe_gemm_fp8_blockscale_prefill_host(
   const int Nb = (N + block_n - 1) / block_n;
   const int Kb = K / block_k;
   const int n_tiles = (N + 15) / 16;
+  // Empirical BMG grid-shaping caps. Small-K groups do less work and tolerate
+  // a larger grid; larger-K groups use a lower cap to bound scheduling cost.
+  // These values only coalesce adjacent N tiles into a work-group and never
+  // truncate the launched computation.
   const int wg_cap = (K <= 512) ? 51200 : 38400;
   int n_per_wg = 1;
   int total_wgs = tile_capacity * n_tiles;

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/fp8_moe_gemm_blockscale.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/fp8_moe_gemm_blockscale.h
@@ -40,6 +40,8 @@
 #include "fp8_GEMM_blockscale.h"  // fp8_blockscale::fp8e4m3_to_fp16
 #include <algorithm>
 #include <cstdint>
+#include <sycl/ext/intel/esimd/xmx/dpas.hpp>
+#include <sycl/ext/intel/experimental/esimd/memory.hpp>
 
 namespace fp8_moe_blockscale {
 
@@ -71,6 +73,41 @@ inline void build_active_experts(const uint32_t* expert_idx,
     cgh.parallel_for(sycl::range<1>(1),
                      build_active_experts_kernel{expert_idx, active_experts,
                                                  num_experts});
+  });
+}
+
+// Build one descriptor for every contiguous tile of up to 64 expert-grouped
+// rows.  The descriptor count is bounded on the host by ceil(total_rows/64)+E,
+// so the large-M kernel needs no device-to-host synchronization to discover the
+// maximum number of tokens routed to one expert.
+struct build_expert_m_tiles_kernel {
+  const uint32_t* expert_idx;
+  int32_t* tile_experts;
+  int32_t* tile_rows;
+  int num_experts;
+
+  void operator()(sycl::id<1>) const {
+    int tile = 0;
+    for (int e = 0; e < num_experts; e++) {
+      const int start = (int)expert_idx[e];
+      const int end = (int)expert_idx[e + 1];
+      for (int row = start; row < end; row += 64) {
+        tile_experts[tile] = e;
+        tile_rows[tile] = row;
+        tile++;
+      }
+    }
+  }
+};
+
+inline void build_expert_m_tiles(const uint32_t* expert_idx,
+                                 int32_t* tile_experts,
+                                 int32_t* tile_rows, int num_experts,
+                                 sycl::queue& q) {
+  q.submit([&](handler& cgh) {
+    cgh.parallel_for(sycl::range<1>(1),
+                     build_expert_m_tiles_kernel{expert_idx, tile_experts,
+                                                 tile_rows, num_experts});
   });
 }
 
@@ -133,6 +170,156 @@ struct moe_gemv_block_kernel {
     }
   }
 };
+
+// Large-M grouped W8A16 GEMM.  Each work-group owns one 64-row expert tile and
+// one group of 16-column N tiles.  FP8 E4M3 weights are converted to FP16,
+// multiplied by their 128x128 scale, then consumed by FP16 DPAS.  This keeps
+// the platform restriction (no FP8 matrix multiply) while replacing the
+// scalar output-channel reductions used by the decode-tuned GEMV.
+struct moe_gemm_block_prefill_kernel {
+  const fp16* input;
+  const uint8_t* weight;
+  const float* wscale;
+  fp16* output;
+  const uint32_t* expert_idx;
+  const int32_t* tile_experts;
+  const int32_t* tile_rows;
+  int total_tokens;
+  int tile_capacity;
+  int N, K, Nb, Kb, num_experts;
+  int n_wg_count, n_per_wg;
+
+  void operator()(sycl::nd_item<1> item) const SYCL_ESIMD_KERNEL {
+    namespace mem = sycl::ext::intel::experimental::esimd;
+    const int wg = item.get_group(0);
+    const int tile_id = wg / n_wg_count;
+    const int n_wg_id = wg - tile_id * n_wg_count;
+    if (tile_id >= tile_capacity) return;
+    const int e = tile_experts[tile_id];
+    if (e < 0 || e >= num_experts) return;
+
+    const int row_start = tile_rows[tile_id];
+    const int row_end = (int)expert_idx[e + 1];
+    const int valid_rows = row_end - row_start < 64 ? row_end - row_start : 64;
+    if (valid_rows <= 0) return;
+
+    const int n_tiles = (N + 15) / 16;
+    const int n_tile_start = n_wg_id * n_per_wg;
+    const int n_tile_end = n_tile_start + n_per_wg < n_tiles
+                               ? n_tile_start + n_per_wg
+                               : n_tiles;
+
+    const uint32_t surfW_A = (uint32_t)K * 2u - 1u;
+    const uint32_t surfH_A = (uint32_t)total_tokens - 1u;
+    mem::config_2d_mem_access<fp16, 16, 8, 1> payA(
+        input, surfW_A, surfH_A, surfW_A, 0u, (uint32_t)row_start);
+
+    const uint32_t surfW_B = (uint32_t)K - 1u;
+    const uint32_t surfH_B = (uint32_t)(num_experts * N) - 1u;
+    mem::config_2d_mem_access<uint32_t, 4, 16, 1> payB_t(
+        reinterpret_cast<const uint32_t*>(weight), surfW_B, surfH_B, surfW_B,
+        0u, 0u);
+
+    for (int nc = n_tile_start; nc < n_tile_end; nc++) {
+      const int n_start = nc * 16;
+      if (n_start >= N) break;
+      const int n_valid = N - n_start < 16 ? N - n_start : 16;
+      payB_t.set_y((uint32_t)(e * N + n_start));
+      simd<float, 128> acc[8];
+#pragma unroll
+      for (int mt = 0; mt < 8; mt++) acc[mt] = 0.0f;
+
+      for (int k_base = 0; k_base < K; k_base += 64) {
+#pragma unroll
+        for (int sub = 0; sub < 4; sub++) {
+          const int k_sub = k_base + sub * 16;
+          payB_t.set_x((uint32_t)(k_sub / 4));
+          simd<uint32_t, 64> w_t =
+              mem::lsc_load_2d<uint32_t, 4, 16, 1, true, false,
+                               mem::cache_hint::cached,
+                               mem::cache_hint::cached>(payB_t);
+
+          // Transposed 16x16 FP8 tile -> DPAS VNNI2 FP16 layout.
+          simd<uint8_t, 256> raw_vnni;
+#pragma unroll
+          for (int col = 0; col < 4; col++) {
+            simd<uint32_t, 16> g = w_t.template select<16, 1>(col * 16);
+            simd<uint8_t, 16> b0 = convert<uint8_t>(g & 0xFF);
+            simd<uint8_t, 16> b1 = convert<uint8_t>((g >> 8) & 0xFF);
+            simd<uint8_t, 16> b2 = convert<uint8_t>((g >> 16) & 0xFF);
+            simd<uint8_t, 16> b3 = convert<uint8_t>((g >> 24) & 0xFF);
+            raw_vnni.template select<16, 2>(col * 64) = b0;
+            raw_vnni.template select<16, 2>(col * 64 + 1) = b1;
+            raw_vnni.template select<16, 2>(col * 64 + 32) = b2;
+            raw_vnni.template select<16, 2>(col * 64 + 33) = b3;
+          }
+          simd<fp16, 256> b_tile = fp8e4m3_to_fp16<256>(raw_vnni);
+          const float scale =
+              wscale[((size_t)e * Nb + n_start / 128) * Kb + k_sub / 128];
+          b_tile *= fp16(scale);
+
+          payA.set_x((uint32_t)k_sub);
+#pragma unroll
+          for (int mt = 0; mt < 8; mt++) {
+            payA.set_y((uint32_t)(row_start + mt * 8));
+            simd<fp16, 128> a =
+                mem::lsc_load_2d<fp16, 16, 8, 1, false, false,
+                                 mem::cache_hint::cached,
+                                 mem::cache_hint::cached>(payA);
+            acc[mt] = sycl::ext::intel::esimd::xmx::dpas<
+                8, 8, float, float, fp16, fp16>(acc[mt], b_tile, a);
+          }
+        }
+      }
+
+#pragma unroll
+      for (int mt = 0; mt < 8; mt++) {
+#pragma unroll
+        for (int mi = 0; mi < 8; mi++) {
+          const int row_id = mt * 8 + mi;
+          if (row_id < valid_rows) {
+            simd<float, 16> row = acc[mt].template select<16, 1>(mi * 16);
+            simd<fp16, 16> out = convert<fp16>(row);
+            const size_t off = (size_t)(row_start + row_id) * N + n_start;
+            if (n_valid == 16) {
+              block_store<fp16, 16>(output + off, out);
+            } else {
+              for (int ni = 0; ni < n_valid; ni++) output[off + ni] = out[ni];
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+inline void moe_gemm_fp8_blockscale_prefill_host(
+    const fp16* input, const uint8_t* weight, const float* weight_scale,
+    fp16* output, const uint32_t* expert_idx, const int32_t* tile_experts,
+    const int32_t* tile_rows, int total_tokens, int tile_capacity, int N, int K,
+    int num_experts, int block_n, int block_k, sycl::queue& q) {
+  const int Nb = (N + block_n - 1) / block_n;
+  const int Kb = K / block_k;
+  const int n_tiles = (N + 15) / 16;
+  const int wg_cap = (K <= 512) ? 51200 : 38400;
+  int n_per_wg = 1;
+  int total_wgs = tile_capacity * n_tiles;
+  while (total_wgs > wg_cap && n_per_wg < n_tiles) {
+    n_per_wg++;
+    while (n_per_wg < n_tiles && n_tiles % n_per_wg != 0) n_per_wg++;
+    total_wgs = tile_capacity * ((n_tiles + n_per_wg - 1) / n_per_wg);
+  }
+  const int n_wg_count = (n_tiles + n_per_wg - 1) / n_per_wg;
+  const int groups = tile_capacity * n_wg_count;
+  q.submit([&](handler& cgh) {
+    cgh.parallel_for(
+        sycl::nd_range<1>((size_t)groups, 1),
+        moe_gemm_block_prefill_kernel{
+            input, weight, weight_scale, output, expert_idx, tile_experts,
+            tile_rows, total_tokens, tile_capacity, N, K, Nb, Kb, num_experts,
+            n_wg_count, n_per_wg});
+  });
+}
 
 template <int VL, int MAX_M>
 inline void launch_moe_gemv_block(const fp16* input, const uint8_t* weight,

--- a/vllm/custom-esimd-kernels-vllm/tests/test_fp8_blockscale_moe_prefill.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/test_fp8_blockscale_moe_prefill.py
@@ -1,14 +1,18 @@
 """Correctness test for the large-M block-scaled MoE W8A16 GEMM."""
 
 import time
+import sys
+from pathlib import Path
 
 import torch
 
 import custom_esimd_kernels_vllm as esimd
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 from test_moe_forward_full_fp8_block import dequant, quantize_block
 
 
-def main() -> None:
+def test_fp8_blockscale_moe_prefill() -> None:
     torch.manual_seed(20260713)
     device = "xpu"
     experts, n, k = 4, 256, 256
@@ -60,4 +64,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    test_fp8_blockscale_moe_prefill()

--- a/vllm/custom-esimd-kernels-vllm/tests/test_fp8_blockscale_moe_prefill.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/test_fp8_blockscale_moe_prefill.py
@@ -1,18 +1,54 @@
 """Correctness test for the large-M block-scaled MoE W8A16 GEMM."""
 
 import time
-import sys
-from pathlib import Path
 
+import pytest
 import torch
 
 import custom_esimd_kernels_vllm as esimd
 
-sys.path.insert(0, str(Path(__file__).resolve().parent))
-from test_moe_forward_full_fp8_block import dequant, quantize_block
+
+FP8_MAX = 448.0
+BLOCK = 128
 
 
-def test_fp8_blockscale_moe_prefill() -> None:
+def quantize_block(weight: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    leading = weight.shape[:-2]
+    n, k = weight.shape[-2:]
+    flat = weight.reshape(-1, n, k)
+    q = torch.empty_like(flat, dtype=torch.float8_e4m3fn)
+    scale = torch.empty(
+        (flat.shape[0], (n + BLOCK - 1) // BLOCK, (k + BLOCK - 1) // BLOCK),
+        dtype=torch.float32,
+        device=weight.device,
+    )
+    for e in range(flat.shape[0]):
+        for nb in range(scale.shape[1]):
+            for kb in range(scale.shape[2]):
+                block = flat[
+                    e,
+                    nb * BLOCK : (nb + 1) * BLOCK,
+                    kb * BLOCK : (kb + 1) * BLOCK,
+                ]
+                s = block.abs().max().clamp_min(1e-12) / FP8_MAX
+                scale[e, nb, kb] = s
+                q[
+                    e,
+                    nb * BLOCK : (nb + 1) * BLOCK,
+                    kb * BLOCK : (kb + 1) * BLOCK,
+                ] = (block / s).to(torch.float8_e4m3fn)
+    return q.reshape(*leading, n, k), scale.reshape(
+        *leading, scale.shape[-2], scale.shape[-1]
+    )
+
+
+def dequant(q: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    n, k = q.shape[-2:]
+    expanded = scale.repeat_interleave(BLOCK, -2).repeat_interleave(BLOCK, -1)
+    return q.float() * expanded[..., :n, :k]
+
+
+def run_prefill_case(*, benchmark: bool) -> None:
     torch.manual_seed(20260713)
     device = "xpu"
     experts, n, k = 4, 256, 256
@@ -47,21 +83,31 @@ def test_fp8_blockscale_moe_prefill() -> None:
     assert mean_rel < 3e-3, mean_rel
     assert cosine > 0.9999, cosine
 
-    for _ in range(10):
-        esimd.esimd_moe_gemm_fp8_blockscale(
-            x, weight, scale, out, offsets, n, k, experts
-        )
-    torch.xpu.synchronize()
-    begin = time.perf_counter()
-    for _ in range(100):
-        esimd.esimd_moe_gemm_fp8_blockscale(
-            x, weight, scale, out, offsets, n, k, experts
-        )
-    torch.xpu.synchronize()
-    mean_ms = (time.perf_counter() - begin) * 10.0
-    print(f"mean_rel={mean_rel:.6e} cosine={cosine:.8f} mean_ms={mean_ms:.4f}")
+    message = f"mean_rel={mean_rel:.6e} cosine={cosine:.8f}"
+    if benchmark:
+        for _ in range(10):
+            esimd.esimd_moe_gemm_fp8_blockscale(
+                x, weight, scale, out, offsets, n, k, experts
+            )
+        torch.xpu.synchronize()
+        begin = time.perf_counter()
+        for _ in range(100):
+            esimd.esimd_moe_gemm_fp8_blockscale(
+                x, weight, scale, out, offsets, n, k, experts
+            )
+        torch.xpu.synchronize()
+        mean_ms = (time.perf_counter() - begin) * 10.0
+        message += f" mean_ms={mean_ms:.4f}"
+    print(message)
     print("RESULT: ALL OK")
 
 
+@pytest.mark.skipif(not torch.xpu.is_available(), reason="XPU is required")
+def test_fp8_blockscale_moe_prefill() -> None:
+    run_prefill_case(benchmark=False)
+
+
 if __name__ == "__main__":
-    test_fp8_blockscale_moe_prefill()
+    if not torch.xpu.is_available():
+        raise SystemExit("XPU is required")
+    run_prefill_case(benchmark=True)

--- a/vllm/custom-esimd-kernels-vllm/tests/test_fp8_blockscale_moe_prefill.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/test_fp8_blockscale_moe_prefill.py
@@ -1,0 +1,63 @@
+"""Correctness test for the large-M block-scaled MoE W8A16 GEMM."""
+
+import time
+
+import torch
+
+import custom_esimd_kernels_vllm as esimd
+from test_moe_forward_full_fp8_block import dequant, quantize_block
+
+
+def main() -> None:
+    torch.manual_seed(20260713)
+    device = "xpu"
+    experts, n, k = 4, 256, 256
+    counts = torch.tensor([33, 40, 27, 36], dtype=torch.int32, device=device)
+    offsets = torch.zeros(experts + 1, dtype=torch.int32, device=device)
+    offsets[1:] = counts.cumsum(0)
+    total = int(counts.sum().cpu())
+
+    x = (torch.randn(total, k, device=device) * 0.2).half()
+    weight, scale = quantize_block(
+        torch.randn(experts, n, k, device=device) * 0.15
+    )
+    out = torch.empty(total, n, dtype=torch.float16, device=device)
+
+    esimd.esimd_moe_gemm_fp8_blockscale(
+        x, weight, scale, out, offsets, n, k, experts
+    )
+    torch.xpu.synchronize()
+
+    ref = torch.empty(total, n, dtype=torch.float32, device=device)
+    dw = dequant(weight, scale)
+    start = 0
+    for expert, count in enumerate(counts.cpu().tolist()):
+        ref[start : start + count] = x[start : start + count].float() @ dw[expert].t()
+        start += count
+
+    out_f = out.float()
+    mean_rel = ((out_f - ref).abs().mean() / ref.abs().mean()).item()
+    cosine = torch.nn.functional.cosine_similarity(
+        out_f.flatten(), ref.flatten(), dim=0
+    ).item()
+    assert mean_rel < 3e-3, mean_rel
+    assert cosine > 0.9999, cosine
+
+    for _ in range(10):
+        esimd.esimd_moe_gemm_fp8_blockscale(
+            x, weight, scale, out, offsets, n, k, experts
+        )
+    torch.xpu.synchronize()
+    begin = time.perf_counter()
+    for _ in range(100):
+        esimd.esimd_moe_gemm_fp8_blockscale(
+            x, weight, scale, out, offsets, n, k, experts
+        )
+    torch.xpu.synchronize()
+    mean_ms = (time.perf_counter() - begin) * 10.0
+    print(f"mean_rel={mean_rel:.6e} cosine={cosine:.8f} mean_ms={mean_ms:.4f}")
+    print("RESULT: ALL OK")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- route block-scaled grouped MoE calls with at least 128 routed rows to a large-M prefill kernel
- build compact 64-row expert-tile descriptors on device without a device-to-host synchronization
- use FP16 DPAS after E4M3 block dequantization for the prefill path while preserving the existing decode path
- add a pytest-collectable correctness and microbenchmark test for the prefill kernel

## Scope

This is the next kernel-only stage after #565. It does not change the public operator schema or require a framework change; the existing `esimd_moe_gemm_fp8_blockscale` dispatch selects the prefill implementation internally for `total_tokens >= 128`.

The later descriptor-buffer reuse optimization is intentionally not included in this PR and will remain a separate stage.

## Testing

Not run as part of PR creation.
