### PR TITLE
docs: add offline FP8 Qwen3.6 models

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ LLM Scaler is an GenAI solution for text generation, image generation, video gen
 `llm-scaler-vllm` supports running text generation models using vLLM, featuring: 
 
 - ***CCL*** support (P2P or USM)
-- ***INT4*** and ***FP8*** quantized online serving
+- ***INT4*** and ***FP8*** quantized online serving, plus pre-quantized FP8 model support
 - ***Embedding*** and ***Reranker*** model support
 - ***Multi-Modal*** model support
 - ***Omni*** model support
@@ -68,6 +68,8 @@ Please follow the instructions in the [Getting Started](vllm/README.md/#1-gettin
 | Qwen/Qwen3-Coder-Next                      |  ✅  |         ✅         |                    |       |                           |
 | Qwen/Qwen3.5/3.6-27B                       |  ✅  |         ✅         |          ✅          |       |                           |
 | Qwen/Qwen3.5/3.6-35B-A3B                   |  ✅  |         ✅         |          ✅          |       |                           |
+| Qwen/Qwen3.6-27B-FP8                       |      |                    |                      |       | Pre-quantized offline FP8 model |
+| Qwen/Qwen3.6-35B-A3B-FP8                   |      |                    |                      |       | Pre-quantized offline FP8 model |
 | Qwen/Qwen3.5-122B-A10B                     |      |         ✅         |          ✅          |       |                           |
 | Qwen/QwQ-32B                               |  ✅  |         ✅         |          ✅          |       |                           |
 | mistralai/Ministral-8B-Instruct-2410       |  ✅  |         ✅         |          ✅          |       |                           |

--- a/vllm/README.md
+++ b/vllm/README.md
@@ -284,7 +284,6 @@ vllm serve \
     --disable-sliding-window \
     --gpu-memory-util=0.9 \
     --max-num-batched-tokens=8192 \
-    --disable-log-requests \
     --max-model-len=8192 \
     --block-size 64 \
     --quantization fp8 \
@@ -376,7 +375,6 @@ vllm serve \
     --gpu-memory-util=0.9 \
     --no-enable-prefix-caching \
     --max-num-batched-tokens=8192 \
-    --disable-log-requests \
     --max-model-len=8192 \
     --block-size 64 \
     --quantization sym_int4 \
@@ -442,7 +440,6 @@ vllm serve \
     --gpu-memory-util=0.9 \
     --no-enable-prefix-caching \
     --max-num-batched-tokens=2048 \
-    --disable-log-requests \
     --max-model-len=2048 \
     --block-size 64 \
     -tp=1
@@ -481,7 +478,6 @@ vllm serve \
     --gpu-memory-util=0.9 \
     --no-enable-prefix-caching \
     --max-num-batched-tokens=2048 \
-    --disable-log-requests \
     --max-model-len=2048 \
     --block-size 64 \
     -tp=1 \
@@ -534,7 +530,6 @@ vllm serve \
     --gpu-memory-util=0.9 \
     --no-enable-prefix-caching \
     --max-num-batched-tokens=5120 \
-    --disable-log-requests \
     --max-model-len=5120 \
     --block-size 64 \
     --quantization fp8 \
@@ -608,7 +603,6 @@ python3 -m vllm.entrypoints.openai.api_server \
     --gpu-memory-util=0.9 \
     --no-enable-prefix-caching \
     --max-num-batched-tokens=5120 \
-    --disable-log-requests \
     --max-model-len=5120 \
     --block-size 16 \
     --quantization fp8 \
@@ -654,7 +648,6 @@ vllm serve \
     --gpu-memory-util=0.9 \
     --no-enable-prefix-caching \
     --max-num-batched-tokens=5120 \
-    --disable-log-requests \
     --max-model-len=5120 \
     --block-size 64 \
     --quantization fp8 \
@@ -1003,7 +996,6 @@ vllm serve \
     --gpu-memory-util=0.9 \
     --no-enable-prefix-caching \
     --max-num-batched-tokens=8192 \
-    --disable-log-requests \
     --max-model-len=20000 \
     --block-size 64 \
     --served-model-name test \
@@ -1257,7 +1249,7 @@ export VLLM_WORKER_MULTIPROC_METHOD=spawn
 export VLLM_OFFLOAD_WEIGHTS_BEFORE_QUANT=1 # or ```export VLLM_OFFLOAD_WEIGHTS_BEFORE_QUANT=0```
 export ZE_AFFINITY_MASK=0,1 # assuming use the first two Arc GPUs
 
-vllm serve --port 8000 --host 0.0.0.0 --gpu-memory-util 0.9 --max-num-batched-tokens 8192 --max-model-len 40000 --block-size 64 --dtype float16 --model /llm/models/Qwen3.6-35B-A3B/ --served-model-name Qwen3.6-35B-A3B --tensor-parallel-size 2 --quantization fp8 --enforce-eager --trust-remote-code --disable-log-requests 
+vllm serve --port 8000 --host 0.0.0.0 --gpu-memory-util 0.9 --max-num-batched-tokens 8192 --max-model-len 40000 --block-size 64 --dtype float16 --model /llm/models/Qwen3.6-35B-A3B/ --served-model-name Qwen3.6-35B-A3B --tensor-parallel-size 2 --quantization fp8 --enforce-eager --trust-remote-code
 ```
 
 For Int4, please use 
@@ -1334,7 +1326,7 @@ export VLLM_ALLOW_LONG_MAX_MODEL_LEN=1
 export VLLM_WORKER_MULTIPROC_METHOD=spawn
 export VLLM_ALLOW_RUNTIME_LORA_UPDATING=True
 
-vllm serve --port 8000 --host 0.0.0.0 --gpu-memory-util 0.9 --max-num-batched-tokens 8192 --max-model-len 20000 --block-size 64 --dtype float16 --model /llm/models/Qwen3.6-27B/ --served-model-name Qwen3.6-27B --tensor-parallel-size 2 --quantization fp8 --enforce-eager --trust-remote-code --disable-log-requests --enable-lora --lora-modules adapter1=/llm/models/adapter/adapter1 adapter2=/llm/models/adapter/adapter2 --max-loras 2 --max-lora-rank 128
+vllm serve --port 8000 --host 0.0.0.0 --gpu-memory-util 0.9 --max-num-batched-tokens 8192 --max-model-len 20000 --block-size 64 --dtype float16 --model /llm/models/Qwen3.6-27B/ --served-model-name Qwen3.6-27B --tensor-parallel-size 2 --quantization fp8 --enforce-eager --trust-remote-code --enable-lora --lora-modules adapter1=/llm/models/adapter/adapter1 adapter2=/llm/models/adapter/adapter2 --max-loras 2 --max-lora-rank 128
 ```
 
 Example for Qwen3.6-35B-A3B with a single LoRA adapter:
@@ -1346,7 +1338,7 @@ export VLLM_ALLOW_LONG_MAX_MODEL_LEN=1
 export VLLM_WORKER_MULTIPROC_METHOD=spawn
 export VLLM_ALLOW_RUNTIME_LORA_UPDATING=True
 
-vllm serve --port 8000 --host 0.0.0.0 --gpu-memory-util 0.9 --max-num-batched-tokens 8192 --max-model-len 40000 --block-size 64 --dtype float16 --model /llm/models/Qwen3.6-35B-A3B/ --served-model-name Qwen3.6-35B-A3B --tensor-parallel-size 2 --quantization fp8 --enforce-eager --trust-remote-code --disable-log-requests --enable-lora --lora-modules adapter1=/llm/models/adapter/adapter1 --max-loras 1 --max-lora-rank 128
+vllm serve --port 8000 --host 0.0.0.0 --gpu-memory-util 0.9 --max-num-batched-tokens 8192 --max-model-len 40000 --block-size 64 --dtype float16 --model /llm/models/Qwen3.6-35B-A3B/ --served-model-name Qwen3.6-35B-A3B --tensor-parallel-size 2 --quantization fp8 --enforce-eager --trust-remote-code --enable-lora --lora-modules adapter1=/llm/models/adapter/adapter1 --max-loras 1 --max-lora-rank 128
 ```
 
 Key LoRA parameters:

--- a/vllm/README.md
+++ b/vllm/README.md
@@ -284,6 +284,7 @@ vllm serve \
     --disable-sliding-window \
     --gpu-memory-util=0.9 \
     --max-num-batched-tokens=8192 \
+    --disable-log-requests \
     --max-model-len=8192 \
     --block-size 64 \
     --quantization fp8 \
@@ -412,10 +413,9 @@ vllm serve \
     --disable-sliding-window \
     --gpu-memory-util=0.9 \
     --max-num-batched-tokens=8192 \
-    --disable-log-requests \
     --max-model-len=8192 \
     --block-size 64 \
-    -tp=1 \
+    -tp=2 \
     2>&1 | tee /llm/vllm.log > /proc/1/fd/1 &
 ```
 

--- a/vllm/README.md
+++ b/vllm/README.md
@@ -284,7 +284,6 @@ vllm serve \
     --disable-sliding-window \
     --gpu-memory-util=0.9 \
     --max-num-batched-tokens=8192 \
-    --disable-log-requests \
     --max-model-len=8192 \
     --block-size 64 \
     --quantization fp8 \

--- a/vllm/README.md
+++ b/vllm/README.md
@@ -354,6 +354,7 @@ To enable online quantization using `llm-scaler-vllm`, specify the desired quant
 | **MXFP4** | `mxfp4` | Microscaling FP4 quantization | `gpt-oss-20b`, `gpt-oss-120b` only |
 | **Online FP8** | `fp8` | Dynamic FP8 quantization at runtime | All supported models |
 | **Online INT4** | `sym_int4` | Dynamic symmetric INT4 quantization at runtime | All supported models |
+| **Offline FP8** | Not required | Uses pre-quantized FP8 weights from the model | `Qwen3.6-27B-FP8`, `Qwen3.6-35B-A3B-FP8` |
 | **Pre-quantized AWQ** | Not required | Auto-detected from model config (`quantization_config.quant_method: awq`) | AWQ-quantized models |
 | **Pre-quantized GPTQ** | Not required | Auto-detected from model config (`quantization_config.quant_method: gptq`) | GPTQ-quantized models |
 
@@ -1120,6 +1121,8 @@ crontab -l | grep -v "vllm_bootstrap_and_rotate.sh" | crontab -
 | Qwen/Qwen3-Coder-Next                      |  ✅  |         ✅         |                    |       |                           |
 | Qwen/Qwen3.6-27B                           |  ✅  |         ✅         |          ✅          |       | LoRA supported, see [LoRA Serving](#34-lora-adapter-serving). MTP supported, see [MTP Enable](#35-mtp-enable).|
 | Qwen/Qwen3.6-35B-A3B                       |  ✅  |         ✅         |          ✅          |       | LoRA supported, see [LoRA Serving](#34-lora-adapter-serving). MTP supported, see [MTP Enable](#35-mtp-enable).|
+| Qwen/Qwen3.6-27B-FP8                       |      |                    |                      |       | Pre-quantized offline FP8 model |
+| Qwen/Qwen3.6-35B-A3B-FP8                   |      |                    |                      |       | Pre-quantized offline FP8 model |
 | Qwen/Qwen3.5-122B-A10B                     |      |         ✅         |          ✅          |       |                           |
 | Qwen/QwQ-32B                               |  ✅  |         ✅         |          ✅          |       |                           |
 | mistralai/Ministral-8B-Instruct-2410       |  ✅  |         ✅         |          ✅          |       |                           |

--- a/vllm/README.md
+++ b/vllm/README.md
@@ -401,7 +401,23 @@ For pre-quantized models, such as AWQ-Int4, GPTQ-Int4, and Offline FP8 models, d
 To serve an Offline FP8 model, provide the model path directly. For example:
 
 ```bash
-vllm serve --model /llm/models/Qwen3.6-27B-FP8 --trust-remote-code
+VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
+VLLM_WORKER_MULTIPROC_METHOD=spawn \
+vllm serve \
+    --model /llm/models/Qwen3.6-27B-FP8 \
+    --dtype=float16 \
+    --enforce-eager \
+    --port 8000 \
+    --host 0.0.0.0 \
+    --trust-remote-code \
+    --disable-sliding-window \
+    --gpu-memory-util=0.9 \
+    --max-num-batched-tokens=8192 \
+    --disable-log-requests \
+    --max-model-len=8192 \
+    --block-size 64 \
+    -tp=1 \
+    2>&1 | tee /llm/vllm.log > /proc/1/fd/1 &
 ```
 
 Replace the model path with `/llm/models/Qwen3.6-35B-A3B-FP8` to serve that model.

--- a/vllm/README.md
+++ b/vllm/README.md
@@ -396,7 +396,15 @@ To use fp8 online quantization, simply replace `--quantization sym_int4` with:
 --quantization fp8
 ```
 
-For those models that have been quantized before, such as AWQ-Int4/GPTQ-Int4/FP8 models, user do not need to specify the `--quantization` option.
+For pre-quantized models, such as AWQ-Int4, GPTQ-Int4, and Offline FP8 models, do not specify the `--quantization` option.
+
+To serve an Offline FP8 model, provide the model path directly. For example:
+
+```bash
+vllm serve --model /llm/models/Qwen3.6-27B-FP8 --trust-remote-code
+```
+
+Replace the model path with `/llm/models/Qwen3.6-35B-A3B-FP8` to serve that model.
 
 ---
 

--- a/vllm/docker-compose/load_balancer/docker-compose.yml
+++ b/vllm/docker-compose/load_balancer/docker-compose.yml
@@ -17,7 +17,6 @@ services:
       --enforce-eager
       --port 8008
       --host 0.0.0.0
-      --disable-log-requests
       --trust-remote-code
       --gpu-memory-util=0.9
       --no-enable-prefix-caching
@@ -53,7 +52,6 @@ services:
       --enforce-eager
       --port 8009
       --host 0.0.0.0
-      --disable-log-requests
       --trust-remote-code
       --gpu-memory-util=0.9
       --no-enable-prefix-caching
@@ -78,4 +76,3 @@ services:
     volumes:
       - ./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg
     restart: always
-

--- a/vllm/patches/ai-dynamo-xpu/patches/vllm-xpu-v0.14.0.patch
+++ b/vllm/patches/ai-dynamo-xpu/patches/vllm-xpu-v0.14.0.patch
@@ -970,7 +970,6 @@ index 000000000..ae4909b29
 +      -tp 1 \
 +      --block-size ${BLOCK_SIZE} \
 +      --gpu-memory-utilization 0.8 \
-+      --disable-log-requests \
 +      --dtype float16 \
 +      --enforce-eager"
 +  echo ${BASELINE_BASE_CMD}      
@@ -997,7 +996,6 @@ index 000000000..ae4909b29
 +      --dtype float16 \
 +      -tp 1 \
 +      --gpu-memory-utilization 0.8 \
-+      --disable-log-requests \
 +      --kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\",\"kv_buffer_device\":\"cpu\"}'"
 +
 +
@@ -1016,7 +1014,6 @@ index 000000000..ae4909b29
 +      -tp 1 \
 +      --dtype float16 \
 +      --gpu-memory-utilization 0.8 \
-+      --disable-log-requests \
 +      --kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\",\"kv_buffer_device\":\"cpu\"}'"
 +
 +  echo ${PREFILL_BASE_CMD}
@@ -6537,4 +6534,3 @@ index 7916d1e02..acd0ab1c4 100644
                  f"{self.device_type} with {self.kv_buffer_device} kv_buffer "
 -- 
 2.43.0
-

--- a/vllm/patches/ai-dynamo-xpu/patches/vllm-xpu.patch
+++ b/vllm/patches/ai-dynamo-xpu/patches/vllm-xpu.patch
@@ -2618,7 +2618,6 @@ index 000000000..ae4909b29
 +      -tp 1 \
 +      --block-size ${BLOCK_SIZE} \
 +      --gpu-memory-utilization 0.8 \
-+      --disable-log-requests \
 +      --dtype float16 \
 +      --enforce-eager"
 +  echo ${BASELINE_BASE_CMD}      
@@ -2645,7 +2644,6 @@ index 000000000..ae4909b29
 +      --dtype float16 \
 +      -tp 1 \
 +      --gpu-memory-utilization 0.8 \
-+      --disable-log-requests \
 +      --kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\",\"kv_buffer_device\":\"cpu\"}'"
 +
 +
@@ -2664,7 +2662,6 @@ index 000000000..ae4909b29
 +      -tp 1 \
 +      --dtype float16 \
 +      --gpu-memory-utilization 0.8 \
-+      --disable-log-requests \
 +      --kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\",\"kv_buffer_device\":\"cpu\"}'"
 +
 +  echo ${PREFILL_BASE_CMD}
@@ -4057,4 +4054,3 @@ index 17f5be76c..063841988 100644
  
 -- 
 2.43.0
-

--- a/vllm/test/run_scripts/gen_run_script.py
+++ b/vllm/test/run_scripts/gen_run_script.py
@@ -57,7 +57,6 @@ def run_model(container, model:ModelSpec, config:ScriptConfig):
     outstr += '--gpu-memory-util=0.9 '
     outstr += '--no-enable-prefix-caching '
     outstr += '--max-num-batched-tokens=2048 '
-    outstr += '--disable-log-requests '
     outstr += '--max-model-len=2048 '
     outstr += '--block-size 64 '
     if model.quantization:

--- a/vllm/webui/multi-modal-gradio/README.md
+++ b/vllm/webui/multi-modal-gradio/README.md
@@ -48,7 +48,6 @@ vllm serve \
 --gpu-memory-util=0.9 \
 --no-enable-prefix-caching \
 --max-num-batched-tokens=8192 \
---disable-log-requests \
 --max-model-len=32768 \
 --block-size 64 \
 --quantization fp8 \


### PR DESCRIPTION
## Summary

- Document support for `Qwen3.6-27B-FP8` and `Qwen3.6-35B-A3B-FP8` on the project homepage.
- Add Offline FP8 guidance and both models to the vLLM supported-models documentation.

## Validation

- `git diff --check`
