### PR TITLE
[SGLang] fix: pin OMIX GPU runtime closure version

### DIFF
--- a/sglang/docker/Dockerfile
+++ b/sglang/docker/Dockerfile
@@ -113,8 +113,23 @@ RUN --mount=type=bind,from=builder,source=/root/wheels,target=/tmp/wheels \
  && add-apt-repository -y ppa:kobuk-team/intel-graphics \
  && apt-get update \
  && apt-get install -y --no-install-recommends \
-        libze-intel-gpu1 libze1 intel-metrics-discovery intel-opencl-icd clinfo intel-gsc \
-        libze-dev \
+       # Keep the production GPU runtime aligned with intel/omix:0.1.0-devel-ubuntu24.04. \
+       # Pin direct packages and version-flexible driver dependencies so a later PPA \
+       # update cannot silently change the Level Zero/OpenCL runtime. \
+        libze-intel-gpu1=26.14.37833.4-1~24.04~ppa1 \
+        libze1=1.28.2-1~24.04~ppa1 \
+        libze-dev=1.28.2-1~24.04~ppa1 \
+        libze-intel-gpu-raytracing=1.2.2-1~24.04~ppa1 \
+        intel-opencl-icd=26.14.37833.4-1~24.04~ppa1 \
+        intel-metrics-discovery=1.14.183-1~24.04~ppa1 \
+        intel-gsc=0.9.5-1~24.04~ppa2 \
+        libigdgmm12=22.10.0-1~24.04~ppa1 \
+        libigc2=2.32.7-1256~24.04 \
+        libigdfcl2=2.32.7-1256~24.04 \
+        libigsc0=0.9.5-1~24.04~ppa2 \
+        libmetee5=5.0.0-1~24.04~ppa2 \
+        ocl-icd-libopencl1=2.3.2-1build1 \
+        clinfo \
  # --- Python deps: pre-built wheels + explicit runtime deps sglang needs ---
  && python3 -m pip config set global.break-system-packages true \
  && pip3 install uv \


### PR DESCRIPTION
# Pins the production Intel GPU Level Zero/OpenCL runtime closure to the OMIX baseline, preventing Intel Graphics PPA version drift.

## Problem

In the previous branch (`amr-registry.caas.intel.com/intelanalytics/llm-scaler-sglang:0.21.0-b1-0729`), the runtime closure was not pinned, causing `libze_intel_gpu.so.1` and other dependencies to drift due to the Intel Graphics PPA updates. This introduced performance regressions – for example, TPOT increased by 1–2 ms compared to the normal dev branch.

The versions we observed:
- Old (unpinned) branch: `libze_intel_gpu.so.1` = **1.15.38646**
- New (pinned) branch: `libze_intel_gpu.so.1` = **1.15.37833**

All dependencies in the new image are now strictly aligned with the `intel/omix:0.1.0-devel-ubuntu24.04` baseline.

## Performance Comparison (4k input, 2k output)

### Image 0729 (Before fix)
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 1         
Successful requests:                     1         
Benchmark duration (s):                  88.88     
Total input tokens:                      4096      
Total input text tokens:                 4096      
Total generated tokens:                  2048      
Total generated tokens (retokenized):    2069      
Request throughput (req/s):              0.01      
Input token throughput (tok/s):          46.08     
Output token throughput (tok/s):         23.04     
Peak output token throughput (tok/s):    24.00     
Peak concurrent requests:                1         
Total token throughput (tok/s):          69.13     
Concurrency:                             1.00      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   88868.17  
Median E2E Latency (ms):                 88868.17  
P90 E2E Latency (ms):                    88868.17  
P99 E2E Latency (ms):                    88868.17  
---------------Time to First Token----------------
Mean TTFT (ms):                          1248.54   
Median TTFT (ms):                        1248.54   
P99 TTFT (ms):                           1248.54   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          42.80     
Median TPOT (ms):                        42.80     
P99 TPOT (ms):                           42.80     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           42.80     
Median ITL (ms):                         41.94     
P95 ITL (ms):                            47.58     
P99 ITL (ms):                            49.77     
Max ITL (ms):                            51.71     
==================================================
```

### Image 0806 (After fix)
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 1         
Successful requests:                     1         
Benchmark duration (s):                  84.49     
Total input tokens:                      4096      
Total input text tokens:                 4096      
Total generated tokens:                  2048      
Total generated tokens (retokenized):    2071      
Request throughput (req/s):              0.01      
Input token throughput (tok/s):          48.48     
Output token throughput (tok/s):         24.24     
Peak output token throughput (tok/s):    25.00     
Peak concurrent requests:                1         
Total token throughput (tok/s):          72.72     
Concurrency:                             1.00      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   84480.09  
Median E2E Latency (ms):                 84480.09  
P90 E2E Latency (ms):                    84480.09  
P99 E2E Latency (ms):                    84480.09  
---------------Time to First Token----------------
Mean TTFT (ms):                          1250.45   
Median TTFT (ms):                        1250.45   
P99 TTFT (ms):                           1250.45   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          40.66     
Median TPOT (ms):                        40.66     
P99 TPOT (ms):                           40.66     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           40.66     
Median ITL (ms):                         40.16     
P95 ITL (ms):                            44.85     
P99 ITL (ms):                            59.49     
Max ITL (ms):                            63.62     
==================================================
```

## New Image

After updating the Dockerfile (pinning the runtime closure to the OMIX baseline), the newly built image is:

```
amr-registry.caas.intel.com/intelanalytics/llm-scaler-sglang:0.21.0-b1-0806
```

Image size: **12.4 GB**

![image](https://github.com/user-attachments/assets/77cbd8d6-a1bd-480f-bdce-9145fbe6d6f6)

Pull it using:

```bash
docker pull amr-registry.caas.intel.com/intelanalytics/llm-scaler-sglang:0.21.0-b1-0806
```

## Dockerfile Changes

The Dockerfile has been modified to explicitly pin the Intel GPU Level Zero and OpenCL runtime packages to the versions provided by `intel/omix:0.1.0-devel-ubuntu24.04`. This prevents the Intel Graphics PPA from automatically upgrading these libraries, thereby keeping the runtime closure consistent and avoiding unexpected performance drops.