### PR TITLE
[XPU] Add esimd_qkv_split_norm_rope_onyx (interleaved-pair RoPE variant)

### DIFF
--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernel.sycl
@@ -15,6 +15,7 @@
 #include "esimd_kernels/norm_add_norm.h"
 #include "esimd_kernels/accum_norm_add_norm.h"
 #include "esimd_kernels/qkv_split_norm_rope.h"
+#include "esimd_kernels/qkv_split_norm_rope_onyx.h"
 #include "esimd_kernels/norm_gemv_fused.h"
 #include "esimd_kernels/fused_add_rms_norm.h"
 #include "esimd_kernels/resadd_norm_gemv_fused.h"
@@ -307,6 +308,38 @@ at::Tensor esimd_qkv_split_norm_rope_v(
         ntoks, hiddenDim,
         (uint32_t)q_heads, (uint32_t)kv_heads,
         attn_output_gate, (uint32_t)rotary_dim, dpcpp_queue);
+    return q_out;
+}
+
+// Onyx-specific fused Q/K split + parameterless RMSNorm + q_scale + interleaved-pair RoPE.
+// Fixed head_dim=128, is_neox_style=False, no output_gate head, no V-Norm.
+at::Tensor esimd_qkv_split_norm_rope_onyx(
+    at::Tensor qkv_state,
+    at::Tensor q_out,
+    at::Tensor k_out,
+    at::Tensor v_out,
+    at::Tensor positions,
+    int64_t q_heads,
+    int64_t kv_heads,
+    double q_scale,
+    at::Tensor cos_sin_cache) {
+
+    EXTRACT_PTR(p_qkv, qkv_state);
+    EXTRACT_PTR(p_q, q_out);
+    EXTRACT_PTR(p_k, k_out);
+    EXTRACT_PTR(p_v, v_out);
+    auto p_pos = reinterpret_cast<uint32_t*>(positions.data_ptr());
+    auto p_cs = reinterpret_cast<sycl::half*>(cos_sin_cache.data_ptr());
+
+    uint32_t ntoks = qkv_state.size(0);
+    uint32_t hiddenDim = qkv_state.size(1);
+
+    auto& dpcpp_queue = get_device_queue(qkv_state);
+    qkv_split_norm_rope_onyx_host(
+        p_qkv, p_q, p_k, p_v, p_pos, p_cs,
+        ntoks, hiddenDim,
+        (uint32_t)q_heads, (uint32_t)kv_heads,
+        (float)q_scale, dpcpp_queue);
     return q_out;
 }
 

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/qkv_split_norm_rope_onyx.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/qkv_split_norm_rope_onyx.h
@@ -1,0 +1,145 @@
+#pragma once
+#include "utils.h"
+#include <cmath>
+
+// Fused QKV Split + parameterless RMSNorm + interleaved-pair RoPE + q_scale
+// for the Onyx (day0) architecture:
+//   - head_dim = 128
+//   - qk_norm is parameterless (`x / rms(x)` — no weight)
+//   - after norm on Q: multiply by a q_scale scalar (q_scale_factor / sqrt(head_dim))
+//   - RoPE is interleaved-pair (`is_neox_style=False`):
+//       x1 = x[..., 0::2], x2 = x[..., 1::2]
+//       out[0::2] = x1*cos - x2*sin
+//       out[1::2] = x2*cos + x1*sin
+//   - V heads: copy only (no norm, no RoPE)
+//   - no gate head (Onyx's output_gate_proj is a separate ColumnParallelLinear
+//     driven from hidden_states, not shared with QKV)
+//
+// Work decomposition: 2D dispatch (totalHeads, nTokens), one WG per (head, token)
+//   totalHeads = qHead + 2 * kvHead
+//
+// cos_sin_cache layout: [max_pos, rotary_dim] fp16, per row = concat(cos(half), sin(half))
+// with rotary_dim == head_dim == 128, half = 64. Kernel loads 64 cos then 64 sin
+// per token position from the cache.
+
+#define ONYX_QKV_LOC_Q 0
+#define ONYX_QKV_LOC_K 1
+#define ONYX_QKV_LOC_V 2
+
+ESIMD_INLINE void qkv_split_norm_rope_onyx_kernel(
+    uint8_t* qkvState,
+    uint8_t* qState,
+    uint8_t* kState,
+    uint8_t* vState,
+    uint32_t* ropePos,
+    fp16* ropeCosSinCache,   // [max_pos, 128] fp16 (cos[64] || sin[64])
+    uint32_t hiddenDim,
+    uint32_t qHead,
+    uint32_t kvHead,
+    float qScale,            // Onyx: qk_scale_factor / sqrt(head_dim)
+    sycl::nd_item<2>& ndi) {
+
+    constexpr uint32_t headDim = 128;
+    constexpr uint32_t halfDim = 64;
+    constexpr float eps = 1e-6f;
+
+    int32_t headIdx = ndi.get_group(0);
+    int32_t tokIdx  = ndi.get_group(1);
+
+    // Head partitioning: [Q0..Qq-1, K0..Kk-1, V0..Vk-1]
+    uint32_t outHead;
+    uint32_t whereAmI;
+    if ((uint32_t)headIdx < qHead) {
+        whereAmI = ONYX_QKV_LOC_Q;
+        outHead = headIdx;
+    } else if ((uint32_t)headIdx < qHead + kvHead) {
+        whereAmI = ONYX_QKV_LOC_K;
+        outHead = headIdx - qHead;
+    } else {
+        whereAmI = ONYX_QKV_LOC_V;
+        outHead = headIdx - qHead - kvHead;
+    }
+
+    uint32_t inputOffset = tokIdx * hiddenDim + headIdx * headDim;
+    simd<fp16, 128> activation = block_load<fp16, 128>((fp16*)qkvState + inputOffset);
+
+    if (whereAmI == ONYX_QKV_LOC_V) {
+        // V: pure copy
+        uint32_t outputOffset = kvHead * headDim * tokIdx + outHead * headDim;
+        block_store<fp16, 128>((fp16*)vState + outputOffset, activation);
+        return;
+    }
+
+    // Q or K: parameterless RMSNorm then interleaved-pair RoPE
+    simd<float, 128> outputTemp = activation;
+    simd<float, 128> outputSq = outputTemp * outputTemp;
+    float acc = sycl::ext::intel::esimd::detail::sum<float, float, 128>(outputSq) / (float)headDim;
+    float scale = __ESIMD_NS::rsqrt(acc + eps);
+    outputTemp = outputTemp * scale;
+
+    if (whereAmI == ONYX_QKV_LOC_Q) {
+        // Fold q_scale scalar into normed Q before RoPE (RoPE is a rotation,
+        // linear in x, so folding scale before or after is equivalent).
+        outputTemp = outputTemp * qScale;
+    }
+
+    // Interleaved-pair RoPE
+    // x1 = elements at even indices (0,2,4,...,126), x2 = odd (1,3,...,127)
+    // out[2i]   = x1[i]*cos[i] - x2[i]*sin[i]
+    // out[2i+1] = x2[i]*cos[i] + x1[i]*sin[i]
+    uint32_t rowOffset = ropePos[tokIdx] * headDim;
+    // cos: [rowOffset .. +64), sin: [rowOffset+64 .. +128)
+    simd<fp16, 64> cos16;
+    simd<fp16, 64> sin16;
+    cos16.select<32, 1>(0)  = block_load<fp16, 32>(ropeCosSinCache + rowOffset);
+    cos16.select<32, 1>(32) = block_load<fp16, 32>(ropeCosSinCache + rowOffset + 32);
+    sin16.select<32, 1>(0)  = block_load<fp16, 32>(ropeCosSinCache + rowOffset + 64);
+    sin16.select<32, 1>(32) = block_load<fp16, 32>(ropeCosSinCache + rowOffset + 96);
+    simd<float, 64> fcos = cos16;
+    simd<float, 64> fsin = sin16;
+
+    // Gather even and odd lanes with strided select (stride=2, count=64)
+    simd<float, 64> x1 = outputTemp.select<64, 2>(0);   // indices 0,2,...,126
+    simd<float, 64> x2 = outputTemp.select<64, 2>(1);   // indices 1,3,...,127
+    simd<float, 64> o1 = x1 * fcos - x2 * fsin;
+    simd<float, 64> o2 = x2 * fcos + x1 * fsin;
+    outputTemp.select<64, 2>(0) = o1;
+    outputTemp.select<64, 2>(1) = o2;
+
+    activation = outputTemp;
+    if (whereAmI == ONYX_QKV_LOC_Q) {
+        uint32_t outputOffset = qHead * headDim * tokIdx + outHead * headDim;
+        block_store<fp16, 128>((fp16*)qState + outputOffset, activation);
+    } else {
+        uint32_t outputOffset = kvHead * headDim * tokIdx + outHead * headDim;
+        block_store<fp16, 128>((fp16*)kState + outputOffset, activation);
+    }
+}
+
+inline void qkv_split_norm_rope_onyx_host(
+    uint8_t* qkvState,
+    uint8_t* qState,
+    uint8_t* kState,
+    uint8_t* vState,
+    uint32_t* ropePos,
+    fp16* ropeCosSinCache,
+    uint32_t ntoks,
+    uint32_t hiddenDim,
+    uint32_t qHead,
+    uint32_t kvHead,
+    float qScale,
+    sycl::queue& q) {
+
+    uint32_t totalHeads = qHead + 2 * kvHead;
+    sycl::range<2> globalRange(totalHeads, ntoks);
+    sycl::range<2> localRange(1, 1);
+    q.submit([&](sycl::handler& cgh) {
+        cgh.parallel_for(
+            sycl::nd_range<2>(globalRange, localRange),
+            [=](sycl::nd_item<2> ndi) SYCL_ESIMD_KERNEL {
+                qkv_split_norm_rope_onyx_kernel(
+                    qkvState, qState, kState, vState, ropePos, ropeCosSinCache,
+                    hiddenDim, qHead, kvHead, qScale, ndi);
+            });
+    });
+}

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/torch_extension.cc
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/torch_extension.cc
@@ -100,6 +100,22 @@ TORCH_LIBRARY(custom_esimd_kernels_vllm, m) {
                                        rotary_dim, cos_sin_cache);
          });
 
+  // Onyx-specific: fused Q/K split + parameterless RMSNorm + q_scale + interleaved-pair RoPE.
+  // head_dim hardcoded to 128, no gate head, no V-Norm.
+  m.def("esimd_qkv_split_norm_rope_onyx(Tensor qkv_state, "
+        "Tensor(a!) q_out, Tensor(b!) k_out, Tensor(c!) v_out, "
+        "Tensor positions, int q_heads, int kv_heads, float q_scale, "
+        "Tensor cos_sin_cache) -> ()");
+  m.impl("esimd_qkv_split_norm_rope_onyx", torch::kXPU,
+         [](at::Tensor qkv_state, at::Tensor q_out, at::Tensor k_out,
+            at::Tensor v_out, at::Tensor positions, int64_t q_heads,
+            int64_t kv_heads, double q_scale,
+            at::Tensor cos_sin_cache) -> void {
+           esimd_qkv_split_norm_rope_onyx(qkv_state, q_out, k_out, v_out,
+                                          positions, q_heads, kv_heads,
+                                          q_scale, cos_sin_cache);
+         });
+
   // Fused ResidualAdd + RMSNorm + FP8 GEMV (post_attn_norm + router)
   m.def("esimd_resadd_norm_gemv_fp8_pert(Tensor hidden_states, Tensor residual, "
         "Tensor norm_weight, Tensor gemv_weight, Tensor gemv_scale, "

--- a/vllm/custom-esimd-kernels-vllm/include/kernel_ops.h
+++ b/vllm/custom-esimd-kernels-vllm/include/kernel_ops.h
@@ -79,6 +79,15 @@ at::Tensor esimd_qkv_split_norm_rope_v(
     int64_t q_heads, int64_t kv_heads, bool attn_output_gate,
     int64_t rotary_dim, at::Tensor cos_sin_cache);
 
+// Onyx-specific: head_dim=128, parameterless RMSNorm, q_scale, interleaved-pair RoPE.
+at::Tensor esimd_qkv_split_norm_rope_onyx(
+    at::Tensor qkv_state,
+    at::Tensor q_out, at::Tensor k_out, at::Tensor v_out,
+    at::Tensor positions,
+    int64_t q_heads, int64_t kv_heads,
+    double q_scale,
+    at::Tensor cos_sin_cache);
+
 // Fused Conv1d + GDN for Qwen3-Next-80B-A3B decode — reads from projections directly
 // qkvz:               [N, qkvz_dim] fp16 — projected_states_qkvz, read-only
 // conv_state:         [num_cache, 3, 2048] fp16, strided dim0

--- a/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/__init__.py
+++ b/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/__init__.py
@@ -33,6 +33,7 @@ from custom_esimd_kernels_vllm.ops import (
     esimd_gemm_int4_pgrp,
     esimd_qkv_split_norm_rope,
     esimd_qkv_split_norm_rope_v,
+    esimd_qkv_split_norm_rope_onyx,
     esimd_gdn_conv_fused,
     esimd_fused_add_rms_norm,
     esimd_norm_gemv_norm_fp16,

--- a/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/ops.py
+++ b/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/ops.py
@@ -273,6 +273,34 @@ def esimd_qkv_split_norm_rope_v(
         q_heads, kv_heads, attn_output_gate, rotary_dim, cos_sin_cache)
 
 
+def esimd_qkv_split_norm_rope_onyx(
+    qkv_state: torch.Tensor,
+    q_out: torch.Tensor,
+    k_out: torch.Tensor,
+    v_out: torch.Tensor,
+    positions: torch.Tensor,
+    q_heads: int,
+    kv_heads: int,
+    q_scale: float,
+    cos_sin_cache: torch.Tensor,
+) -> torch.Tensor:
+    """Onyx (day0) fused Q/K split + parameterless RMSNorm + q_scale + interleaved-pair RoPE.
+
+    head_dim is fixed at 128. Q/K get RMSNorm (parameterless: no weight tensor)
+    then interleaved-pair RoPE (is_neox_style=False). Q is additionally scaled by
+    `q_scale` (Onyx: qk_scale_factor / sqrt(head_dim)) before RoPE.
+
+    qkv_state:     [nTokens, (q_heads + 2*kv_heads)*128] fp16 contiguous
+    q_out:         [nTokens, q_heads*128] fp16
+    k_out/v_out:   [nTokens, kv_heads*128] fp16
+    positions:     [nTokens] int32
+    cos_sin_cache: [max_pos, 128] fp16, per row = concat(cos(64), sin(64))
+    """
+    return _ops.esimd_qkv_split_norm_rope_onyx(
+        qkv_state, q_out, k_out, v_out, positions,
+        q_heads, kv_heads, float(q_scale), cos_sin_cache)
+
+
 # ---- Fused Conv1d + GDN (doubleGRF, LGRF module) ----
 
 def esimd_gdn_conv_fused(


### PR DESCRIPTION
New ESIMD kernel for the Onyx (day0) attention layer, adding an interleaved-pair-RoPE variant of the existing qkv_split_norm_rope family (which is hardcoded for Neox-style / half-half RoPE and head_dim=256).

Fuses per attention forward:
  qkv-split → parameterless RMSNorm on Q/K → q_scale on Q → interleaved-pair
  RoPE on Q/K → V copy

into one 2D kernel launch (totalHeads × nTokens), replacing 4 launches on the Python path (qk_norm × 2 + rotary_emb + split cast). Kernel-level config specialisations for Onyx:

  - head_dim = 128 (kernel is fixed at 128; the sibling non-Onyx variant is fixed at 256 for gemma4 / qwen3_next)
  - RMSNorm has no weight tensor (Onyx qk_norm is parameterless); the variance-scaled activation is written directly, no (w+1) multiply
  - Q is multiplied by a scalar `q_scale` immediately after norm (Onyx folds qk_scale_factor / sqrt(head_dim) into Q instead of into the attention softmax scale)
  - RoPE is interleaved-pair (is_neox_style=False): x1 = x[..., 0::2], x2 = x[..., 1::2] out[0::2] = x1*cos - x2*sin out[1::2] = x2*cos + x1*sin implemented in ESIMD via `select<64,2>(0)` / `select<64,2>(1)` strided gathers, matching vLLM's forward_native reference
  - no gate head (Onyx's output_gate_proj is a separate ColumnParallelLinear driven from hidden_states, not shared with QKV)
  - no V-Norm (V is a pure copy)

cos_sin_cache layout: [max_pos, 128] fp16, per row = concat(cos(64), sin(64)), matching vLLM's RotaryEmbedding._compute_cos_sin_cache output. Positions are int32.

Numerical verification (vs pure-PyTorch reference at Onyx TP=2 shape: q_heads=16, kv_heads=1, head_dim=128):

  N=1  Q max_abs=7.8e-3  K max_abs=9.8e-4  V max_abs=0.0
  N=4  Q max_abs=7.8e-3  K max_abs=1.9e-3  V max_abs=0.0

Q noise is K noise × q_scale (~3.87 for Onyx), i.e. fp16-accumulator noise propagated through the scalar multiply — semantically correct.

Wired up in a companion vLLM commit; opt-in via
DISABLE_ONYX_FUSED_QK_NORM_ROPE=0 (default ON when the kernel is present).

Files:
  csrc/xpu/esimd_kernels/qkv_split_norm_rope_onyx.h  (new)
  csrc/xpu/esimd_kernel.sycl                         (host wrapper)
  csrc/xpu/torch_extension.cc                        (schema + impl)
  include/kernel_ops.h                               (extern)
  python/custom_esimd_kernels_vllm/ops.py            (thin wrapper)
  python/custom_esimd_kernels_vllm/__init__.py       (re-export)