### PR TITLE
[XPU] Harden fused GDN recurrent state updates

### DIFF
--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_lgrf.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_lgrf.sycl
@@ -19,6 +19,97 @@ static inline sycl::queue& get_device_queue(const at::Tensor& tensor) {
     return c10::xpu::getCurrentXPUStream(tensor.device().index()).queue();
 }
 
+static inline void validate_gdn_conv_args(
+    const at::Tensor& qkvz,
+    const at::Tensor& conv_state,
+    const at::Tensor& conv_weight,
+    const at::Tensor& conv_bias,
+    const at::Tensor& conv_state_indices,
+    const at::Tensor& A_log,
+    const at::Tensor& dt_bias,
+    const at::Tensor& ba,
+    const at::Tensor& ssm_state,
+    const at::Tensor& ssm_state_indices,
+    const at::Tensor& output,
+    const at::Tensor& z_out,
+    int64_t N, int64_t H, int64_t HV, int64_t K, int64_t V) {
+    TORCH_CHECK(N > 0, "gdn_conv_fused: N must be positive");
+    TORCH_CHECK(H > 0 && HV > 0 && HV % H == 0,
+                "gdn_conv_fused: require H>0, HV>0 and HV%H==0");
+    TORCH_CHECK(K == 128 && V == 128,
+                "gdn_conv_fused: only K=V=128 is supported");
+
+    const auto device = qkvz.device();
+    TORCH_CHECK(device.type() == c10::DeviceType::XPU,
+                "gdn_conv_fused: all tensors must be on XPU");
+    const at::Tensor tensors[] = {
+        conv_state, conv_weight, conv_bias, conv_state_indices, A_log,
+        dt_bias, ba, ssm_state, ssm_state_indices, output, z_out};
+    for (const auto& tensor : tensors) {
+        TORCH_CHECK(tensor.device() == device,
+                    "gdn_conv_fused: all tensors must be on the same XPU device");
+    }
+
+    const at::Tensor fp16_tensors[] = {
+        qkvz, conv_state, conv_weight, conv_bias, A_log, dt_bias,
+        ba, ssm_state, output, z_out};
+    for (const auto& tensor : fp16_tensors) {
+        TORCH_CHECK(tensor.scalar_type() == at::kHalf,
+                    "gdn_conv_fused: all data/state/output tensors must be FP16");
+    }
+    TORCH_CHECK(conv_state_indices.scalar_type() == at::kInt &&
+                    ssm_state_indices.scalar_type() == at::kInt,
+                "gdn_conv_fused: state indices must be int32");
+
+    const int64_t dim = 2 * H * K + HV * V;
+    const int64_t qkvz_dim = 2 * H * K + 2 * HV * V;
+    TORCH_CHECK(qkvz.dim() == 2 && qkvz.size(0) >= N &&
+                    qkvz.size(1) >= qkvz_dim && qkvz.is_contiguous(),
+                "gdn_conv_fused: qkvz must be contiguous [>=N, >=", qkvz_dim, "]");
+    TORCH_CHECK(ba.dim() == 2 && ba.size(0) >= N && ba.size(1) >= 2 * HV &&
+                    ba.is_contiguous(),
+                "gdn_conv_fused: ba must be contiguous [>=N, >=2*HV]");
+    TORCH_CHECK(conv_weight.dim() == 2 && conv_weight.size(0) >= dim &&
+                    conv_weight.size(1) == 4 && conv_weight.is_contiguous(),
+                "gdn_conv_fused: conv_weight must be contiguous [>=dim, 4]");
+    TORCH_CHECK(conv_bias.dim() == 1 && conv_bias.numel() >= dim &&
+                    conv_bias.is_contiguous(),
+                "gdn_conv_fused: conv_bias must be contiguous [>=dim]");
+    TORCH_CHECK(A_log.dim() == 1 && A_log.numel() >= HV && A_log.is_contiguous(),
+                "gdn_conv_fused: A_log must be contiguous [>=HV]");
+    TORCH_CHECK(dt_bias.dim() == 1 && dt_bias.numel() >= HV &&
+                    dt_bias.is_contiguous(),
+                "gdn_conv_fused: dt_bias must be contiguous [>=HV]");
+    TORCH_CHECK(conv_state_indices.dim() == 1 &&
+                    conv_state_indices.numel() >= N &&
+                    conv_state_indices.is_contiguous(),
+                "gdn_conv_fused: conv_state_indices must be contiguous [>=N]");
+    TORCH_CHECK(ssm_state_indices.dim() == 1 &&
+                    ssm_state_indices.numel() >= N &&
+                    ssm_state_indices.is_contiguous(),
+                "gdn_conv_fused: ssm_state_indices must be contiguous [>=N]");
+
+    TORCH_CHECK(conv_state.dim() == 3 && conv_state.size(0) > 0 &&
+                    conv_state.size(1) == 3 && conv_state.size(2) >= dim &&
+                    conv_state.stride(2) == 1 && conv_state.stride(1) == dim &&
+                    conv_state.stride(0) >= 3 * dim,
+                "gdn_conv_fused: invalid conv_state shape/stride");
+    TORCH_CHECK(ssm_state.dim() == 4 && ssm_state.size(0) > 0 &&
+                    ssm_state.size(1) == HV && ssm_state.size(2) == V &&
+                    ssm_state.size(3) == K && ssm_state.stride(3) == 1 &&
+                    ssm_state.stride(2) == K && ssm_state.stride(1) == V * K &&
+                    ssm_state.stride(0) >= HV * V * K,
+                "gdn_conv_fused: invalid ssm_state shape/stride");
+    TORCH_CHECK(output.dim() == 3 && output.size(0) >= N &&
+                    output.size(1) == HV && output.size(2) == V &&
+                    output.is_contiguous(),
+                "gdn_conv_fused: output must be contiguous [>=N, HV, V]");
+    TORCH_CHECK(z_out.dim() == 3 && z_out.size(0) >= N &&
+                    z_out.size(1) == HV && z_out.size(2) == V &&
+                    z_out.is_contiguous(),
+                "gdn_conv_fused: z_out must be contiguous [>=N, HV, V]");
+}
+
 at::Tensor esimd_gdn_conv_fused(
     at::Tensor qkvz,                // [N, qkvz_dim] fp16 — projected_states_qkvz
     at::Tensor conv_state,           // [num_cache, 3, 2048] fp16, strided dim0
@@ -36,6 +127,10 @@ at::Tensor esimd_gdn_conv_fused(
     int64_t K, int64_t V,
     double scale)
 {
+    validate_gdn_conv_args(
+        qkvz, conv_state, conv_weight, conv_bias, conv_state_indices,
+        A_log, dt_bias, ba, ssm_state, ssm_state_indices, output, z_out,
+        N, H, HV, K, V);
     auto& dpcpp_queue = get_device_queue(qkvz);
 
     // Extract strides (in fp16 elements)
@@ -64,6 +159,7 @@ at::Tensor esimd_gdn_conv_fused(
         p_sstate, p_ssidx, p_out, p_zout,
         (int)N, (int)H, (int)HV, (int)K, (int)V,
         (float)scale, conv_stride0, ssm_stride0,
+        (int)conv_state.size(0), (int)ssm_state.size(0),
         dpcpp_queue);
 
     return output;
@@ -86,6 +182,10 @@ at::Tensor esimd_gdn_conv_fused_seq(
     int64_t K, int64_t V,
     double scale)
 {
+    validate_gdn_conv_args(
+        qkvz, conv_state, conv_weight, conv_bias, conv_state_indices,
+        A_log, dt_bias, ba, ssm_state, ssm_state_indices, output, z_out,
+        N, H, HV, K, V);
     auto& dpcpp_queue = get_device_queue(qkvz);
 
     int64_t qkvz_stride0 = qkvz.stride(0);
@@ -112,6 +212,7 @@ at::Tensor esimd_gdn_conv_fused_seq(
         p_sstate, p_ssidx, p_out, p_zout,
         (int)N, (int)H, (int)HV, (int)K, (int)V,
         (float)scale, conv_stride0, ssm_stride0,
+        (int)conv_state.size(0), (int)ssm_state.size(0),
         dpcpp_queue);
 
     return output;

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/gdn_conv_fused.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/gdn_conv_fused.h
@@ -68,11 +68,9 @@ ESIMD_INLINE float gdn_dot128(simd<float, 64> a_lo, simd<float, 64> a_hi,
 }
 
 ESIMD_INLINE float gdn_load_fp16_scalar(const fp16* base, int64_t idx) {
-    int64_t aligned = idx & ~15;
-    int lane = (int)(idx & 15);
-    simd<fp16, 16> chunk = block_load<fp16, 16>(base + aligned);
-    simd<float, 16> chunk_f32 = chunk;
-    return chunk_f32[lane];
+    simd<fp16, 1> value = block_load<fp16, 1>(base + idx);
+    simd<float, 1> value_f32 = value;
+    return value_f32[0];
 }
 
 /* ---- SLM layout per WG (byte offsets) ---- */
@@ -104,7 +102,7 @@ ESIMD_INLINE void gdn_conv_fused_kernel_v9(
     fp16* __restrict__ z_out_ptr,
     int N, int H, int HV, int gdn_K, int gdn_V,
     float attn_scale, int64_t conv_stride0, int64_t ssm_stride0,
-    int inline_conv_shift,   // 1 = do conv_state shift inline (safe when N*HV<=32)
+    int num_conv_states, int num_ssm_states,
     nd_item<3>& ndi)
 {
     slm_init<2048>();
@@ -131,6 +129,19 @@ ESIMD_INLINE void gdn_conv_fused_kernel_v9(
 
     const int conv_idx = conv_state_indices_ptr[seq_idx];
     const int ssm_idx = ssm_state_indices_ptr[seq_idx];
+
+    if (conv_idx < 0 || conv_idx >= num_conv_states ||
+        ssm_idx < 0 || ssm_idx >= num_ssm_states) {
+        for (int i = tid; i < HV * gdn_V; i += 32) {
+            block_store<fp16, 1>(
+                output_ptr + (int64_t)seq_idx * HV * gdn_V + i,
+                simd<fp16, 1>(0));
+            block_store<fp16, 1>(
+                z_out_ptr + (int64_t)seq_idx * HV * gdn_V + i,
+                simd<fp16, 1>(0));
+        }
+        return;
+    }
 
     // ---- Compute qkvz read offset and conv_state chunk_start ----
     const int group_dim = gdn_K + gdn_K + heads_per_group * gdn_V * 2;
@@ -357,24 +368,6 @@ ESIMD_INLINE void gdn_conv_fused_kernel_v9(
             out, simd<fp16, 4>(0.0f));
     }
 
-    // ---- Phase 3: conv_state shift (inline path, only when N*HV <= 32) ----
-    // When N*HV > 32, the shift is done by a separate kernel to avoid a
-    // cross-WG race: hv==0's writes could land before a later-scheduled WG's
-    // Phase 1 reads for the same seq_idx.
-    if (inline_conv_shift && conv_idx >= 0 && hv == 0 && is_valid) {
-        // lo chunk (valid threads only)
-        block_store<fp16, 64>(cstate_base + 0 * dim + chunk_start, simd<fp16, 64>(s1));
-        block_store<fp16, 64>(cstate_base + 1 * dim + chunk_start, simd<fp16, 64>(s2));
-        block_store<fp16, 64>(cstate_base + 2 * dim + chunk_start, x_fp16);
-
-        // hi chunk (v-threads only, when double_v)
-        if (double_v && tid >= 4 * H) {
-            block_store<fp16, 64>(cstate_base + 0 * dim + chunk_start_hi, simd<fp16, 64>(s1_hi));
-            block_store<fp16, 64>(cstate_base + 1 * dim + chunk_start_hi, simd<fp16, 64>(s2_hi));
-            block_store<fp16, 64>(cstate_base + 2 * dim + chunk_start_hi, x_fp16_hi);
-        }
-    }
-
     // ---- z extraction: v-threads copy z from qkvz to z_out ----
     if (tid >= 4 * H && is_valid) {
         int v_tid = tid - 4 * H;
@@ -431,6 +424,7 @@ ESIMD_INLINE void conv_state_shift_kernel(
     fp16* __restrict__ conv_state_ptr,
     const int* __restrict__ conv_state_indices_ptr,
     int N, int H, int HV, int gdn_K, int gdn_V,
+    int num_conv_states,
     int64_t conv_stride0,
     nd_item<3>& ndi)
 {
@@ -438,7 +432,7 @@ ESIMD_INLINE void conv_state_shift_kernel(
     const int tid = ndi.get_local_id(2);
 
     const int conv_idx = conv_state_indices_ptr[seq_idx];
-    if (conv_idx < 0) return;
+    if (conv_idx < 0 || conv_idx >= num_conv_states) return;
 
     const int heads_per_group = HV / H;
     const int dim = 2 * H * gdn_K + HV * gdn_V;
@@ -533,21 +527,16 @@ inline void gdn_conv_fused_host(
     float scale,
     int64_t conv_stride0,
     int64_t ssm_stride0,
+    int num_conv_states,
+    int num_ssm_states,
     sycl::queue& q)
 {
     constexpr int WG_SIZE = 32;
-    const int total_wgs = N * HV;
-
-    // When total WGs fit in a single scheduling wave (<=32), all WGs run
-    // concurrently so the hv==0 inline conv_state shift is safe.  Otherwise
-    // split into two kernels to avoid the cross-WG read/write race.
-    const int inline_shift = (total_wgs <= WG_SIZE) ? 1 : 0;
-
     sycl::nd_range<3> Range(
         sycl::range<3>(N, HV, WG_SIZE),
         sycl::range<3>(1, 1, WG_SIZE));
 
-    q.submit([&](sycl::handler& cgh) {
+    auto main_event = q.submit([&](sycl::handler& cgh) {
         cgh.parallel_for(Range, [=](sycl::nd_item<3> ndi) SYCL_ESIMD_KERNEL {
             gdn_conv_fused_kernel_v9(
                 qkvz_ptr, qkvz_stride0, conv_state_ptr,
@@ -556,25 +545,23 @@ inline void gdn_conv_fused_host(
                 ssm_state_ptr, ssm_state_indices_ptr,
                 output_ptr, z_out_ptr,
                 N, H, HV, K, V, scale, conv_stride0, ssm_stride0,
-                inline_shift, ndi);
+                num_conv_states, num_ssm_states, ndi);
         });
     });
 
-    if (!inline_shift) {
-        // Separate kernel for conv_state shift — runs after kernel 1
-        // completes (in-order queue guarantees ordering).
-        sycl::nd_range<3> ShiftRange(
-            sycl::range<3>(N, 1, WG_SIZE),
-            sycl::range<3>(1, 1, WG_SIZE));
+    sycl::nd_range<3> ShiftRange(
+        sycl::range<3>(N, 1, WG_SIZE),
+        sycl::range<3>(1, 1, WG_SIZE));
 
-        q.submit([&](sycl::handler& cgh) {
-            cgh.parallel_for(ShiftRange, [=](sycl::nd_item<3> ndi) SYCL_ESIMD_KERNEL {
-                conv_state_shift_kernel(
-                    qkvz_ptr, qkvz_stride0, conv_state_ptr,
-                    conv_state_indices_ptr,
-                    N, H, HV, K, V,
-                    conv_stride0, ndi);
-            });
+    q.submit([&](sycl::handler& cgh) {
+        cgh.depends_on(main_event);
+        cgh.parallel_for(ShiftRange, [=](sycl::nd_item<3> ndi) SYCL_ESIMD_KERNEL {
+            conv_state_shift_kernel(
+                qkvz_ptr, qkvz_stride0, conv_state_ptr,
+                conv_state_indices_ptr,
+                N, H, HV, K, V,
+                num_conv_states,
+                conv_stride0, ndi);
         });
-    }
+    });
 }

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/gdn_conv_fused_seq.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/gdn_conv_fused_seq.h
@@ -85,11 +85,13 @@ ESIMD_INLINE float gdn_dot128_seq(simd<float, 64> a_lo, simd<float, 64> a_hi,
 }
 
 ESIMD_INLINE float gdn_load_fp16_scalar_seq(const fp16* base, int64_t idx) {
-    int64_t aligned = idx & ~15;
-    int lane = (int)(idx & 15);
-    simd<fp16, 16> chunk = block_load<fp16, 16>(base + aligned);
-    simd<float, 16> chunk_f32 = chunk;
-    return chunk_f32[lane];
+    // A 16-element aligned block load is not safe for tensors whose logical
+    // tail is not padded to 16 elements (for example HV=12 under TP4).  The
+    // unused lanes still participate in the memory transaction and can read
+    // beyond the allocation.  Use a real scalar transaction instead.
+    simd<fp16, 1> value = block_load<fp16, 1>(base + idx);
+    simd<float, 1> value_f32 = value;
+    return value_f32[0];
 }
 
 /* ---- SLM layout per WG (byte offsets, same as original) ---- */
@@ -121,7 +123,7 @@ ESIMD_INLINE void gdn_conv_fused_seq_kernel(
     fp16* __restrict__ z_out_ptr,
     int N, int H, int HV, int gdn_K, int gdn_V,
     float attn_scale, int64_t conv_stride0, int64_t ssm_stride0,
-    int inline_conv_shift,   // 1 = do conv_state shift inline (safe when N*HV<=32)
+    int num_conv_states, int num_ssm_states,
     nd_item<3>& ndi)
 {
     slm_init<2048>();
@@ -139,6 +141,19 @@ ESIMD_INLINE void gdn_conv_fused_seq_kernel(
 
     const int conv_idx = conv_state_indices_ptr[seq_idx];
     const int ssm_idx = ssm_state_indices_ptr[seq_idx];
+
+    if (conv_idx < 0 || conv_idx >= num_conv_states ||
+        ssm_idx < 0 || ssm_idx >= num_ssm_states) {
+        for (int i = tid; i < HV * gdn_V; i += WG_SIZE) {
+            block_store<fp16, 1>(
+                output_ptr + (int64_t)seq_idx * HV * gdn_V + i,
+                simd<fp16, 1>(0));
+            block_store<fp16, 1>(
+                z_out_ptr + (int64_t)seq_idx * HV * gdn_V + i,
+                simd<fp16, 1>(0));
+        }
+        return;
+    }
 
     // ---- Sequential layout base offsets ----
     const int dim = 2 * H * gdn_K + HV * gdn_V;  // conv_state row width
@@ -404,25 +419,6 @@ ESIMD_INLINE void gdn_conv_fused_seq_kernel(
         }
     }
 
-    // ---- Phase 3: conv_state shift (inline path, only when N*HV <= WG_SIZE) ----
-    // When N*HV > WG_SIZE, the shift is done by a separate kernel to avoid a
-    // cross-WG race: one WG's shift writes could land before another WG's
-    // Phase 1 reads for the same seq_idx.
-    // Uses register-cached s1, s2, x_fp16 from Phase 1 (not re-read from memory).
-    if (inline_conv_shift && conv_idx >= 0 && hv == 0 && !v_oob) {
-        // lo chunk (all threads)
-        block_store<fp16, 64>(cstate_base + 0 * dim + chunk_start, simd<fp16, 64>(s1));
-        block_store<fp16, 64>(cstate_base + 1 * dim + chunk_start, simd<fp16, 64>(s2));
-        block_store<fp16, 64>(cstate_base + 2 * dim + chunk_start, x_fp16);
-
-        // hi chunk (v-threads only, when double_v)
-        if (double_v && tid >= 4 * H) {
-            block_store<fp16, 64>(cstate_base + 0 * dim + chunk_start_hi, simd<fp16, 64>(s1_hi));
-            block_store<fp16, 64>(cstate_base + 1 * dim + chunk_start_hi, simd<fp16, 64>(s2_hi));
-            block_store<fp16, 64>(cstate_base + 2 * dim + chunk_start_hi, x_fp16_hi);
-        }
-    }
-
     // ---- z extraction: v-threads copy z from SEQUENTIAL qkvz to z_out ----
     if (tid >= 4 * H && !v_oob) {
         int v_tid = tid - 4 * H;
@@ -488,6 +484,7 @@ ESIMD_INLINE void gdn_conv_fused_seq_kernel_large_h(
     fp16* __restrict__ z_out_ptr,
     int N, int H, int HV, int gdn_K, int gdn_V,
     float attn_scale, int64_t conv_stride0, int64_t ssm_stride0,
+    int num_conv_states, int num_ssm_states,
     nd_item<3>& ndi)
 {
     slm_init<2048>();
@@ -502,6 +499,19 @@ ESIMD_INLINE void gdn_conv_fused_seq_kernel_large_h(
 
     const int conv_idx = conv_state_indices_ptr[seq_idx];
     const int ssm_idx = ssm_state_indices_ptr[seq_idx];
+
+    if (conv_idx < 0 || conv_idx >= num_conv_states ||
+        ssm_idx < 0 || ssm_idx >= num_ssm_states) {
+        for (int i = tid; i < HV * gdn_V; i += WG_SIZE) {
+            block_store<fp16, 1>(
+                output_ptr + (int64_t)seq_idx * HV * gdn_V + i,
+                simd<fp16, 1>(0));
+            block_store<fp16, 1>(
+                z_out_ptr + (int64_t)seq_idx * HV * gdn_V + i,
+                simd<fp16, 1>(0));
+        }
+        return;
+    }
 
     const int dim = 2 * H * gdn_K + HV * gdn_V;
     const int q_base = 0;
@@ -648,6 +658,7 @@ ESIMD_INLINE void conv_state_shift_seq_multipass_kernel(
     fp16* __restrict__ conv_state_ptr,
     const int* __restrict__ conv_state_indices_ptr,
     int N, int H, int HV, int gdn_K, int gdn_V,
+    int num_conv_states,
     int64_t conv_stride0,
     nd_item<3>& ndi)
 {
@@ -655,7 +666,7 @@ ESIMD_INLINE void conv_state_shift_seq_multipass_kernel(
     const int tid = ndi.get_local_id(2);
 
     const int conv_idx = conv_state_indices_ptr[seq_idx];
-    if (conv_idx < 0) return;
+    if (conv_idx < 0 || conv_idx >= num_conv_states) return;
 
     const int dim = 2 * H * gdn_K + HV * gdn_V;
     const int num_chunks = (dim + 63) / 64;
@@ -695,6 +706,7 @@ ESIMD_INLINE void conv_state_shift_seq_kernel(
     fp16* __restrict__ conv_state_ptr,
     const int* __restrict__ conv_state_indices_ptr,
     int N, int H, int HV, int gdn_K, int gdn_V,
+    int num_conv_states,
     int64_t conv_stride0,
     nd_item<3>& ndi)
 {
@@ -702,7 +714,7 @@ ESIMD_INLINE void conv_state_shift_seq_kernel(
     const int tid = ndi.get_local_id(2);
 
     const int conv_idx = conv_state_indices_ptr[seq_idx];
-    if (conv_idx < 0) return;
+    if (conv_idx < 0 || conv_idx >= num_conv_states) return;
 
     // Sequential layout offsets (same as main kernel)
     const int dim = 2 * H * gdn_K + HV * gdn_V;
@@ -782,16 +794,14 @@ inline void gdn_conv_fused_seq_dispatch(
     fp16* output_ptr, fp16* z_out_ptr,
     int N, int H, int HV, int K, int V, float scale,
     int64_t conv_stride0, int64_t ssm_stride0,
+    int num_conv_states, int num_ssm_states,
     sycl::queue& q)
 {
-    const int total_wgs = N * HV;
-    const int inline_shift = (total_wgs <= WG_SIZE) ? 1 : 0;
-
     sycl::nd_range<3> Range(
         sycl::range<3>(N, HV, WG_SIZE),
         sycl::range<3>(1, 1, WG_SIZE));
 
-    q.submit([&](sycl::handler& cgh) {
+    auto main_event = q.submit([&](sycl::handler& cgh) {
         cgh.parallel_for(Range, [=](sycl::nd_item<3> ndi) SYCL_ESIMD_KERNEL {
             gdn_conv_fused_seq_kernel<WG_SIZE>(
                 qkvz_ptr, qkvz_stride0, conv_state_ptr,
@@ -800,25 +810,28 @@ inline void gdn_conv_fused_seq_dispatch(
                 ssm_state_ptr, ssm_state_indices_ptr,
                 output_ptr, z_out_ptr,
                 N, H, HV, K, V, scale, conv_stride0, ssm_stride0,
-                inline_shift, ndi);
+                num_conv_states, num_ssm_states, ndi);
         });
     });
 
-    if (!inline_shift) {
-        sycl::nd_range<3> ShiftRange(
-            sycl::range<3>(N, 1, WG_SIZE),
-            sycl::range<3>(1, 1, WG_SIZE));
+    // Updating conv_state in the main kernel races with other HV work-groups
+    // that may still be reading the old state.  Always perform the shift in a
+    // second kernel and explicitly encode the dependency for graph replay.
+    sycl::nd_range<3> ShiftRange(
+        sycl::range<3>(N, 1, WG_SIZE),
+        sycl::range<3>(1, 1, WG_SIZE));
 
-        q.submit([&](sycl::handler& cgh) {
-            cgh.parallel_for(ShiftRange, [=](sycl::nd_item<3> ndi) SYCL_ESIMD_KERNEL {
-                conv_state_shift_seq_kernel<WG_SIZE>(
-                    qkvz_ptr, qkvz_stride0, conv_state_ptr,
-                    conv_state_indices_ptr,
-                    N, H, HV, K, V,
-                    conv_stride0, ndi);
-            });
+    q.submit([&](sycl::handler& cgh) {
+        cgh.depends_on(main_event);
+        cgh.parallel_for(ShiftRange, [=](sycl::nd_item<3> ndi) SYCL_ESIMD_KERNEL {
+            conv_state_shift_seq_kernel<WG_SIZE>(
+                qkvz_ptr, qkvz_stride0, conv_state_ptr,
+                conv_state_indices_ptr,
+                N, H, HV, K, V,
+                num_conv_states,
+                conv_stride0, ndi);
         });
-    }
+    });
 }
 
 /* ============================================================
@@ -843,6 +856,8 @@ inline void gdn_conv_fused_seq_host(
     float scale,
     int64_t conv_stride0,
     int64_t ssm_stride0,
+    int num_conv_states,
+    int num_ssm_states,
     sycl::queue& q)
 {
     TORCH_CHECK(HV > 0 && HV % H == 0,
@@ -860,7 +875,8 @@ inline void gdn_conv_fused_seq_host(
             A_log_ptr, dt_bias_ptr, ba_ptr, ba_stride0,
             ssm_state_ptr, ssm_state_indices_ptr,
             output_ptr, z_out_ptr,
-            N, H, HV, K, V, scale, conv_stride0, ssm_stride0, q);
+            N, H, HV, K, V, scale, conv_stride0, ssm_stride0,
+            num_conv_states, num_ssm_states, q);
     } else {
         const int v_slots_64 = 64 - 4 * H;
         if (v_slots_64 > 0 && HV <= v_slots_64) {
@@ -870,7 +886,8 @@ inline void gdn_conv_fused_seq_host(
                 A_log_ptr, dt_bias_ptr, ba_ptr, ba_stride0,
                 ssm_state_ptr, ssm_state_indices_ptr,
                 output_ptr, z_out_ptr,
-                N, H, HV, K, V, scale, conv_stride0, ssm_stride0, q);
+                N, H, HV, K, V, scale, conv_stride0, ssm_stride0,
+                num_conv_states, num_ssm_states, q);
         } else {
             // Large-H path: use specialized kernel that only computes
             // conv1d for the 3 relevant heads per WG.
@@ -882,7 +899,7 @@ inline void gdn_conv_fused_seq_host(
                 sycl::range<3>(N, HV, WG),
                 sycl::range<3>(1, 1, WG));
 
-            q.submit([&](sycl::handler& cgh) {
+            auto main_event = q.submit([&](sycl::handler& cgh) {
                 cgh.parallel_for(Range, [=](sycl::nd_item<3> ndi) SYCL_ESIMD_KERNEL {
                     gdn_conv_fused_seq_kernel_large_h(
                         qkvz_ptr, qkvz_stride0, conv_state_ptr,
@@ -891,7 +908,7 @@ inline void gdn_conv_fused_seq_host(
                         ssm_state_ptr, ssm_state_indices_ptr,
                         output_ptr, z_out_ptr,
                         N, H, HV, K, V, scale, conv_stride0, ssm_stride0,
-                        ndi);
+                        num_conv_states, num_ssm_states, ndi);
                 });
             });
 
@@ -901,11 +918,13 @@ inline void gdn_conv_fused_seq_host(
                 sycl::range<3>(1, 1, WG));
 
             q.submit([&](sycl::handler& cgh) {
+                cgh.depends_on(main_event);
                 cgh.parallel_for(ShiftRange, [=](sycl::nd_item<3> ndi) SYCL_ESIMD_KERNEL {
                     conv_state_shift_seq_multipass_kernel(
                         qkvz_ptr, qkvz_stride0, conv_state_ptr,
                         conv_state_indices_ptr,
                         N, H, HV, K, V,
+                        num_conv_states,
                         conv_stride0, ndi);
                 });
             });

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/torch_extension_lgrf.cc
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/torch_extension_lgrf.cc
@@ -10,25 +10,25 @@
 
 TORCH_LIBRARY_FRAGMENT(custom_esimd_kernels_vllm, m) {
   m.def("esimd_gdn_conv_fused(Tensor qkvz, "
-        "Tensor conv_state, Tensor conv_weight, Tensor conv_bias, "
+        "Tensor(a!) conv_state, Tensor conv_weight, Tensor conv_bias, "
         "Tensor conv_state_indices, "
         "Tensor A_log, Tensor dt_bias, "
         "Tensor ba, "
-        "Tensor ssm_state, Tensor ssm_state_indices, "
-        "Tensor output, Tensor z_out, "
+        "Tensor(b!) ssm_state, Tensor ssm_state_indices, "
+        "Tensor(c!) output, Tensor(d!) z_out, "
         "int N, int H, int HV, int K, int V, "
-        "float scale) -> Tensor");
+        "float scale) -> Tensor(c!)");
   m.impl("esimd_gdn_conv_fused", torch::kXPU, &esimd_gdn_conv_fused);
 
   m.def("esimd_gdn_conv_fused_seq(Tensor qkvz, "
-        "Tensor conv_state, Tensor conv_weight, Tensor conv_bias, "
+        "Tensor(a!) conv_state, Tensor conv_weight, Tensor conv_bias, "
         "Tensor conv_state_indices, "
         "Tensor A_log, Tensor dt_bias, "
         "Tensor ba, "
-        "Tensor ssm_state, Tensor ssm_state_indices, "
-        "Tensor output, Tensor z_out, "
+        "Tensor(b!) ssm_state, Tensor ssm_state_indices, "
+        "Tensor(c!) output, Tensor(d!) z_out, "
         "int N, int H, int HV, int K, int V, "
-        "float scale) -> Tensor");
+        "float scale) -> Tensor(c!)");
   m.impl("esimd_gdn_conv_fused_seq", torch::kXPU, &esimd_gdn_conv_fused_seq);
 }
 

--- a/vllm/custom-esimd-kernels-vllm/tests/test_e2e_gdn_conv_fused_seq.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/test_e2e_gdn_conv_fused_seq.py
@@ -114,9 +114,13 @@ def test_e2e_seq(N=1, num_v_heads_global=32, tp_size=4, num_cache=32, seed=42):
         conv_state=conv_ref, ssm_state=ssm_ref,
         conv_weights=conv_weight, conv_bias=None, activation="silu",
         A_log=A_log, dt_bias=dt_bias,
-        num_prefills=0, num_decodes=N, has_initial_state=None,
+        num_prefills=0, num_decodes=N, num_spec_decodes=0,
+        has_initial_state=None,
         non_spec_query_start_loc=query_start_loc,
+        non_spec_token_indx=None,
         non_spec_state_indices_tensor=state_indices,
+        spec_query_start_loc=None, spec_token_indx=None,
+        spec_state_indices_tensor=None, num_accepted_tokens=None,
         num_actual_tokens=N, tp_size=tp_size,
         reorder_input=False)
     torch.xpu.synchronize()


### PR DESCRIPTION
## Summary

- validate fused GDN tensor devices, dtypes, shapes, strides, dimensions, and state indices before launch
- replace bounds-unsafe aligned 16-element scalar loads with true scalar transactions
- remove the inline `conv_state` shift that can race across HV work-groups
- always run the state shift after the main kernel with an explicit SYCL event dependency, including graph replay
- annotate all mutated state/output tensors in the Torch operator schemas
- update the end-to-end sequential GDN test for the current metadata API

## Correctness and performance tradeoff

The prior small-grid shortcut could update `conv_state` while another work-group was still reading the old state. This PR always uses a second state-shift kernel to make ordering correct. Small workloads therefore gain one kernel submission; larger workloads already used a separate shift kernel. The dependency is explicit rather than relying on queue ordering.

## Scope

This is a kernel-only hardening stage following #569. The operator names and call signatures are unchanged, so no framework PR is required.

## Testing

Not run as part of PR creation.
