### PR TITLE
[XPU][FP8] Optimize exact block-scaled decode GEMV

### DIFF
--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/fp8_GEMM_blockscale.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/fp8_GEMM_blockscale.h
@@ -34,52 +34,18 @@ namespace fp8_blockscale {
 #define BS_WE 4
 #define BS_WM 3
 
-// Vectorized fp8_e4m3 (fn) -> fp16 conversion (handles zero + subnormals; NaN
-// inputs are not expected in weights and are not special-cased). Mirrors the
-// bit manipulation in GEMV_a16_wfp8_block.
+// Branchless fp8_e4m3fn -> fp16 conversion used by the oneDNN JIT path.
+// Shifting the encoded byte into the fp16 subnormal range and multiplying by
+// 2^8 maps all finite E4M3 values exactly, including E4M3 subnormals.
 template <uint32_t N>
 inline simd<fp16, N> fp8e4m3_to_fp16(simd<uint8_t, N> x) {
-  constexpr uint16_t weo = 5;   // fp16 exponent bits
-  constexpr uint16_t wmo = 10;  // fp16 mantissa bits
-
-  // E4M3 has both +0 (0x00) and -0 (0x80). Ignore the sign bit when
-  // identifying zero, then preserve it in the FP16 result below.
-  auto is_zero = ((x & 0x7F) == 0);
-
-  simd<uint16_t, N> mantissa = x & ((1 << BS_WM) - 1);
-  simd<uint16_t, N> exponent = (x & 0x7F) >> BS_WM;
-
-  auto zero_exponent = (exponent == 0);
-  simd<uint16_t, N> mantissa_subnormal = mantissa;
-  simd<uint16_t, N> exponent_subnormal = exponent;
-  {
-    // Re-normalize subnormal fp8 mantissa: count leading zeros via the exponent
-    // of (float)mantissa, then shift into a normalized fp16 representation.
-    simd<uint16_t, N> vec = mantissa;
-    simd<float, N> vec_float = vec;
-    simd<uint32_t, N> vec_uint = vec_float.template bit_cast_view<uint32_t>();
-    simd<uint32_t, N> exponent_tmp = (vec_uint >> 23) & 0xFF;
-    simd<uint32_t, N> lz = 158 - exponent_tmp;  // 158 = 127 + 31
-    simd<uint16_t, N> renorm_shift = lz;
-
-    simd<uint16_t, N> sh = 1 + renorm_shift - (32 - BS_WM);
-    mantissa_subnormal <<= sh;
-    exponent_subnormal += 1 - sh;
-    mantissa_subnormal &= ((1 << BS_WM) - 1);
-  }
-
-  mantissa.merge(mantissa_subnormal, zero_exponent);
-  exponent.merge(exponent_subnormal, zero_exponent);
-
-  const uint16_t exp_low_cutoff = (1 << (weo - 1)) - (1 << (BS_WE - 1));
-  exponent += exp_low_cutoff;
-  mantissa <<= wmo - BS_WM;
-
-  simd<uint16_t, N> sign = x >> 7;
-  simd<uint16_t, N> retval = (sign << 15) | (exponent << 10) | mantissa;
-  retval.merge(sign << 15, is_zero);
-
-  return retval.template bit_cast_view<fp16>();
+  simd<uint16_t, N> u16 = convert<uint16_t>(x);
+  u16 <<= 8;
+  simd<int16_t, N> shifted =
+      u16.template bit_cast_view<int16_t>().read() >> 1;
+  u16 = shifted.template bit_cast_view<uint16_t>().read() & 0xBFFF;
+  simd<fp16, N> value = u16.template bit_cast_view<fp16>().read();
+  return value * fp16(256.0f);
 }
 
 // Block-scaled FP8 GEMV, BMG-tuned (modeled on GEMV_fp8_pert_bmg_kernel).

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/fp8_GEMM_blockscale.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/fp8_GEMM_blockscale.h
@@ -85,21 +85,27 @@ struct gemv_block_bmg_kernel {
     simd<float, MAX_M> acc = 0.0f;
 
     for (int k = ks; k < ks + kp; k += VL) {
-      // Load + dequant the weight slice once, fold in the per-128 block scale.
+      // Load + dequant the weight slice once. Apply each 128-wide block scale
+      // after its local dot product: this is algebraically identical to
+      // scaling every weight, but replaces 128 vector multiplies with one
+      // scalar multiply per block.
       simd<uint8_t, VL> raw = block_load<uint8_t, VL>(w_row + k);
       simd<float, VL> wf = fp8e4m3_to_fp16<VL>(raw);
-#pragma unroll
-      for (int sb = 0; sb < VL / BK; sb++) {
-        const float sc = s_row[(k / BK) + sb];
-        wf.template select<BK, 1>(sb * BK) = wf.template select<BK, 1>(sb * BK) * sc;
-      }
-      // Reuse the scaled weight across all M activation rows.
+      // Reuse the decoded weight across all M activation rows.
 #pragma unroll
       for (int m = 0; m < MAX_M; m++) {
         if (m < M) {
           simd<fp16, VL> iv = block_load<fp16, VL>(input + (size_t)m * K + k);
           simd<float, VL> ivf = iv;
-          acc[m] += reduce<float>(ivf * wf, std::plus<>());
+#pragma unroll
+          for (int sb = 0; sb < VL / BK; sb++) {
+            acc[m] +=
+                reduce<float>(
+                    ivf.template select<BK, 1>(sb * BK) *
+                        wf.template select<BK, 1>(sb * BK),
+                    std::plus<>()) *
+                s_row[(k / BK) + sb];
+          }
         }
       }
     }
@@ -239,13 +245,16 @@ struct gemv_block_fused2_bmg_kernel {
     for (int k = ks; k < ks + kp; k += VL) {
       simd<uint8_t, VL> raw = block_load<uint8_t, VL>(w_row + k);
       simd<float, VL> wf = fp8e4m3_to_fp16<VL>(raw);
+      simd<float, VL> iv = block_load<fp16, VL>(input + k);
 #pragma unroll
       for (int sb = 0; sb < VL / BK; sb++) {
-        const float sc = s_row[(k / BK) + sb];
-        wf.template select<BK, 1>(sb * BK) *= sc;
+        acc +=
+            reduce<float>(
+                iv.template select<BK, 1>(sb * BK) *
+                    wf.template select<BK, 1>(sb * BK),
+                std::plus<>()) *
+            s_row[(k / BK) + sb];
       }
-      simd<float, VL> iv = block_load<fp16, VL>(input + k);
-      acc += reduce<float>(iv * wf, std::plus<>());
     }
 
     if constexpr (K_SPLIT == 1) {
@@ -345,14 +354,22 @@ struct gemv_block_fp16_fused2_bmg_kernel {
         simd<uint8_t, VL> raw =
             block_load<uint8_t, VL>(weight0 + (size_t)n * K + k);
         wf = fp8e4m3_to_fp16<VL>(raw);
+      }
+      simd<float, VL> iv = block_load<fp16, VL>(input + k);
+      if (fp16_matrix) {
+        acc += reduce<float>(iv * wf, std::plus<>());
+      } else {
         const float* s_row = scale0 + (size_t)(n / 128) * Kb;
 #pragma unroll
         for (int sb = 0; sb < VL / 128; sb++) {
-          wf.template select<128, 1>(sb * 128) *= s_row[(k / 128) + sb];
+          acc +=
+              reduce<float>(
+                  iv.template select<128, 1>(sb * 128) *
+                      wf.template select<128, 1>(sb * 128),
+                  std::plus<>()) *
+              s_row[(k / 128) + sb];
         }
       }
-      simd<float, VL> iv = block_load<fp16, VL>(input + k);
-      acc += reduce<float>(iv * wf, std::plus<>());
     }
     fp16* output = fp16_matrix ? output1 : output0;
     if constexpr (K_SPLIT == 1) {

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/norm_gemv_fused.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/norm_gemv_fused.h
@@ -37,10 +37,14 @@ SYCL_ESIMD_FUNCTION inline simd<float, VL> fp8_dequant_norm(
     simd<uint16_t, VL> fp16_bits;
 
     if (fp8_mode == 0) {
-        simd<uint16_t, VL> fp8_exp  = (u16 >> 3) & 0xF;
-        simd<uint16_t, VL> fp8_mant = u16 & 0x7;
-        fp16_bits = (fp8_sign << 15) | ((fp8_exp + 8) << 10) | (fp8_mant << 7);
-        fp16_bits.merge(fp8_sign << 15, fp8_exp == 0);
+        u16 <<= 8;
+        simd<int16_t, VL> shifted =
+            u16.template bit_cast_view<int16_t>().read() >> 1;
+        fp16_bits =
+            shifted.template bit_cast_view<uint16_t>().read() & 0xBFFF;
+        simd<fp16, VL> wh =
+            fp16_bits.template bit_cast_view<fp16>().read();
+        return simd<float, VL>(wh * fp16(256.0f));
     } else {
         simd<uint16_t, VL> fp8_exp  = (u16 >> 2) & 0x1F;
         simd<uint16_t, VL> fp8_mant = u16 & 0x3;

--- a/vllm/custom-esimd-kernels-vllm/setup_gemm_only.py
+++ b/vllm/custom-esimd-kernels-vllm/setup_gemm_only.py
@@ -1,0 +1,41 @@
+"""Build only the ESIMD GEMM/GEMV extension for fast kernel iteration."""
+
+from pathlib import Path
+
+import torch
+from setuptools import find_packages, setup
+from torch.utils.cpp_extension import SyclExtension
+
+from esimd_build_extention import BuildExtension
+
+
+root = Path(__file__).parent.resolve()
+torch_include = str(Path(torch.__file__).parent / "include")
+
+setup(
+    name="custom-esimd-kernels-vllm-gemm-only",
+    version="0.1.0",
+    packages=find_packages(where="python"),
+    package_dir={"": "python"},
+    ext_modules=[
+        SyclExtension(
+            name="custom_esimd_kernels_vllm.custom_esimd_kernels_gemm",
+            sources=[
+                "csrc/xpu/esimd_kernel_gemm.sycl",
+                "csrc/xpu/torch_extension_gemm.cc",
+            ],
+            include_dirs=[root / "include", root / "csrc"],
+            extra_compile_args={
+                "cxx": ["-O3", "-std=c++17"],
+                "sycl": [
+                    "-ffast-math",
+                    "-fsycl-device-code-split=per_kernel",
+                    f"-I{torch_include}",
+                ],
+            },
+            extra_link_args=["-Wl,-rpath,$ORIGIN/../../torch/lib"],
+            py_limited_api=False,
+        )
+    ],
+    cmdclass={"build_ext": BuildExtension},
+)

--- a/vllm/custom-esimd-kernels-vllm/tests/bench_fp8_blockscale_decode.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/bench_fp8_blockscale_decode.py
@@ -1,0 +1,106 @@
+"""Decode microbenchmark for exact 128x128 block FP8 GEMV.
+
+Run on one XPU:
+    ZE_AFFINITY_MASK=0 python tests/bench_fp8_blockscale_decode.py
+"""
+
+import json
+import statistics
+import time
+
+import torch
+
+import custom_esimd_kernels_vllm as esimd
+
+
+SHAPES = (
+    ("attn_qkv", 7168, 5120),
+    ("attn_o", 5120, 3072),
+    ("mlp_gate_up", 17408, 5120),
+    ("mlp_down", 5120, 8704),
+)
+
+
+def timed_ms(fn, iterations=80):
+    samples = []
+    for _ in range(iterations):
+        start = time.perf_counter()
+        fn()
+        torch.xpu.synchronize()
+        samples.append((time.perf_counter() - start) * 1e3)
+    return {
+        "median_ms": statistics.median(samples),
+        "mean_ms": statistics.mean(samples),
+        "p10_ms": sorted(samples)[iterations // 10],
+        "p90_ms": sorted(samples)[iterations * 9 // 10],
+    }
+
+
+def main():
+    torch.manual_seed(20260731)
+    results = []
+    for name, n, k in SHAPES:
+        x = (torch.randn((1, k), device="xpu") * 0.25).half()
+        weight = (torch.randn((n, k), device="xpu") * 0.2).to(
+            torch.float8_e4m3fn
+        )
+        block_scale = torch.ones(
+            (n // 128, k // 128), device="xpu", dtype=torch.float32
+        )
+        tensor_scale = torch.ones(1, device="xpu", dtype=torch.float32)
+        block_out = torch.empty((1, n), device="xpu", dtype=torch.float16)
+        tensor_out = torch.empty_like(block_out)
+
+        def block():
+            esimd.esimd_gemm_fp8_blockscale(
+                x, weight, block_scale, block_out, 128, 128
+            )
+
+        def tensor():
+            esimd.esimd_gemv_fp8_pert(x, weight, tensor_scale, tensor_out)
+
+        for _ in range(20):
+            block()
+            tensor()
+        torch.xpu.synchronize()
+
+        # Alternate measurement order to reduce clock/thermal bias.
+        block_samples = []
+        tensor_samples = []
+        for iteration in range(80):
+            order = (
+                (("block", block), ("tensor", tensor))
+                if iteration % 2 == 0
+                else (("tensor", tensor), ("block", block))
+            )
+            for kind, fn in order:
+                start = time.perf_counter()
+                fn()
+                torch.xpu.synchronize()
+                elapsed = (time.perf_counter() - start) * 1e3
+                (block_samples if kind == "block" else tensor_samples).append(
+                    elapsed
+                )
+
+        result = {
+            "name": name,
+            "n": n,
+            "k": k,
+            "block_median_ms": statistics.median(block_samples),
+            "tensor_median_ms": statistics.median(tensor_samples),
+            "block_over_tensor": statistics.median(block_samples)
+            / statistics.median(tensor_samples),
+            "mean_abs_output_diff": (
+                block_out.float() - tensor_out.float()
+            ).abs().mean().item(),
+        }
+        results.append(result)
+        print(json.dumps(result, sort_keys=True), flush=True)
+        del x, weight, block_scale, tensor_scale, block_out, tensor_out
+        torch.xpu.empty_cache()
+
+    print(json.dumps({"results": results}, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/custom-esimd-kernels-vllm/tests/test_fp8_blockscale_gemm.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/test_fp8_blockscale_gemm.py
@@ -62,6 +62,30 @@ def run_case(M, N, K, dev):
     return ok
 
 
+def run_all_finite_e4m3_codes(dev):
+    """Exercise every finite E4M3 encoding, especially the 14 subnormals."""
+    N, K = 128, 256
+    codes = torch.arange(256, dtype=torch.uint8, device=dev)
+    codes = codes[(codes != 0x7F) & (codes != 0xFF)]
+    raw = codes.repeat((N * K + codes.numel() - 1) // codes.numel())[:N * K]
+    wq = raw.reshape(N, K).view(torch.float8_e4m3fn)
+    ws = torch.ones(N // BN, K // BK, dtype=torch.float32, device=dev)
+    a = torch.linspace(-1, 1, K, dtype=torch.float16, device=dev).reshape(1, K)
+    ref = a.float() @ wq.float().t()
+    out = torch.empty(1, N, dtype=torch.float16, device=dev)
+    esimd.esimd_gemm_fp8_blockscale(a, wq, ws, out, BN, BK)
+    torch.xpu.synchronize()
+
+    rel = (out.float() - ref).abs().mean() / ref.abs().mean().clamp(min=1e-6)
+    cos = torch.nn.functional.cosine_similarity(
+        out.float().flatten(), ref.flatten(), dim=0
+    )
+    ok = rel < 5e-3 and cos > 0.99999
+    print(f"all finite E4M3 codes: mean_rel={rel:.4e} cos={cos:.8f}  "
+          f"{'OK' if ok else 'FAIL'}")
+    return ok
+
+
 def main():
     dev = "xpu"
     torch.xpu.synchronize()
@@ -75,6 +99,7 @@ def main():
     # N not a multiple of PPG (scalar tail store path)
     all_ok &= run_case(1, 1000, 5120, dev)
     all_ok &= run_case(4, 1000, 5120, dev)
+    all_ok &= run_all_finite_e4m3_codes(dev)
     print("\nRESULT:", "ALL OK" if all_ok else "FAILURES PRESENT")
     raise SystemExit(0 if all_ok else 1)
 


### PR DESCRIPTION
## What changed

- replace the block GEMV E4M3 conversion with a branchless exact mapping that
  handles all finite E4M3 values, including subnormals
- apply each 128-wide block scale after its local dot product instead of once
  per weight element
- apply the same scale placement to the block/block and block/FP16 fused GEMV
  variants
- use the exact E4M3 conversion in the fused block NormGEMV path
- add exactness coverage and a decode microbenchmark
- add an incremental GEMM-only build entry point

## Why

Batch-1 decode is bandwidth and launch-latency bound. Multiplying all 128 FP8
weight elements by the same block scale adds redundant vector work. For each
block, `sum(x * w * scale) = scale * sum(x * w)`, so the scale can be applied
once to the local partial sum while retaining exact 128x128 block metadata.

## Impact

The kernel continues reading the original FP8 weight bytes and original
128x128 scale tensor. It does not requantize or transcode weights to per-tensor
FP8 and adds no persistent allocation.

On Qwen3.6-27B-FP8 TP2, batch-1 32k input / 2k output, median TPOT improves from
36.190 ms to 33.211 ms. The same-session per-tensor reference is 33.248 ms.
Median TTFT remains unchanged at about 12.287 seconds.

## Validation

- exact block GEMV covers all finite E4M3 codes
- block GEMV and fusion tests pass on XPU card 0 and card 1
- Qwen3.6-27B-FP8 TP2 GSM8K: 35/35 rounds x 100 questions passed
- final accuracy: min 0.97, median 0.98, mean 0.9794; invalid rate 0
- no NaN or device errors across 3500 questions
- 32k input / 2k output: 5/5 requests passed

Related prefill integration and grouped oneDNN support:

- https://github.com/intel-sandbox/llm-scaler-vllm-xpu/pull/154
- https://github.com/analytics-zoo/vllm-xpu-kernels/pull/9
