### PR TITLE
docker: stabilize oneCCL 2021.15 integration for vllm images

### DIFF
--- a/vllm/docker/Dockerfile
+++ b/vllm/docker/Dockerfile
@@ -136,7 +136,6 @@ ARG ONECCL_INSTALLER_SHA256="f7ab81b6ed1b10dd35fadec366a78046d8af214888dfd625047
 ENV PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/xpu" \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_NO_CACHE_DIR=1 \
-    LD_PRELOAD="/opt/intel/oneapi/ccl/2021.15/lib/libccl.so.1" \
     VLLM_QUANTIZE_Q40_LIB="/opt/venv/lib/python3.12/site-packages/vllm_int4_for_multi_arc.so" \
     VLLM_OFFLOAD_WEIGHTS_BEFORE_QUANT=1 \
     VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
@@ -171,12 +170,31 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     printf "%s  %s\n" "${ONECCL_INSTALLER_SHA256}" "${ONECCL_INSTALLER}" > /tmp/oneccl.sha256 && \
     sha256sum -c /tmp/oneccl.sha256 && \
     rm -f /tmp/oneccl.sha256 && \
-    bash "${ONECCL_INSTALLER}" -a --silent --eula accept && \
+    bash "${ONECCL_INSTALLER}" -s -x -f /tmp && \
+    ONECCL_CUP="/tmp/${ONECCL_INSTALLER%.sh}/packages/intel.oneapi.lin.ccl.runtime,v=2021.15.9+13/cupPayload.cup" && \
+    ONECCL_DST="/tmp/oneccl-runtime" && \
+    python3 -m zipfile -e "${ONECCL_CUP}" "${ONECCL_DST}" && \
+    ONECCL_LIB="${ONECCL_DST}/_installdir/ccl/2021.15/lib" && \
+    rm -f "${ONECCL_LIB}/libccl.so" "${ONECCL_LIB}/libccl.so.1" "${ONECCL_LIB}/libccl_openmp.so" "${ONECCL_LIB}/libccl_openmp.so.0" && \
+    ln -sf libccl.so.1 "${ONECCL_LIB}/libccl.so" && \
+    ln -sf libccl.so.1.0 "${ONECCL_LIB}/libccl.so.1" && \
+    ln -sf libccl_openmp.so.0 "${ONECCL_LIB}/libccl_openmp.so" && \
+    ln -sf libccl_openmp.so.0.1 "${ONECCL_LIB}/libccl_openmp.so.0" && \
+    ONECCL_CPU_LIB="${ONECCL_DST}/_installdir/ccl/2021.15/lib/ccl/cpu/lib" && \
+    rm -f "${ONECCL_CPU_LIB}/libccl.so" "${ONECCL_CPU_LIB}/libccl.so.1" "${ONECCL_CPU_LIB}/libccl_openmp.so" "${ONECCL_CPU_LIB}/libccl_openmp.so.0" && \
+    ln -sf libccl.so.1 "${ONECCL_CPU_LIB}/libccl.so" && \
+    ln -sf libccl.so.1.0 "${ONECCL_CPU_LIB}/libccl.so.1" && \
+    ln -sf libccl_openmp.so.0 "${ONECCL_CPU_LIB}/libccl_openmp.so" && \
+    ln -sf libccl_openmp.so.0.1 "${ONECCL_CPU_LIB}/libccl_openmp.so.0" && \
+    mkdir -p /opt/intel/oneapi/ccl && \
+    rm -rf /opt/intel/oneapi/ccl/2021.15 && \
+    cp -a /tmp/oneccl-runtime/_installdir/ccl/2021.15 /opt/intel/oneapi/ccl/ && \
     rm "${ONECCL_INSTALLER}" && \
     echo "source /opt/intel/oneapi/setvars.sh --force" >> /root/.bashrc && \
     echo "source /opt/intel/oneapi/ccl/2021.15/env/vars.sh --force" >> /root/.bashrc && \
     rm -f /opt/intel/oneapi/ccl/latest && \
     ln -s /opt/intel/oneapi/ccl/2021.15 /opt/intel/oneapi/ccl/latest && \
+    rm -rf "/tmp/${ONECCL_INSTALLER%.sh}" /tmp/oneccl-runtime && \
     pip install /wheels/vllm-*.whl --extra-index-url https://download.pytorch.org/whl/xpu && \
     pip install --no-deps --force-reinstall \
         /wheels/custom_esimd_kernels_vllm-*.whl \
@@ -187,6 +205,13 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     pip uninstall -y triton triton-xpu || true && \
     pip install --no-deps triton-xpu==3.7.0 \
         --extra-index-url https://download.pytorch.org/whl/xpu && \
+    pip uninstall -y oneccl oneccl-devel || true && \
+    rm -f /opt/venv/lib/libccl.so /opt/venv/lib/libccl.so.1 /opt/venv/lib/libccl.so.1.0 \
+        /opt/venv/lib/libccl_openmp.so /opt/venv/lib/libccl_openmp.so.0 /opt/venv/lib/libccl_openmp.so.0.1 && \
+    ln -sf /opt/intel/oneapi/ccl/2021.15/lib/libccl.so.1.0 /opt/venv/lib/libccl.so.1 && \
+    ln -sf /opt/venv/lib/libccl.so.1 /opt/venv/lib/libccl.so && \
+    ln -sf /opt/intel/oneapi/ccl/2021.15/lib/libccl_openmp.so.0.1 /opt/venv/lib/libccl_openmp.so.0 && \
+    ln -sf /opt/venv/lib/libccl_openmp.so.0 /opt/venv/lib/libccl_openmp.so && \
     TRITON=/opt/venv/lib/python3.12/site-packages/triton && \
     strip --strip-debug ${TRITON}/_C/libtriton.so && \
     rm -f ${TRITON}/plugins/libMLIRDialectPlugin.so.22.0git && \
@@ -194,4 +219,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 # --- entrypoint: oneCCL 2021.15 is preloaded via LD_PRELOAD to avoid torch's
 #     /opt/venv/lib libccl.so.1 taking precedence due to libtorch_xpu.so RPATH. ---
+ENV LD_PRELOAD="/opt/intel/oneapi/ccl/2021.15/lib/libccl.so.1"
+
 ENTRYPOINT ["bash", "-c", "exec vllm serve \"$@\"", "--"]

--- a/vllm/docker/Dockerfile
+++ b/vllm/docker/Dockerfile
@@ -194,6 +194,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     echo "source /opt/intel/oneapi/ccl/2021.15/env/vars.sh --force" >> /root/.bashrc && \
     rm -f /opt/intel/oneapi/ccl/latest && \
     ln -s /opt/intel/oneapi/ccl/2021.15 /opt/intel/oneapi/ccl/latest && \
+    find /opt/intel/oneapi/ccl -mindepth 1 -maxdepth 1 -type d -not -name 2021.15 -exec rm -rf {} + && \
     rm -rf "/tmp/${ONECCL_INSTALLER%.sh}" /tmp/oneccl-runtime && \
     pip install /wheels/vllm-*.whl --extra-index-url https://download.pytorch.org/whl/xpu && \
     pip install --no-deps --force-reinstall \

--- a/vllm/docker/Dockerfile.dev
+++ b/vllm/docker/Dockerfile.dev
@@ -125,6 +125,7 @@ RUN curl -fL --retry 3 -o "${ONECCL_INSTALLER}" "https://github.com/uxlfoundatio
     echo "source /opt/intel/oneapi/ccl/2021.15/env/vars.sh --force" >> /root/.bashrc && \
     rm -f /opt/intel/oneapi/ccl/latest && \
     ln -s /opt/intel/oneapi/ccl/2021.15 /opt/intel/oneapi/ccl/latest && \
+    find /opt/intel/oneapi/ccl -mindepth 1 -maxdepth 1 -type d -not -name 2021.15 -exec rm -rf {} + && \
     rm -rf "/tmp/${ONECCL_INSTALLER%.sh}" /tmp/oneccl-runtime
 
 # ---------------------------------------------------------------------------

--- a/vllm/docker/Dockerfile.dev
+++ b/vllm/docker/Dockerfile.dev
@@ -52,7 +52,6 @@ ENV VIRTUAL_ENV=/opt/venv \
     VLLM_TARGET_DEVICE=xpu \
     WHEELS=/wheels \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
-    LD_PRELOAD="/opt/intel/oneapi/ccl/2021.15/lib/libccl.so.1" \
     VLLM_QUANTIZE_Q40_LIB="/opt/venv/lib/python3.12/site-packages/vllm_int4_for_multi_arc.so" \
     VLLM_OFFLOAD_WEIGHTS_BEFORE_QUANT=1 \
     VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
@@ -102,12 +101,31 @@ RUN curl -fL --retry 3 -o "${ONECCL_INSTALLER}" "https://github.com/uxlfoundatio
     printf "%s  %s\n" "${ONECCL_INSTALLER_SHA256}" "${ONECCL_INSTALLER}" > /tmp/oneccl.sha256 && \
     sha256sum -c /tmp/oneccl.sha256 && \
     rm -f /tmp/oneccl.sha256 && \
-    bash "${ONECCL_INSTALLER}" -a --silent --eula accept && \
+    bash "${ONECCL_INSTALLER}" -s -x -f /tmp && \
+    ONECCL_CUP="/tmp/${ONECCL_INSTALLER%.sh}/packages/intel.oneapi.lin.ccl.runtime,v=2021.15.9+13/cupPayload.cup" && \
+    ONECCL_DST="/tmp/oneccl-runtime" && \
+    python3 -m zipfile -e "${ONECCL_CUP}" "${ONECCL_DST}" && \
+    ONECCL_LIB="${ONECCL_DST}/_installdir/ccl/2021.15/lib" && \
+    rm -f "${ONECCL_LIB}/libccl.so" "${ONECCL_LIB}/libccl.so.1" "${ONECCL_LIB}/libccl_openmp.so" "${ONECCL_LIB}/libccl_openmp.so.0" && \
+    ln -sf libccl.so.1 "${ONECCL_LIB}/libccl.so" && \
+    ln -sf libccl.so.1.0 "${ONECCL_LIB}/libccl.so.1" && \
+    ln -sf libccl_openmp.so.0 "${ONECCL_LIB}/libccl_openmp.so" && \
+    ln -sf libccl_openmp.so.0.1 "${ONECCL_LIB}/libccl_openmp.so.0" && \
+    ONECCL_CPU_LIB="${ONECCL_DST}/_installdir/ccl/2021.15/lib/ccl/cpu/lib" && \
+    rm -f "${ONECCL_CPU_LIB}/libccl.so" "${ONECCL_CPU_LIB}/libccl.so.1" "${ONECCL_CPU_LIB}/libccl_openmp.so" "${ONECCL_CPU_LIB}/libccl_openmp.so.0" && \
+    ln -sf libccl.so.1 "${ONECCL_CPU_LIB}/libccl.so" && \
+    ln -sf libccl.so.1.0 "${ONECCL_CPU_LIB}/libccl.so.1" && \
+    ln -sf libccl_openmp.so.0 "${ONECCL_CPU_LIB}/libccl_openmp.so" && \
+    ln -sf libccl_openmp.so.0.1 "${ONECCL_CPU_LIB}/libccl_openmp.so.0" && \
+    mkdir -p /opt/intel/oneapi/ccl && \
+    rm -rf /opt/intel/oneapi/ccl/2021.15 && \
+    cp -a /tmp/oneccl-runtime/_installdir/ccl/2021.15 /opt/intel/oneapi/ccl/ && \
     rm "${ONECCL_INSTALLER}" && \
     echo "source /opt/intel/oneapi/setvars.sh --force" >> /root/.bashrc && \
     echo "source /opt/intel/oneapi/ccl/2021.15/env/vars.sh --force" >> /root/.bashrc && \
     rm -f /opt/intel/oneapi/ccl/latest && \
-    ln -s /opt/intel/oneapi/ccl/2021.15 /opt/intel/oneapi/ccl/latest
+    ln -s /opt/intel/oneapi/ccl/2021.15 /opt/intel/oneapi/ccl/latest && \
+    rm -rf "/tmp/${ONECCL_INSTALLER%.sh}" /tmp/oneccl-runtime
 
 # ---------------------------------------------------------------------------
 # vLLM v0.21.0 + multi-arc patch  ->  EDITABLE install (source kept at
@@ -181,8 +199,21 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     pip install --no-deps triton-xpu==3.7.0 \
         --extra-index-url https://download.pytorch.org/whl/xpu
 
+# Replace torch-bundled oneCCL stubs in /opt/venv/lib with links to oneCCL 2021.15.
+RUN set -eo pipefail && \
+    pip uninstall -y oneccl oneccl-devel || true && \
+    rm -f /opt/venv/lib/libccl.so /opt/venv/lib/libccl.so.1 /opt/venv/lib/libccl.so.1.0 \
+        /opt/venv/lib/libccl_openmp.so /opt/venv/lib/libccl_openmp.so.0 /opt/venv/lib/libccl_openmp.so.0.1 && \
+    ln -sf /opt/intel/oneapi/ccl/2021.15/lib/libccl.so.1.0 /opt/venv/lib/libccl.so.1 && \
+    ln -sf /opt/venv/lib/libccl.so.1 /opt/venv/lib/libccl.so && \
+    ln -sf /opt/intel/oneapi/ccl/2021.15/lib/libccl_openmp.so.0.1 /opt/venv/lib/libccl_openmp.so.0 && \
+    ln -sf /opt/venv/lib/libccl_openmp.so.0 /opt/venv/lib/libccl_openmp.so
+
 # Component inventory in the build log for sanity.
 RUN pip list 2>/dev/null | grep -iE "^(vllm|torch|triton|transformers|bigdl|accelerate)" || true
+
+# Ensure runtime resolves oneCCL 2021.15 before torch RPATH candidates.
+ENV LD_PRELOAD="/opt/intel/oneapi/ccl/2021.15/lib/libccl.so.1"
 
 # --- dev default: interactive login shell (oneAPI env auto-sourced by the base).
 #     Override with `docker run ... vllm serve <model> ...` to serve. ---


### PR DESCRIPTION
## Summary
- update `vllm/docker/Dockerfile` and `vllm/docker/Dockerfile.dev` to avoid oneCCL installer failure on non-empty `/opt/intel/oneapi`
- extract oneCCL 2021.15 runtime payload, install into `/opt/intel/oneapi/ccl/2021.15`, and keep `latest` symlink pinned to `2021.15`
- replace `/opt/venv/lib/libccl*` links to point to oneCCL 2021.15 after uninstalling pip oneccl wheels
- keep `LD_PRELOAD=/opt/intel/oneapi/ccl/2021.15/lib/libccl.so.1` as additional runtime guard

## Motivation
Ensure vLLM worker processes resolve `libccl.so.1` to oneCCL 2021.15 (`/opt/intel/oneapi/ccl/2021.15/lib/libccl.so.1.0`) consistently.