### PR TITLE
docker: remove global LD_PRELOAD from vLLM images

### DIFF
--- a/vllm/docker/Dockerfile
+++ b/vllm/docker/Dockerfile
@@ -218,8 +218,4 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     rm -f ${TRITON}/plugins/libMLIRDialectPlugin.so.22.0git && \
     ln -s libMLIRDialectPlugin.so ${TRITON}/plugins/libMLIRDialectPlugin.so.22.0git
 
-# --- entrypoint: oneCCL 2021.15 is preloaded via LD_PRELOAD to avoid torch's
-#     /opt/venv/lib libccl.so.1 taking precedence due to libtorch_xpu.so RPATH. ---
-ENV LD_PRELOAD="/opt/intel/oneapi/ccl/2021.15/lib/libccl.so.1"
-
 ENTRYPOINT ["bash", "-c", "exec vllm serve \"$@\"", "--"]

--- a/vllm/docker/Dockerfile.dev
+++ b/vllm/docker/Dockerfile.dev
@@ -213,9 +213,6 @@ RUN set -eo pipefail && \
 # Component inventory in the build log for sanity.
 RUN pip list 2>/dev/null | grep -iE "^(vllm|torch|triton|transformers|bigdl|accelerate)" || true
 
-# Ensure runtime resolves oneCCL 2021.15 before torch RPATH candidates.
-ENV LD_PRELOAD="/opt/intel/oneapi/ccl/2021.15/lib/libccl.so.1"
-
 # --- dev default: interactive login shell (oneAPI env auto-sourced by the base).
 #     Override with `docker run ... vllm serve <model> ...` to serve. ---
 CMD ["/bin/bash", "-l"]


### PR DESCRIPTION
## Summary
- remove global `ENV LD_PRELOAD` from `vllm/docker/Dockerfile`
- remove global `ENV LD_PRELOAD` from `vllm/docker/Dockerfile.dev`
- keep oneCCL 2021.15 runtime symlink strategy in `/opt/venv/lib` unchanged

## Why
Global `LD_PRELOAD` causes container startup failures for interactive entrypoints (e.g. `/bin/bash`) when dependent oneAPI runtime libs are not yet resolved.

## Validation
- rebuilt release/dev images with this change
- verified `docker run --entrypoint /bin/bash` starts normally
- verified vLLM service starts and worker `libccl.so` maps to `/opt/intel/oneapi/ccl/2021.15/lib/libccl.so.1.0`
