### PR TITLE
[XPU] Declare fused GDN state mutations

### DIFF
--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/torch_extension_lgrf.cc
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/torch_extension_lgrf.cc
@@ -10,25 +10,25 @@
 
 TORCH_LIBRARY_FRAGMENT(custom_esimd_kernels_vllm, m) {
   m.def("esimd_gdn_conv_fused(Tensor qkvz, "
-        "Tensor conv_state, Tensor conv_weight, Tensor conv_bias, "
+        "Tensor(a!) conv_state, Tensor conv_weight, Tensor conv_bias, "
         "Tensor conv_state_indices, "
         "Tensor A_log, Tensor dt_bias, "
         "Tensor ba, "
-        "Tensor ssm_state, Tensor ssm_state_indices, "
-        "Tensor output, Tensor z_out, "
+        "Tensor(b!) ssm_state, Tensor ssm_state_indices, "
+        "Tensor(c!) output, Tensor(d!) z_out, "
         "int N, int H, int HV, int K, int V, "
-        "float scale) -> Tensor");
+        "float scale) -> Tensor(c!)");
   m.impl("esimd_gdn_conv_fused", torch::kXPU, &esimd_gdn_conv_fused);
 
   m.def("esimd_gdn_conv_fused_seq(Tensor qkvz, "
-        "Tensor conv_state, Tensor conv_weight, Tensor conv_bias, "
+        "Tensor(a!) conv_state, Tensor conv_weight, Tensor conv_bias, "
         "Tensor conv_state_indices, "
         "Tensor A_log, Tensor dt_bias, "
         "Tensor ba, "
-        "Tensor ssm_state, Tensor ssm_state_indices, "
-        "Tensor output, Tensor z_out, "
+        "Tensor(b!) ssm_state, Tensor ssm_state_indices, "
+        "Tensor(c!) output, Tensor(d!) z_out, "
         "int N, int H, int HV, int K, int V, "
-        "float scale) -> Tensor");
+        "float scale) -> Tensor(c!)");
   m.impl("esimd_gdn_conv_fused_seq", torch::kXPU, &esimd_gdn_conv_fused_seq);
 }
 


### PR DESCRIPTION
## Summary

- mark `conv_state` and `ssm_state` as mutated by both fused GDN operators
- mark `output` and `z_out` as mutated output buffers
- declare the returned tensor as an alias of `output`

## Scope

This PR contains only the Torch mutation/alias schemas extracted from #570. It does not include tensor validation, state-index checks, scalar-load changes, or the separate state-shift kernel.

The operator names and call signatures are unchanged. The current framework does not register fake implementations for these two GDN operators, so no framework change is required for this schema-only update.

## Testing

Not run as part of PR creation. This is a dispatcher contract change and does not alter eager kernel execution.
