### PR TITLE
[XPU][FP8] Reuse block MoE prefill descriptor buffers

### DIFF
--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_moe.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_moe.sycl
@@ -11,6 +11,7 @@
 #include <torch/python.h>
 
 #include <cstdint>
+#include <vector>
 
 #include "esimd_kernels/moe_ops.h"
 #include "esimd_kernels/fp8_moe_gemm.h"
@@ -24,25 +25,45 @@ static inline sycl::queue& get_device_queue(const at::Tensor& tensor) {
 struct MoePrefillTileBuffers {
     at::Tensor experts;
     at::Tensor rows;
-    int64_t capacity = 0;
-    int device_index = -1;
+    int64_t capacity;
+    int device_index;
+    sycl::queue queue;
+
+    MoePrefillTileBuffers(
+            int64_t requested_capacity,
+            const at::Tensor& input,
+            const sycl::queue& current_queue)
+        : experts(at::empty(
+              {requested_capacity}, input.options().dtype(at::kInt))),
+          rows(at::empty(
+              {requested_capacity}, input.options().dtype(at::kInt))),
+          capacity(requested_capacity),
+          device_index(input.device().index()),
+          queue(current_queue) {}
 };
 
-static thread_local MoePrefillTileBuffers s_moe_prefill_tiles;
+// Calls from different host threads already have independent caches. Keep one
+// entry per XPU stream within each thread so asynchronously executing streams
+// never overwrite each other's descriptor storage.
+static thread_local std::vector<MoePrefillTileBuffers> s_moe_prefill_tiles;
 
 static MoePrefillTileBuffers& ensure_moe_prefill_tile_buffers(
-        int64_t capacity, const at::Tensor& input) {
+        int64_t capacity, const at::Tensor& input, const sycl::queue& queue) {
     const int device_index = input.device().index();
-    if (s_moe_prefill_tiles.capacity < capacity ||
-        s_moe_prefill_tiles.device_index != device_index) {
-        s_moe_prefill_tiles.experts = at::empty(
-            {capacity}, input.options().dtype(at::kInt));
-        s_moe_prefill_tiles.rows = at::empty(
-            {capacity}, input.options().dtype(at::kInt));
-        s_moe_prefill_tiles.capacity = capacity;
-        s_moe_prefill_tiles.device_index = device_index;
+    for (auto& buffers : s_moe_prefill_tiles) {
+        if (buffers.device_index != device_index || buffers.queue != queue) {
+            continue;
+        }
+        if (buffers.capacity < capacity) {
+            buffers.experts = at::empty(
+                {capacity}, input.options().dtype(at::kInt));
+            buffers.rows = at::empty(
+                {capacity}, input.options().dtype(at::kInt));
+            buffers.capacity = capacity;
+        }
+        return buffers;
     }
-    return s_moe_prefill_tiles;
+    return s_moe_prefill_tiles.emplace_back(capacity, input, queue);
 }
 
 // ======================== MoE Auxiliary Ops ========================
@@ -204,7 +225,7 @@ at::Tensor esimd_moe_gemm_fp8_blockscale(
         const int64_t tile_capacity =
             (total_tokens + 63) / 64 + num_experts;
         auto& tile_buffers =
-            ensure_moe_prefill_tile_buffers(tile_capacity, input);
+            ensure_moe_prefill_tile_buffers(tile_capacity, input, q);
         auto& tile_experts = tile_buffers.experts;
         auto& tile_rows = tile_buffers.rows;
         fp8_moe_blockscale::build_expert_m_tiles(

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_moe.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel_moe.sycl
@@ -21,6 +21,30 @@ static inline sycl::queue& get_device_queue(const at::Tensor& tensor) {
     return c10::xpu::getCurrentXPUStream(tensor.device().index()).queue();
 }
 
+struct MoePrefillTileBuffers {
+    at::Tensor experts;
+    at::Tensor rows;
+    int64_t capacity = 0;
+    int device_index = -1;
+};
+
+static thread_local MoePrefillTileBuffers s_moe_prefill_tiles;
+
+static MoePrefillTileBuffers& ensure_moe_prefill_tile_buffers(
+        int64_t capacity, const at::Tensor& input) {
+    const int device_index = input.device().index();
+    if (s_moe_prefill_tiles.capacity < capacity ||
+        s_moe_prefill_tiles.device_index != device_index) {
+        s_moe_prefill_tiles.experts = at::empty(
+            {capacity}, input.options().dtype(at::kInt));
+        s_moe_prefill_tiles.rows = at::empty(
+            {capacity}, input.options().dtype(at::kInt));
+        s_moe_prefill_tiles.capacity = capacity;
+        s_moe_prefill_tiles.device_index = device_index;
+    }
+    return s_moe_prefill_tiles;
+}
+
 // ======================== MoE Auxiliary Ops ========================
 
 at::Tensor esimd_moe_topk(
@@ -179,15 +203,14 @@ at::Tensor esimd_moe_gemm_fp8_blockscale(
         // device; the capacity bound avoids a max(rows_per_expert) host sync.
         const int64_t tile_capacity =
             (total_tokens + 63) / 64 + num_experts;
-        auto tile_experts = at::full(
-            {tile_capacity}, (int64_t)num_experts,
-            input.options().dtype(at::kInt));
-        auto tile_rows = at::empty(
-            {tile_capacity}, input.options().dtype(at::kInt));
+        auto& tile_buffers =
+            ensure_moe_prefill_tile_buffers(tile_capacity, input);
+        auto& tile_experts = tile_buffers.experts;
+        auto& tile_rows = tile_buffers.rows;
         fp8_moe_blockscale::build_expert_m_tiles(
             reinterpret_cast<const uint32_t*>(expert_idx.data_ptr()),
             tile_experts.data_ptr<int32_t>(), tile_rows.data_ptr<int32_t>(),
-            (int)num_experts, q);
+            (int)num_experts, (int)tile_capacity, q);
         fp8_moe_blockscale::moe_gemm_fp8_blockscale_prefill_host(
             reinterpret_cast<const fp16*>(input.data_ptr()),
             reinterpret_cast<const uint8_t*>(weight.data_ptr()),

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/fp8_moe_gemm_blockscale.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/fp8_moe_gemm_blockscale.h
@@ -85,6 +85,7 @@ struct build_expert_m_tiles_kernel {
   int32_t* tile_experts;
   int32_t* tile_rows;
   int num_experts;
+  int tile_capacity;
 
   void operator()(sycl::id<1>) const {
     int tile = 0;
@@ -97,17 +98,24 @@ struct build_expert_m_tiles_kernel {
         tile++;
       }
     }
+    // Fill unused descriptors here so the caller does not need a separate
+    // tensor-fill submission. The prefill kernel checks this sentinel before
+    // reading tile_rows.
+    for (; tile < tile_capacity; tile++) {
+      tile_experts[tile] = num_experts;
+    }
   }
 };
 
 inline void build_expert_m_tiles(const uint32_t* expert_idx,
                                  int32_t* tile_experts,
                                  int32_t* tile_rows, int num_experts,
-                                 sycl::queue& q) {
+                                 int tile_capacity, sycl::queue& q) {
   q.submit([&](handler& cgh) {
     cgh.parallel_for(sycl::range<1>(1),
                      build_expert_m_tiles_kernel{expert_idx, tile_experts,
-                                                 tile_rows, num_experts});
+                                                 tile_rows, num_experts,
+                                                 tile_capacity});
   });
 }
 


### PR DESCRIPTION
## Summary

- reuse `tile_experts` and `tile_rows` tensors across block-scaled MoE prefill calls
- fill unused expert descriptors inside the descriptor-builder kernel, removing the separate tensor-fill submission
- grow cached tensors only when the required tile capacity increases
- isolate cached buffers by host thread, XPU device, and SYCL queue so concurrent streams cannot overwrite one another

## Stream safety

A single thread-local buffer is not sufficient because one host thread can enqueue work on multiple XPU streams while prior work remains asynchronous. This PR keeps a persistent cache entry for each `(device_index, sycl::queue)` pair. Calls on the same stream reuse ordered storage; calls on different streams use distinct tensors.

## Scope

This is a kernel-only performance optimization following #566 and the schema-only #572. The existing operator and framework dispatch are unchanged.

## Testing

Not run as part of PR creation.
