### PR TITLE
[XPU][FP8] Optimize block FP8 decode through batch 12

### DIFF
--- a/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe.sycl
@@ -1670,14 +1670,14 @@ struct MoeBlockBuffers {
     int cached_device = -1;
 };
 
-// Capture and serving commonly alternate among 1..4 decode tokens. Keep one
-// persistent slot per token count so switching shapes does not reallocate all
+// Capture and serving commonly alternate among small decode token counts. Keep
+// one persistent slot per token count so switching shapes does not reallocate all
 // intermediate tensors. The memory cost is tiny for these decode-only buffers.
 // This cache follows vLLM's single model-compute-stream-per-TP-worker contract;
 // concurrent use from multiple compute streams is unsupported. If that
 // execution model changes, use per-stream caches rather than synchronizing the
 // decode hot path on every stream change.
-static thread_local std::array<MoeBlockBuffers, 8> s_block_buffers;
+static thread_local std::array<MoeBlockBuffers, 12> s_block_buffers;
 
 static MoeBlockBuffers& ensure_moe_block_buffers(
         int num_tokens, int top_k, int hidden_size, int intermediate_size,
@@ -1713,8 +1713,8 @@ torch::Tensor moe_forward_full_fp8_block(
     torch::Tensor shared_expert_gate_weight,
     int64_t top_k, int64_t num_shared_experts,
     int64_t n_routed_experts) {
-    TORCH_CHECK(x.dim() == 2 && x.size(0) >= 1 && x.size(0) <= 8,
-                "moe_forward_full_fp8_block supports 1 to 8 tokens");
+    TORCH_CHECK(x.dim() == 2 && x.size(0) >= 1 && x.size(0) <= 12,
+                "moe_forward_full_fp8_block supports 1 to 12 tokens");
     TORCH_CHECK(x.is_contiguous() && x.scalar_type() == torch::kHalf);
     const int num_tokens = x.size(0);
     TORCH_CHECK(logits.dim() == 2 && logits.size(0) == num_tokens &&

--- a/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe.sycl
@@ -1658,7 +1658,7 @@ struct MoeBlockBuffers {
 // concurrent use from multiple compute streams is unsupported. If that
 // execution model changes, use per-stream caches rather than synchronizing the
 // decode hot path on every stream change.
-static thread_local std::array<MoeBlockBuffers, 4> s_block_buffers;
+static thread_local std::array<MoeBlockBuffers, 8> s_block_buffers;
 
 static MoeBlockBuffers& ensure_moe_block_buffers(
         int num_tokens, int top_k, int hidden_size, int intermediate_size,
@@ -1692,8 +1692,8 @@ torch::Tensor moe_forward_full_fp8_block(
     torch::Tensor shared_expert_gate_weight,
     int64_t top_k, int64_t num_shared_experts,
     int64_t n_routed_experts) {
-    TORCH_CHECK(x.dim() == 2 && x.size(0) >= 1 && x.size(0) <= 4,
-                "moe_forward_full_fp8_block supports 1 to 4 tokens");
+    TORCH_CHECK(x.dim() == 2 && x.size(0) >= 1 && x.size(0) <= 8,
+                "moe_forward_full_fp8_block supports 1 to 8 tokens");
     TORCH_CHECK(x.is_contiguous() && x.scalar_type() == torch::kHalf);
     const int num_tokens = x.size(0);
     TORCH_CHECK(logits.dim() == 2 && logits.size(0) == num_tokens &&

--- a/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe.sycl
@@ -1503,6 +1503,10 @@ static void ensure_moe_buffers(int n_tokens, int top_k, int num_shared_experts,
 // Shared-expert weights omit the leading expert dimension. Activations remain
 // FP16; FP8 values are converted to FP16/FP32 and multiplied by the 128x128
 // block scale before accumulation. This path does not use FP8 matrix multiply.
+template <int VecWidth>
+class MoeUpFP8BlockBatched;
+
+template <int VecWidth>
 void moe_up_fp8_block_batched_kernel(
     const fp16* x,
     const uint8_t* gate_up_weight, const float* gate_up_scale,
@@ -1516,7 +1520,7 @@ void moe_up_fp8_block_batched_kernel(
     const int scale_kb = (hidden_size + 127) / 128;
 
     auto cgf = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class MoeUpFP8BlockBatched>(
+        cgh.parallel_for<MoeUpFP8BlockBatched<VecWidth>>(
             sycl::range<3>(num_tokens, top_k + 1, intermediate_size),
             [=](sycl::id<3> idx) SYCL_ESIMD_KERNEL {
                 const int token = (int)idx[0];
@@ -1537,22 +1541,21 @@ void moe_up_fp8_block_batched_kernel(
                 const float* up_s = scales
                     + (size_t)((intermediate_size + row) / 128) * scale_kb;
 
-                simd<float, 64> gate_acc(0.f), up_acc(0.f);
-                for (int k = 0; k < hidden_size; k += 64) {
-                    simd<float, 64> xv =
-                        block_load<fp16, 64>(token_x + k);
-                    simd<float, 64> gw = fp8e4m3_to_half<64>(
-                        block_load<uint8_t, 64>(gate_w + k));
-                    simd<float, 64> uw = fp8e4m3_to_half<64>(
-                        block_load<uint8_t, 64>(up_w + k));
+                simd<float, VecWidth> gate_acc(0.f), up_acc(0.f);
+                for (int k = 0; k < hidden_size; k += VecWidth) {
+                    simd<float, VecWidth> xv =
+                        block_load<fp16, VecWidth>(token_x + k);
+                    simd<float, VecWidth> gw = fp8e4m3_to_half<VecWidth>(
+                        block_load<uint8_t, VecWidth>(gate_w + k));
+                    simd<float, VecWidth> uw = fp8e4m3_to_half<VecWidth>(
+                        block_load<uint8_t, VecWidth>(up_w + k));
                     gate_acc += xv * (gw * gate_s[k / 128]);
                     up_acc += xv * (uw * up_s[k / 128]);
                 }
-
                 float gate = sycl::ext::intel::esimd::detail::sum<
-                    float, float, 64>(gate_acc);
+                    float, float, VecWidth>(gate_acc);
                 float up = sycl::ext::intel::esimd::detail::sum<
-                    float, float, 64>(up_acc);
+                    float, float, VecWidth>(up_acc);
                 float silu = gate / (1.f + sycl::exp(-gate));
                 const size_t intermediate_offset =
                     ((size_t)token * (top_k + 1) + route)
@@ -1564,11 +1567,16 @@ void moe_up_fp8_block_batched_kernel(
     submit_kernel(cgf, device, "moe up fp8 block batched");
 }
 
+template <int VecWidth>
+class MoeDownFinalizeFP8BlockBatched;
+
+template <int VecWidth>
 void moe_down_finalize_fp8_block_batched_kernel(
     const fp16* x, const fp16* intermediates,
     const uint8_t* down_weight, const float* down_scale,
     const uint8_t* shared_down_weight, const float* shared_down_scale,
     const fp16* shared_expert_gate_weight,
+    const float* shared_gate_values,
     const fp16* routing_weights, const int* selected_experts,
     fp16* final_output, const int num_tokens, const int hidden_size,
     const int intermediate_size, const int top_k,
@@ -1577,12 +1585,11 @@ void moe_down_finalize_fp8_block_batched_kernel(
     const int scale_kb = (intermediate_size + 127) / 128;
 
     auto cgf = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class MoeDownFinalizeFP8BlockBatched>(
+        cgh.parallel_for<MoeDownFinalizeFP8BlockBatched<VecWidth>>(
             sycl::range<2>(num_tokens, hidden_size),
             [=](sycl::id<2> idx) SYCL_ESIMD_KERNEL {
                 const int token = (int)idx[0];
                 const int out = (int)idx[1];
-                const fp16* token_x = x + (size_t)token * hidden_size;
                 float result = 0.f;
 
                 for (int route = 0; route < top_k; route++) {
@@ -1595,29 +1602,40 @@ void moe_down_finalize_fp8_block_batched_kernel(
                         + ((size_t)eid * hidden_size + out) * intermediate_size;
                     const float* scales = down_scale
                         + ((size_t)eid * scale_nb + out / 128) * scale_kb;
-                    simd<float, 64> acc(0.f);
-                    for (int k = 0; k < intermediate_size; k += 64) {
-                        simd<float, 64> iv =
-                            block_load<fp16, 64>(input + k);
-                        simd<float, 64> wv = fp8e4m3_to_half<64>(
-                            block_load<uint8_t, 64>(weight + k));
+                    simd<float, VecWidth> acc(0.f);
+                    for (int k = 0; k < intermediate_size; k += VecWidth) {
+                        simd<float, VecWidth> iv =
+                            block_load<fp16, VecWidth>(input + k);
+                        simd<float, VecWidth> wv =
+                            fp8e4m3_to_half<VecWidth>(
+                                block_load<uint8_t, VecWidth>(weight + k));
                         acc += iv * (wv * scales[k / 128]);
                     }
-                    result += sycl::ext::intel::esimd::detail::sum<
-                        float, float, 64>(acc)
+                    float route_result =
+                        sycl::ext::intel::esimd::detail::sum<
+                            float, float, VecWidth>(acc);
+                    result += route_result
                         * (float)routing_weights[route_offset];
                 }
 
-                simd<float, 64> gate_acc(0.f);
-                for (int k = 0; k < hidden_size; k += 64) {
-                    simd<float, 64> xv = block_load<fp16, 64>(token_x + k);
-                    simd<float, 64> gw = block_load<fp16, 64>(
-                        shared_expert_gate_weight + k);
-                    gate_acc += xv * gw;
+                float gate;
+                if (num_tokens < 4) {
+                    const fp16* token_x = x + (size_t)token * hidden_size;
+                    simd<float, VecWidth> gate_acc(0.f);
+                    for (int k = 0; k < hidden_size; k += VecWidth) {
+                        simd<float, VecWidth> xv =
+                            block_load<fp16, VecWidth>(token_x + k);
+                        simd<float, VecWidth> gw =
+                            block_load<fp16, VecWidth>(
+                            shared_expert_gate_weight + k);
+                        gate_acc += xv * gw;
+                    }
+                    gate = sycl::ext::intel::esimd::detail::sum<
+                        float, float, VecWidth>(gate_acc);
+                    gate = 1.f / (1.f + sycl::exp(-gate));
+                } else {
+                    gate = shared_gate_values[token];
                 }
-                float gate = sycl::ext::intel::esimd::detail::sum<
-                    float, float, 64>(gate_acc);
-                gate = 1.f / (1.f + sycl::exp(-gate));
 
                 const fp16* shared_input =
                     intermediates
@@ -1627,16 +1645,17 @@ void moe_down_finalize_fp8_block_batched_kernel(
                     shared_down_weight + (size_t)out * intermediate_size;
                 const float* shared_scales = shared_down_scale
                     + (size_t)(out / 128) * scale_kb;
-                simd<float, 64> shared_acc(0.f);
-                for (int k = 0; k < intermediate_size; k += 64) {
-                    simd<float, 64> iv =
-                        block_load<fp16, 64>(shared_input + k);
-                    simd<float, 64> wv = fp8e4m3_to_half<64>(
-                        block_load<uint8_t, 64>(shared_weight + k));
+                simd<float, VecWidth> shared_acc(0.f);
+                for (int k = 0; k < intermediate_size; k += VecWidth) {
+                    simd<float, VecWidth> iv =
+                        block_load<fp16, VecWidth>(shared_input + k);
+                    simd<float, VecWidth> wv = fp8e4m3_to_half<VecWidth>(
+                        block_load<uint8_t, VecWidth>(shared_weight + k));
                     shared_acc += iv * (wv * shared_scales[k / 128]);
                 }
-                result += gate * sycl::ext::intel::esimd::detail::sum<
-                    float, float, 64>(shared_acc);
+                float shared_result = sycl::ext::intel::esimd::detail::sum<
+                    float, float, VecWidth>(shared_acc);
+                result += gate * shared_result;
                 final_output[(size_t)token * hidden_size + out] = fp16(result);
             });
     };
@@ -1644,7 +1663,7 @@ void moe_down_finalize_fp8_block_batched_kernel(
 }
 
 struct MoeBlockBuffers {
-    torch::Tensor topk_idx, topk_weight, intermediates;
+    torch::Tensor topk_idx, topk_weight, intermediates, shared_gate_values;
     int cached_topk = -1;
     int cached_hidden = -1;
     int cached_intermediate = -1;
@@ -1675,6 +1694,8 @@ static MoeBlockBuffers& ensure_moe_block_buffers(
         buffers.intermediates = torch::empty(
             {num_tokens, top_k + 1, intermediate_size},
             torch::device(dev).dtype(torch::kHalf));
+        buffers.shared_gate_values = torch::empty(
+            {num_tokens}, torch::device(dev).dtype(torch::kFloat32));
         buffers.cached_topk = top_k;
         buffers.cached_hidden = hidden_size;
         buffers.cached_intermediate = intermediate_size;
@@ -1781,26 +1802,53 @@ torch::Tensor moe_forward_full_fp8_block(
         (int)n_routed_experts,
         (int)top_k, /*norm=*/true, logits.device());
 
-    moe_up_fp8_block_batched_kernel(
-        (const fp16*)x.data_ptr(),
-        (const uint8_t*)gate_up_weight.data_ptr(), gate_up_scale.data_ptr<float>(),
-        (const uint8_t*)shared_gate_up_weight.data_ptr(),
-        shared_gate_up_scale.data_ptr<float>(),
-        buffers.topk_idx.data_ptr<int>(),
-        (fp16*)buffers.intermediates.data_ptr(), num_tokens, hidden_size,
-        intermediate_size, top_k, x.device());
+    auto launch_up = [&]<int VecWidth>() {
+        moe_up_fp8_block_batched_kernel<VecWidth>(
+            (const fp16*)x.data_ptr(),
+            (const uint8_t*)gate_up_weight.data_ptr(),
+            gate_up_scale.data_ptr<float>(),
+            (const uint8_t*)shared_gate_up_weight.data_ptr(),
+            shared_gate_up_scale.data_ptr<float>(),
+            buffers.topk_idx.data_ptr<int>(),
+            (fp16*)buffers.intermediates.data_ptr(), num_tokens, hidden_size,
+            intermediate_size, top_k, x.device());
+    };
+    if (num_tokens < 4) {
+        launch_up.template operator()<64>();
+    } else {
+        launch_up.template operator()<128>();
+    }
 
-    moe_down_finalize_fp8_block_batched_kernel(
-        (const fp16*)x.data_ptr(),
-        (const fp16*)buffers.intermediates.data_ptr(),
-        (const uint8_t*)down_weight.data_ptr(), down_scale.data_ptr<float>(),
-        (const uint8_t*)shared_down_weight.data_ptr(),
-        shared_down_scale.data_ptr<float>(),
-        (const fp16*)shared_expert_gate_weight.data_ptr(),
-        (const fp16*)buffers.topk_weight.data_ptr(),
-        buffers.topk_idx.data_ptr<int>(),
-        (fp16*)output.data_ptr(), num_tokens, hidden_size,
-        intermediate_size, top_k, x.device());
+    // The shared-expert gate depends only on the token, not the output row.
+    // Precompute it once instead of repeating the hidden-size dot product for
+    // every one of the hidden_size down-projection work-items.
+    if (num_tokens >= 4) {
+        moe_down_gate_precompute_kernel(
+            (const fp16*)x.data_ptr(),
+            (const fp16*)shared_expert_gate_weight.data_ptr(),
+            buffers.shared_gate_values.data_ptr<float>(), num_tokens,
+            hidden_size, /*num_shared_experts=*/1, x.device());
+    }
+
+    auto launch_down = [&]<int VecWidth>() {
+        moe_down_finalize_fp8_block_batched_kernel<VecWidth>(
+            (const fp16*)x.data_ptr(),
+            (const fp16*)buffers.intermediates.data_ptr(),
+            (const uint8_t*)down_weight.data_ptr(), down_scale.data_ptr<float>(),
+            (const uint8_t*)shared_down_weight.data_ptr(),
+            shared_down_scale.data_ptr<float>(),
+            (const fp16*)shared_expert_gate_weight.data_ptr(),
+            buffers.shared_gate_values.data_ptr<float>(),
+            (const fp16*)buffers.topk_weight.data_ptr(),
+            buffers.topk_idx.data_ptr<int>(),
+            (fp16*)output.data_ptr(), num_tokens, hidden_size,
+            intermediate_size, top_k, x.device());
+    };
+    if (num_tokens < 4) {
+        launch_down.template operator()<64>();
+    } else {
+        launch_down.template operator()<128>();
+    }
     return output;
 }
 

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel.sycl
@@ -101,9 +101,24 @@ at::Tensor esimd_gemv_fp16(
     at::Tensor input,    // [M, K] fp16
     at::Tensor weight,   // [N, K] fp16
     at::Tensor output) { // [M, N] fp16
+    TORCH_CHECK(input.scalar_type() == at::ScalarType::Half);
+    TORCH_CHECK(weight.scalar_type() == at::ScalarType::Half);
+    TORCH_CHECK(output.scalar_type() == at::ScalarType::Half);
+    TORCH_CHECK(input.dim() == 2);
+    TORCH_CHECK(weight.dim() == 2);
+    TORCH_CHECK(output.dim() == 2);
+    TORCH_CHECK(input.is_contiguous());
+    TORCH_CHECK(weight.is_contiguous());
+    TORCH_CHECK(output.is_contiguous());
+    TORCH_CHECK(input.device() == weight.device());
+    TORCH_CHECK(input.device() == output.device());
+
     int64_t M = input.size(0);
     int64_t N = weight.size(0);
     int64_t K = weight.size(1);
+    TORCH_CHECK(input.size(1) == K);
+    TORCH_CHECK(output.size(0) == M && output.size(1) == N);
+
     auto p_in  = reinterpret_cast<const fp16*>(input.data_ptr());
     auto p_w   = reinterpret_cast<const fp16*>(weight.data_ptr());
     auto p_out = reinterpret_cast<fp16*>(output.data_ptr());

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel.sycl
@@ -98,16 +98,19 @@ at::Tensor esimd_gemv_fp8_pert(
 }
 
 at::Tensor esimd_gemv_fp16(
-    at::Tensor input,    // [1, K] fp16
+    at::Tensor input,    // [M, K] fp16
     at::Tensor weight,   // [N, K] fp16
-    at::Tensor output) { // [1, N] fp16
+    at::Tensor output) { // [M, N] fp16
+    int64_t M = input.size(0);
     int64_t N = weight.size(0);
     int64_t K = weight.size(1);
     auto p_in  = reinterpret_cast<const fp16*>(input.data_ptr());
     auto p_w   = reinterpret_cast<const fp16*>(weight.data_ptr());
     auto p_out = reinterpret_cast<fp16*>(output.data_ptr());
     auto& dpcpp_queue = get_device_queue(input);
-    GEMV_fp16_host(p_in, p_w, p_out, (uint32_t)N, (uint32_t)K, dpcpp_queue);
+    GEMV_fp16_host(
+        p_in, p_w, p_out, (uint32_t)M, (uint32_t)N, (uint32_t)K,
+        dpcpp_queue);
     return output;
 }
 

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/fp16_GEMV.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/fp16_GEMV.h
@@ -1,4 +1,4 @@
-/* fp16_GEMV.h — FP16×FP16→FP16/FP32 GEMV for decode (M=1).
+/* fp16_GEMV.h — FP16×FP16→FP16/FP32 GEMV for small-batch decode.
  *
  * Mirrors the fp8_GEMV_v2 dispatch pattern (templated VL + K_SPLIT,
  * SLM partial reduction) but skips the FP8 dequant — both input and
@@ -9,9 +9,9 @@
  * generalizes to any small-N decode-batch GEMV that has no per-tensor
  * scale.
  *
- * Input:  [1, K] fp16
+ * Input:  [M, K] fp16
  * Weight: [N, K] fp16 (row-major, contiguous)
- * Output: [1, N] fp16
+ * Output: [M, N] fp16
  */
 
 #pragma once
@@ -44,9 +44,10 @@ struct GEMV_fp16_kernel {
             slm_init<K_SPLIT * sizeof(float)>();
         }
 
-        int n   = item.get_group(0);
+        int mn  = item.get_group(0);
+        int m   = mn / N;
+        int n   = mn - m * N;
         int lid = item.get_local_id(0);
-        if (n >= N) return;
 
         int kp = K / K_SPLIT;
         int ks = lid * kp;
@@ -54,7 +55,8 @@ struct GEMV_fp16_kernel {
         simd<float, VL> acc = 0.0f;
 
         for (int k = ks; k < ks + kp; k += VL) {
-            simd<fp16, VL> iv = block_load<fp16, VL>(input + k);
+            simd<fp16, VL> iv = block_load<fp16, VL>(
+                input + (size_t)m * K + k);
             simd<float, VL> input_f = iv;
 
             simd<fp16, VL> wv = block_load<fp16, VL>(weight + (size_t)n * K + k);
@@ -66,13 +68,14 @@ struct GEMV_fp16_kernel {
         float my_sum = reduce<float>(acc, std::plus<>());
 
         if constexpr (K_SPLIT == 1) {
-            output[n] = fp16(my_sum);
+            output[(size_t)m * N + n] = fp16(my_sum);
         } else {
             slm_block_store<float, 1>(lid * sizeof(float), simd<float, 1>(my_sum));
             barrier();
             if (lid == 0) {
                 simd<float, K_SPLIT> parts = slm_block_load<float, K_SPLIT>(0);
-                output[n] = fp16(reduce<float>(parts, std::plus<>()));
+                output[(size_t)m * N + n] = fp16(
+                    reduce<float>(parts, std::plus<>()));
             }
         }
     }
@@ -166,6 +169,7 @@ inline void GEMV_fp16_host(
     const fp16* input,
     const fp16* weight,
     fp16*       output,
+    uint32_t M,
     uint32_t N,
     uint32_t K,
     sycl::queue& q) {
@@ -173,7 +177,7 @@ inline void GEMV_fp16_host(
     int vl, ks;
     select_vl_ks_fp16(N, K, vl, ks);
 
-    uint32_t global = N * ks;
+    uint32_t global = M * N * ks;
     uint32_t local  = ks;
 
     #define LAUNCH(V, KS)         q.submit([&](sycl::handler& cgh) {             cgh.parallel_for(                 sycl::nd_range<1>(global, local),                 GEMV_fp16_kernel<V, KS>{input, weight, output, (int)N, (int)K});         });

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/fp8_GEMM_blockscale.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/fp8_GEMM_blockscale.h
@@ -191,8 +191,9 @@ inline void dispatch_gemv_block_bmg(const fp16* input, const uint8_t* weight,
 #undef BS_DISPATCH
 }
 
-// Host launcher. block_n/block_k must be 128. Handles any M by tiling into
-// groups of TILE rows (weight is reloaded per tile but reused across the tile).
+// Host launcher. block_n/block_k must be 128. Keep decode batches through 12
+// rows in one launch so the weight is streamed once and reused across all rows.
+// Larger M is tiled in groups of eight to bound register pressure.
 inline void gemm_fp8_blockscale_host(const fp16* input, const uint8_t* weight,
                                      const float* weight_scale, fp16* output,
                                      uint32_t M, uint32_t N, uint32_t K,
@@ -201,6 +202,16 @@ inline void gemm_fp8_blockscale_host(const fp16* input, const uint8_t* weight,
   if (M == 1) {
     dispatch_gemv_block_bmg<1>(input, weight, weight_scale, output, 1, (int)N,
                                (int)K, q);
+    return;
+  }
+  if (M <= 8) {
+    dispatch_gemv_block_bmg<8>(input, weight, weight_scale, output, (int)M,
+                               (int)N, (int)K, q);
+    return;
+  }
+  if (M <= 12) {
+    dispatch_gemv_block_bmg<12>(input, weight, weight_scale, output, (int)M,
+                                (int)N, (int)K, q);
     return;
   }
   constexpr uint32_t TILE = 8;

--- a/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/ops.py
+++ b/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/ops.py
@@ -66,12 +66,12 @@ def esimd_gemv_fp8_pert(
 def esimd_gemv_fp16(
     input: torch.Tensor, weight: torch.Tensor, output: torch.Tensor,
 ) -> torch.Tensor:
-    """FP16 weight GEMV (no quantization). Decode (M=1) path.
+    """FP16 weight GEMV (no quantization), including small decode batches.
 
-    input:  [1, K] fp16
+    input:  [M, K] fp16
     weight: [N, K] fp16, contiguous (row-major). N inferred from weight.size(0),
             K from weight.size(1).
-    output: [1, N] fp16.
+    output: [M, N] fp16.
 
     Used by gemma4's decode router projection (GateLinear is fp16 fp16-fp16).
     """

--- a/vllm/custom-esimd-kernels-vllm/tests/test_fp8_blockscale_gemm.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/test_fp8_blockscale_gemm.py
@@ -94,7 +94,7 @@ def main():
         for N in (1024, 5120, 6144):
             all_ok &= run_case(1, N, K, dev)      # decode
     # M>1 tiled path + remainder tile
-    for M in (2, 7, 8, 9, 33, 64):
+    for M in (2, 7, 8, 9, 10, 12, 33, 64):
         all_ok &= run_case(M, 5120, 5120, dev)
     # N not a multiple of PPG (scalar tail store path)
     all_ok &= run_case(1, 1000, 5120, dev)

--- a/vllm/custom-esimd-kernels-vllm/tests/test_gemv_fp16.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/test_gemv_fp16.py
@@ -3,24 +3,32 @@ import sys, torch
 import custom_esimd_kernels_vllm  # noqa: F401  (registers ops)
 
 
-def run(N, K, tol=5e-2):
+def run(M, N, K, tol=5e-2):
     torch.manual_seed(0)
     dev = torch.device("xpu")
-    x = torch.randn(1, K, dtype=torch.float16, device=dev) * 0.1
+    x = torch.randn(M, K, dtype=torch.float16, device=dev) * 0.1
     w = torch.randn(N, K, dtype=torch.float16, device=dev) * 0.05
-    out = torch.empty(1, N, dtype=torch.float16, device=dev)
+    out = torch.empty(M, N, dtype=torch.float16, device=dev)
     torch.ops.custom_esimd_kernels_vllm.esimd_gemv_fp16(x, w, out)
     ref = torch.nn.functional.linear(x, w)
     diff = (out.float() - ref.float()).abs().max().item()
     ok = diff < tol
-    print(f"  [{'PASS' if ok else 'FAIL'}] N={N} K={K}  max_abs={diff:.3e}")
+    print(
+        f"  [{'PASS' if ok else 'FAIL'}] M={M} N={N} K={K}  "
+        f"max_abs={diff:.3e}"
+    )
     return ok
 
 
 if __name__ == "__main__":
     cases = [
-        (128, 2816),    # gemma4-26B router (TP=2)
-        (128, 1408),    # gemma4-26B router (TP=4 hypothetical)
-        (256, 2048),    # generic
+        (1, 128, 2816),  # gemma4-26B router (TP=2)
+        (1, 128, 1408),  # gemma4-26B router (TP=4 hypothetical)
+        (2, 32, 2048),   # Qwen3.6 GDN in_proj_ba
+        (4, 32, 2048),
+        (8, 32, 2048),
+        (2, 256, 2048),  # Qwen3.6 MoE router
+        (4, 256, 2048),
+        (8, 256, 2048),
     ]
     sys.exit(0 if all(run(*c) for c in cases) else 1)

--- a/vllm/custom-esimd-kernels-vllm/tests/test_gemv_fp16.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/test_gemv_fp16.py
@@ -1,6 +1,8 @@
 """Numerical regression for esimd_gemv_fp16 at the gemma4 router shape."""
-import sys, torch
+import sys
+
 import custom_esimd_kernels_vllm  # noqa: F401  (registers ops)
+import torch
 
 
 def run(M, N, K, tol=5e-2):
@@ -20,6 +22,16 @@ def run(M, N, K, tol=5e-2):
     return ok
 
 
+def rejects(label, x, w, out):
+    try:
+        torch.ops.custom_esimd_kernels_vllm.esimd_gemv_fp16(x, w, out)
+    except RuntimeError:
+        print(f"  [PASS] rejects {label}")
+        return True
+    print(f"  [FAIL] accepts invalid {label}")
+    return False
+
+
 if __name__ == "__main__":
     cases = [
         (1, 128, 2816),  # gemma4-26B router (TP=2)
@@ -31,4 +43,25 @@ if __name__ == "__main__":
         (4, 256, 2048),
         (8, 256, 2048),
     ]
-    sys.exit(0 if all(run(*c) for c in cases) else 1)
+    torch.manual_seed(0)
+    dev = torch.device("xpu")
+    M, N, K = 2, 32, 2048
+    x = torch.randn(M, K, dtype=torch.float16, device=dev)
+    w = torch.randn(N, K, dtype=torch.float16, device=dev)
+    out = torch.empty(M, N, dtype=torch.float16, device=dev)
+    invalid_cases = [
+        rejects("bf16 input", x.to(torch.bfloat16), w, out),
+        rejects(
+            "non-contiguous input",
+            torch.randn(K, M, dtype=torch.float16, device=dev).t(),
+            w,
+            out,
+        ),
+        rejects(
+            "wrong output shape",
+            x,
+            w,
+            torch.empty(M, N - 1, dtype=torch.float16, device=dev),
+        ),
+    ]
+    sys.exit(0 if all(run(*c) for c in cases) and all(invalid_cases) else 1)

--- a/vllm/custom-esimd-kernels-vllm/tests/test_moe_forward_full_fp8_block.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/test_moe_forward_full_fp8_block.py
@@ -80,7 +80,7 @@ def reference(
     return out
 
 
-@pytest.mark.parametrize("batch_size", [1, 2, 3, 4, 8])
+@pytest.mark.parametrize("batch_size", [1, 2, 3, 4, 8, 10, 12])
 @pytest.mark.parametrize("seed", range(3))
 def test_moe_forward_full_fp8_block(batch_size: int, seed: int):
     device = "xpu"

--- a/vllm/custom-esimd-kernels-vllm/tests/test_moe_forward_full_fp8_block.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/test_moe_forward_full_fp8_block.py
@@ -80,7 +80,7 @@ def reference(
     return out
 
 
-@pytest.mark.parametrize("batch_size", [1, 4, 2, 3])
+@pytest.mark.parametrize("batch_size", [1, 2, 3, 4, 8])
 @pytest.mark.parametrize("seed", range(3))
 def test_moe_forward_full_fp8_block(batch_size: int, seed: int):
     device = "xpu"


### PR DESCRIPTION
## What changed

- Extends native block-FP8 MoE decode from batch 8 through batch 12 and tunes the M-aware block-MoE and dense decode kernels.

## Why

- Covers the multi-row decode shapes required by the Qwen3.6 FP8 performance matrix while preserving exact checkpoint block scales.

## Impact

- Enables optimized native block-FP8 decode for batch sizes 1 through 12 without a per-tensor transcode.

## Validation

- `git diff --check origin/main...HEAD`
- Fresh TP2 27B/35B batch matrix (1, 2, 4, 8, 10, 12) completed all 24 workload integrity checks.
- 23 of 24 performance points passed the configured thresholds. The remaining 35B batch-1 TPOT point measured 1.0526x block/per-tensor, above the 1.05 threshold; this draft PR retains that follow-up explicitly.