### PR TITLE
Optimize gemma4

### DIFF
--- a/vllm/custom-esimd-kernels-vllm/csrc/eagle/eagle.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/eagle/eagle.sycl
@@ -169,7 +169,8 @@ inline void dumpDeviceMem(sycl::queue& debugDumpQueue, void* deviceMem, size_t s
 // ── Kernel 3: page attention kernel ───────────────────────────────
 void page_attention_forward_kernel(
   uint8_t* qState,
-  uint8_t* kvCache,
+  uint8_t* kCache,
+  uint8_t* vCache,
   uint32_t* pageTable,
   uint32_t* kvSeqLens,
   uint8_t* out,
@@ -184,8 +185,9 @@ void page_attention_forward_kernel(
   uint32_t headQk,
   uint32_t headV,
   uint32_t headDim,
-  uint32_t kvCacheStride0,
-  uint32_t kvCacheStride1,
+  uint32_t kvCachePageStride,
+  uint32_t kvCacheTokenStride,
+  uint32_t kvCacheHeadStride,
   uint32_t pageTableBatchStride,
   uint32_t pageTableSizeLog2,
   uint32_t pStride,
@@ -237,30 +239,34 @@ void page_attention_forward_kernel(
         kernelPhase1 = [&](sycl::handler& cgh) {
           cgh.parallel_for<class paPhase1Gqa2Forward>(
             rangePaPhase1, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
-              sdpaDecodeGqa2Phase1(qState, kvCache, (uint8_t*)pState, pGroupMax, pGlobalMax, pPollP, pageTable, kvSeqLens,
-                batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, gqaRatio, idx);
+              sdpaDecodeGqa2Phase1(qState, kCache, (uint8_t*)pState, pGroupMax, pGlobalMax, pPollP, pageTable, kvSeqLens,
+                batches, kvCachePageStride, kvCacheTokenStride, kvCacheHeadStride,
+                pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, gqaRatio, idx);
             });
           };
         kernelPhase2 = [&](sycl::handler& cgh) {
           cgh.parallel_for<class paPhase2Gqa2Forward>(
             rangePaPhase2, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
-              sdpaDecodeGqa2Phase2((uint8_t*)pState, pGroupMax, kvCache, pGlobalMax, pTempOut, pGlobalSoftmaxSum, out, pageTable, kvSeqLens,
-                batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, maxKvSeqLen, flag, gqaRatio, idx);
+              sdpaDecodeGqa2Phase2((uint8_t*)pState, pGroupMax, vCache, pGlobalMax, pTempOut, pGlobalSoftmaxSum, out, pageTable, kvSeqLens,
+                batches, kvCachePageStride, kvCacheTokenStride, kvCacheHeadStride,
+                pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, maxKvSeqLen, flag, gqaRatio, idx);
             });
           };
       } else {
         kernelPhase1 = [&](sycl::handler& cgh) {
           cgh.parallel_for<class paPhase1Forward>(
             rangePaPhase1, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
-              sdpaDecodeGqa4Phase1(qState, kvCache, (uint8_t*)pState, pGroupMax, pGlobalMax, pPollP, pageTable, kvSeqLens,
-                batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, gqaRatio, idx);
+              sdpaDecodeGqa4Phase1(qState, kCache, (uint8_t*)pState, pGroupMax, pGlobalMax, pPollP, pageTable, kvSeqLens,
+                batches, kvCachePageStride, kvCacheTokenStride, kvCacheHeadStride,
+                pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, gqaRatio, idx);
             });
           };
         kernelPhase2 = [&](sycl::handler& cgh) {
           cgh.parallel_for<class paPhase2Forward>(
             rangePaPhase2, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
-              sdpaDecodeGqa4Phase2((uint8_t*)pState, pGroupMax, kvCache, pGlobalMax, pTempOut, pGlobalSoftmaxSum, out, pageTable, kvSeqLens,
-                batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, maxKvSeqLen, flag, gqaRatio, idx);
+              sdpaDecodeGqa4Phase2((uint8_t*)pState, pGroupMax, vCache, pGlobalMax, pTempOut, pGlobalSoftmaxSum, out, pageTable, kvSeqLens,
+                batches, kvCachePageStride, kvCacheTokenStride, kvCacheHeadStride,
+                pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, maxKvSeqLen, flag, gqaRatio, idx);
             });
           };
       }
@@ -271,30 +277,34 @@ void page_attention_forward_kernel(
         kernelPhase1 = [&](sycl::handler& cgh) {
           cgh.parallel_for<class paPhase1Gqa2Fp8E4m3Forward>(
             rangePaPhase1, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
-              sdpaDecodeGqa2Phase1Fp8<Fp8Variant::E4M3FN>(qState, kvCache, (uint8_t*)pState, pGroupMax, pGlobalMax, pPollP, pageTable, kvSeqLens,
-                batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, gqaRatio, k_scale, idx);
+              sdpaDecodeGqa2Phase1Fp8<Fp8Variant::E4M3FN>(qState, kCache, (uint8_t*)pState, pGroupMax, pGlobalMax, pPollP, pageTable, kvSeqLens,
+                batches, kvCachePageStride, kvCacheTokenStride, kvCacheHeadStride,
+                pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, gqaRatio, k_scale, idx);
             });
           };
         kernelPhase2 = [&](sycl::handler& cgh) {
           cgh.parallel_for<class paPhase2Gqa2Fp8E4m3Forward>(
             rangePaPhase2, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
-              sdpaDecodeGqa2Phase2Fp8<Fp8Variant::E4M3FN>((uint8_t*)pState, pGroupMax, kvCache, pGlobalMax, pTempOut, pGlobalSoftmaxSum, out, pageTable, kvSeqLens,
-                batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, maxKvSeqLen, flag, gqaRatio, v_scale, idx);
+              sdpaDecodeGqa2Phase2Fp8<Fp8Variant::E4M3FN>((uint8_t*)pState, pGroupMax, vCache, pGlobalMax, pTempOut, pGlobalSoftmaxSum, out, pageTable, kvSeqLens,
+                batches, kvCachePageStride, kvCacheTokenStride, kvCacheHeadStride,
+                pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, maxKvSeqLen, flag, gqaRatio, v_scale, idx);
             });
           };
       } else {
         kernelPhase1 = [&](sycl::handler& cgh) {
           cgh.parallel_for<class paPhase1Fp8E4m3Forward>(
             rangePaPhase1, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
-              sdpaDecodeGqa4Phase1Fp8<Fp8Variant::E4M3FN>(qState, kvCache, (uint8_t*)pState, pGroupMax, pGlobalMax, pPollP, pageTable, kvSeqLens,
-                batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, gqaRatio, k_scale, idx);
+              sdpaDecodeGqa4Phase1Fp8<Fp8Variant::E4M3FN>(qState, kCache, (uint8_t*)pState, pGroupMax, pGlobalMax, pPollP, pageTable, kvSeqLens,
+                batches, kvCachePageStride, kvCacheTokenStride, kvCacheHeadStride,
+                pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, gqaRatio, k_scale, idx);
             });
           };
         kernelPhase2 = [&](sycl::handler& cgh) {
           cgh.parallel_for<class paPhase2Fp8E4m3Forward>(
             rangePaPhase2, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
-              sdpaDecodeGqa4Phase2Fp8<Fp8Variant::E4M3FN>((uint8_t*)pState, pGroupMax, kvCache, pGlobalMax, pTempOut, pGlobalSoftmaxSum, out, pageTable, kvSeqLens,
-                batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, maxKvSeqLen, flag, gqaRatio, v_scale, idx);
+              sdpaDecodeGqa4Phase2Fp8<Fp8Variant::E4M3FN>((uint8_t*)pState, pGroupMax, vCache, pGlobalMax, pTempOut, pGlobalSoftmaxSum, out, pageTable, kvSeqLens,
+                batches, kvCachePageStride, kvCacheTokenStride, kvCacheHeadStride,
+                pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, maxKvSeqLen, flag, gqaRatio, v_scale, idx);
             });
           };
       }
@@ -305,30 +315,34 @@ void page_attention_forward_kernel(
         kernelPhase1 = [&](sycl::handler& cgh) {
           cgh.parallel_for<class paPhase1Gqa2Fp8E5m2Forward>(
             rangePaPhase1, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
-              sdpaDecodeGqa2Phase1Fp8<Fp8Variant::E5M2>(qState, kvCache, (uint8_t*)pState, pGroupMax, pGlobalMax, pPollP, pageTable, kvSeqLens,
-                batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, gqaRatio, k_scale, idx);
+              sdpaDecodeGqa2Phase1Fp8<Fp8Variant::E5M2>(qState, kCache, (uint8_t*)pState, pGroupMax, pGlobalMax, pPollP, pageTable, kvSeqLens,
+                batches, kvCachePageStride, kvCacheTokenStride, kvCacheHeadStride,
+                pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, gqaRatio, k_scale, idx);
             });
           };
         kernelPhase2 = [&](sycl::handler& cgh) {
           cgh.parallel_for<class paPhase2Gqa2Fp8E5m2Forward>(
             rangePaPhase2, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
-              sdpaDecodeGqa2Phase2Fp8<Fp8Variant::E5M2>((uint8_t*)pState, pGroupMax, kvCache, pGlobalMax, pTempOut, pGlobalSoftmaxSum, out, pageTable, kvSeqLens,
-                batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, maxKvSeqLen, flag, gqaRatio, v_scale, idx);
+              sdpaDecodeGqa2Phase2Fp8<Fp8Variant::E5M2>((uint8_t*)pState, pGroupMax, vCache, pGlobalMax, pTempOut, pGlobalSoftmaxSum, out, pageTable, kvSeqLens,
+                batches, kvCachePageStride, kvCacheTokenStride, kvCacheHeadStride,
+                pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, maxKvSeqLen, flag, gqaRatio, v_scale, idx);
             });
           };
       } else {
         kernelPhase1 = [&](sycl::handler& cgh) {
           cgh.parallel_for<class paPhase1Fp8E5m2Forward>(
             rangePaPhase1, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
-              sdpaDecodeGqa4Phase1Fp8<Fp8Variant::E5M2>(qState, kvCache, (uint8_t*)pState, pGroupMax, pGlobalMax, pPollP, pageTable, kvSeqLens,
-                batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, gqaRatio, k_scale, idx);
+              sdpaDecodeGqa4Phase1Fp8<Fp8Variant::E5M2>(qState, kCache, (uint8_t*)pState, pGroupMax, pGlobalMax, pPollP, pageTable, kvSeqLens,
+                batches, kvCachePageStride, kvCacheTokenStride, kvCacheHeadStride,
+                pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, gqaRatio, k_scale, idx);
             });
           };
         kernelPhase2 = [&](sycl::handler& cgh) {
           cgh.parallel_for<class paPhase2Fp8E5m2Forward>(
             rangePaPhase2, [=](sycl::nd_item<3> idx) SYCL_ESIMD_KERNEL{
-              sdpaDecodeGqa4Phase2Fp8<Fp8Variant::E5M2>((uint8_t*)pState, pGroupMax, kvCache, pGlobalMax, pTempOut, pGlobalSoftmaxSum, out, pageTable, kvSeqLens,
-                batches, kvCacheStride0, kvCacheStride1, pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, maxKvSeqLen, flag, gqaRatio, v_scale, idx);
+              sdpaDecodeGqa4Phase2Fp8<Fp8Variant::E5M2>((uint8_t*)pState, pGroupMax, vCache, pGlobalMax, pTempOut, pGlobalSoftmaxSum, out, pageTable, kvSeqLens,
+                batches, kvCachePageStride, kvCacheTokenStride, kvCacheHeadStride,
+                pageTableBatchStride, pageTableSizeLog2, pStride, maxStride, headV, maxKvSeqLen, flag, gqaRatio, v_scale, idx);
             });
           };
       }
@@ -426,9 +440,10 @@ torch::Tensor gdn_eagle(
     return gdn_out;
 }
 
-void page_attn_decode(
+static void page_attn_decode_separate_impl(
   torch::Tensor query,
-  torch::Tensor kv_cache,
+  torch::Tensor key_cache,
+  torch::Tensor value_cache,
   torch::Tensor block_table,
   torch::Tensor seq_lens,
   torch::Tensor& out,
@@ -439,24 +454,37 @@ void page_attn_decode(
 ) {
   TORCH_CHECK(block_table.dim() == 2);
   TORCH_CHECK(seq_lens.dim() == 1);
-  TORCH_CHECK(kv_cache.dim() == 5);
+  TORCH_CHECK(key_cache.dim() == 4,
+              "key_cache must be [num_blocks, page_size, num_kv_heads, head_dim]");
+  TORCH_CHECK(value_cache.dim() == 4,
+              "value_cache must be [num_blocks, page_size, num_kv_heads, head_dim]");
+  TORCH_CHECK(key_cache.sizes() == value_cache.sizes(),
+              "key_cache and value_cache must have identical shapes");
+  TORCH_CHECK(key_cache.stride(0) == value_cache.stride(0)
+                 && key_cache.stride(1) == value_cache.stride(1)
+                 && key_cache.stride(2) == value_cache.stride(2)
+                 && key_cache.stride(3) == value_cache.stride(3),
+             "key_cache and value_cache must have identical strides");
+  TORCH_CHECK(key_cache.stride(3) == 1 && value_cache.stride(3) == 1,
+              "key/value cache head_dim must be contiguous");
   TORCH_CHECK(query.dim() == 3, "query must be [batches, num_q_heads, head_dim]");
   TORCH_CHECK(query.scalar_type() == torch::kHalf);
   TORCH_CHECK(
-    kv_cache.scalar_type() == torch::kHalf
-    || kv_cache.scalar_type() == at::kFloat8_e4m3fn
-    || kv_cache.scalar_type() == at::kFloat8_e5m2,
-    "kv_cache dtype must be float16 / float8_e4m3fn / float8_e5m2, got ",
-    kv_cache.scalar_type());
+    key_cache.scalar_type() == torch::kHalf
+    || key_cache.scalar_type() == at::kFloat8_e4m3fn
+    || key_cache.scalar_type() == at::kFloat8_e5m2,
+    "key/value cache dtype must be float16 / float8_e4m3fn / float8_e5m2, got ",
+    key_cache.scalar_type());
+  TORCH_CHECK(value_cache.scalar_type() == key_cache.scalar_type(),
+              "key/value cache dtypes must match");
   TORCH_CHECK(out.scalar_type() == torch::kHalf);
 
-  uint32_t kvCacheStride0 = kv_cache.stride(0);
-  uint32_t kvCacheStride1 = kv_cache.stride(1);
-  uint32_t totalDimsKv = kv_cache.dim();
-
-  uint32_t headDim = kv_cache.size(totalDimsKv - 1);
-  uint32_t headV = kv_cache.size(totalDimsKv - 2);
-  uint32_t pageSize = kv_cache.size(totalDimsKv - 3);
+  uint32_t kvCachePageStride = key_cache.stride(0);
+  uint32_t kvCacheTokenStride = key_cache.stride(1);
+  uint32_t kvCacheHeadStride = key_cache.stride(2);
+  uint32_t headDim = key_cache.size(3);
+  uint32_t headV = key_cache.size(2);
+  uint32_t pageSize = key_cache.size(1);
   uint32_t batches = seq_lens.size(0);
   // Derive headQk from query tensor shape instead of hardcoding gqaRatio=4
   uint32_t headQk = query.size(1);
@@ -488,7 +516,7 @@ void page_attn_decode(
   size_t totalSize = szP + szGroupMax + szGlobalMax + szGlobalPollP + szOutTemp + szGlobalSoftmaxSum;
 
   torch::Tensor temp_p = torch::zeros({ static_cast<long>(totalSize) },
-    torch::device(kv_cache.device()).dtype(torch::kFloat32));
+    torch::device(key_cache.device()).dtype(torch::kFloat32));
 
   float* pState = (float*)temp_p.data_ptr();
   float* pGroupMax = pState + szP;
@@ -496,11 +524,10 @@ void page_attn_decode(
   uint32_t* pPollP = (uint32_t*)pGlobalMax + szGlobalMax;
   float* pOutTemp = (float*)pPollP + szGlobalPollP;
   float* pGloablSoftmaxSum = (float*)pOutTemp + szOutTemp;
-  sycl::queue& queue = c10::xpu::getCurrentXPUStream(kv_cache.device().index()).queue();
-
   page_attention_forward_kernel(
     (uint8_t*)query.data_ptr(),
-    (uint8_t*)kv_cache.data_ptr(),
+    (uint8_t*)key_cache.data_ptr(),
+    (uint8_t*)value_cache.data_ptr(),
     (uint32_t*)block_table.data_ptr(),
     (uint32_t*)seq_lens.data_ptr(),
     (uint8_t*)out.data_ptr(),
@@ -515,32 +542,71 @@ void page_attn_decode(
     headQk,
     headV,
     headDim,
-    kvCacheStride0,
-    kvCacheStride1,
+    kvCachePageStride,
+    kvCacheTokenStride,
+    kvCacheHeadStride,
     pageTableBatchStride,
     pageTableSizeLog2,
     hiddenDimP,
     hiddenDimPMax,
     maxSeqLen,
     gqaRatio,
-    kv_cache.scalar_type(),
+    key_cache.scalar_type(),
     static_cast<float>(k_scale),
     static_cast<float>(v_scale),
-    kv_cache.device()
+    key_cache.device()
   );
+}
+
+void page_attn_decode(
+  torch::Tensor query,
+  torch::Tensor kv_cache,
+  torch::Tensor block_table,
+  torch::Tensor seq_lens,
+  torch::Tensor& out,
+  int64_t max_query_len,
+  int64_t max_seq_len,
+  double k_scale,
+  double v_scale
+) {
+  TORCH_CHECK(kv_cache.dim() == 5,
+              "legacy kv_cache must be [2, num_blocks, page_size, num_kv_heads, head_dim]");
+  page_attn_decode_separate_impl(
+    query, kv_cache.select(0, 0), kv_cache.select(0, 1), block_table,
+    seq_lens, out, max_query_len, max_seq_len, k_scale, v_scale);
+}
+
+void page_attn_decode_separate(
+  torch::Tensor query,
+  torch::Tensor key_cache,
+  torch::Tensor value_cache,
+  torch::Tensor block_table,
+  torch::Tensor seq_lens,
+  torch::Tensor& out,
+  int64_t max_query_len,
+  int64_t max_seq_len,
+  double k_scale,
+  double v_scale
+) {
+  page_attn_decode_separate_impl(
+    query, key_cache, value_cache, block_table, seq_lens, out,
+    max_query_len, max_seq_len, k_scale, v_scale);
 }
 
 TORCH_LIBRARY_FRAGMENT(eagle_ops, m) {
     m.def("gdn_eagle(Tensor! qkvz, Tensor! z_out, Tensor conv_w, Tensor? conv_b, Tensor! conv_state, Tensor accepted_tokens, Tensor ba, Tensor a_log, Tensor dt_bias, Tensor! state_in, Tensor ssm_state_idx, Tensor norm_w, int max_query_len) -> Tensor");
     m.def("page_attn_decode(Tensor query, Tensor kv_cache, Tensor block_table, Tensor seq_lens, Tensor! out, int max_query_len, int max_seq_len, float k_scale=1.0, float v_scale=1.0) -> ()");
+    m.def("page_attn_decode_separate(Tensor query, Tensor key_cache, Tensor value_cache, Tensor block_table, Tensor seq_lens, Tensor! out, int max_query_len, int max_seq_len, float k_scale=1.0, float v_scale=1.0) -> ()");
 }
 
 TORCH_LIBRARY_IMPL(eagle_ops, XPU, m) {
     m.impl("gdn_eagle", &gdn_eagle);
     m.impl("page_attn_decode", &page_attn_decode);
+    m.impl("page_attn_decode_separate", &page_attn_decode_separate);
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("gdn_eagle", &gdn_eagle, "gdn_eagle");
     m.def("page_attn_decode", &page_attn_decode, "page_attn_decode");
+    m.def("page_attn_decode_separate", &page_attn_decode_separate, "page_attn_decode_separate");
 }

--- a/vllm/custom-esimd-kernels-vllm/csrc/eagle/page.attn.fp8.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/eagle/page.attn.fp8.h
@@ -65,8 +65,9 @@ ESIMD_INLINE void sdpaDecodeGqa4Phase1Fp8(
   uint32_t* pageTable,
   uint32_t* batchKvSeqLen,
   uint32_t batchSize,
-  uint32_t kvCacheBatchStride0,
-  uint32_t kvCacheBatchStride1,
+  uint32_t kvCachePageStride,
+  uint32_t kvCacheTokenStride,
+  uint32_t kvCacheHeadStride,
   uint32_t pageTableBatchStride,
   uint32_t pageTableSizeLog2,
   uint32_t pStride,
@@ -117,7 +118,9 @@ ESIMD_INLINE void sdpaDecodeGqa4Phase1Fp8(
   uint32_t offsetQ = qHeadIdx * headDim * sizeof(fp16) + hh * 32 * sizeof(fp16) + batchIdx * headQ * headDim * sizeof(fp16);
   uint32_t baseCoordK = globalLinearId1 * outputPerGroup;
   // K is fp8 in HBM: all element strides drop to sizeof(uint8_t)==1.
-  uint32_t offsetBaseK = hh * 32 * sizeof(uint8_t) + headDim * kvHeadIdx * sizeof(uint8_t);
+  uint32_t offsetBaseK =
+    hh * 32 * sizeof(uint8_t) +
+    kvHeadIdx * kvCacheHeadStride * sizeof(uint8_t);
   uint32_t kvSeqOffset = baseCoordK;
 
   if (baseCoordK >= kvSeqLen) {
@@ -192,11 +195,9 @@ ESIMD_INLINE void sdpaDecodeGqa4Phase1Fp8(
       // Byte step: inner +16 byte = +16 fp8; outer +96 byte = +96 fp8.
       // (fp16's +192 byte outer is +96 fp16, same element count.)
       simdOffsetsK =
-        simdOffsetsK * headKv * headDim * sizeof(uint8_t) +
+        (simdOffsetsK + pageTableOffset) * kvCacheTokenStride * sizeof(uint8_t) +
         offsetBaseK +
-        pageIdx * kvCacheBatchStride1 * sizeof(uint8_t) +
-        pageTableOffset * headKv * headDim * sizeof(uint8_t)
-        ;
+        pageIdx * kvCachePageStride * sizeof(uint8_t);
 
       // Pull the entire chunk's 64-col footprint with ONE gather:
       //   NElts=16 -> 16 lane * 64 byte = 1024 fp8 / gather.  But hh's two
@@ -399,8 +400,9 @@ ESIMD_INLINE void sdpaDecodeGqa4Phase2Fp8(
   uint32_t* pageTable,
   uint32_t* batchKvSeqLen,
   uint32_t batchSize,
-  uint32_t kvCacheBatchStride0,
-  uint32_t kvCacheBatchStride1,
+  uint32_t kvCachePageStride,
+  uint32_t kvCacheTokenStride,
+  uint32_t kvCacheHeadStride,
   uint32_t pageTableBatchStride,
   uint32_t pageTableSizeLog2,
   uint32_t pStride,
@@ -468,16 +470,16 @@ ESIMD_INLINE void sdpaDecodeGqa4Phase2Fp8(
   uint32_t offsetMax = qBaseIdx * maxStride + batchIdx * headQ * maxStride + groupIdx * 16;
   uint32_t offsetGlobalMax = batchIdx * headQ + qBaseIdx;
   // V row width / X stride switch to fp8 (1 byte/element).
-  uint32_t widthV = headKv * headDim * sizeof(uint8_t) - 1;
+  uint32_t widthV = kvCacheTokenStride * sizeof(uint8_t) - 1;
   uint32_t heightV = pageTableSize - 1;
-  uint32_t vX = channelOffset * 16 + headDim * kvHeadIdx;
+  uint32_t vX = channelOffset * 16 + kvCacheHeadStride * kvHeadIdx;
   uint32_t vY = 32 * hh;
   uint32_t totalPages = (kvSeqLen + pageTableSize - 1) >> pageTableSizeLog2;
   uint32_t lastPageHeight = (kvSeqLen - 1) & (pageTableSize - 1);
   if (kvSeqLen == 0) {
     lastPageHeight = 0;
   }
-  uint8_t* vPtrBase = (uint8_t*)vState + kvCacheBatchStride0;     // K|V stride still in elements
+  uint8_t* vPtrBase = (uint8_t*)vState;
 
   historicMax = FP32_MIN * matMulQuantCoeff;
   softmaxSum = 0;
@@ -503,7 +505,7 @@ ESIMD_INLINE void sdpaDecodeGqa4Phase2Fp8(
     1,
     uint32_t>(pageTable, pageTableOffsets, mask);
 
-  pageAlignedOffsets = pageNumbers * kvCacheBatchStride1;
+  pageAlignedOffsets = pageNumbers * kvCachePageStride;
   pageAlignedOffsets.merge(0, maskNeg);
   globalMax = block_load<float, 4>(pGlobalMax + offsetGlobalMax);
 
@@ -683,8 +685,9 @@ ESIMD_INLINE void sdpaDecodeGqa2Phase1Fp8(
   uint32_t* pageTable,
   uint32_t* batchKvSeqLen,
   uint32_t batchSize,
-  uint32_t kvCacheBatchStride0,
-  uint32_t kvCacheBatchStride1,
+  uint32_t kvCachePageStride,
+  uint32_t kvCacheTokenStride,
+  uint32_t kvCacheHeadStride,
   uint32_t pageTableBatchStride,
   uint32_t pageTableSizeLog2,
   uint32_t pStride,
@@ -728,7 +731,9 @@ ESIMD_INLINE void sdpaDecodeGqa2Phase1Fp8(
   uint32_t outputMaxOffset = qHeadIdx * maxStride + globalLinearId1 + hh * maxStride + batchIdx * headQ * maxStride;
   uint32_t offsetQ = qHeadIdx * headDim * sizeof(fp16) + hh * 32 * sizeof(fp16) + batchIdx * headQ * headDim * sizeof(fp16);
   uint32_t baseCoordK = globalLinearId1 * outputPerGroup;
-  uint32_t offsetBaseK = hh * 32 * sizeof(uint8_t) + headDim * kvHeadIdx * sizeof(uint8_t);
+  uint32_t offsetBaseK =
+    hh * 32 * sizeof(uint8_t) +
+    kvHeadIdx * kvCacheHeadStride * sizeof(uint8_t);
   uint32_t kvSeqOffset = baseCoordK;
 
   if (baseCoordK >= kvSeqLen) {
@@ -781,11 +786,9 @@ ESIMD_INLINE void sdpaDecodeGqa2Phase1Fp8(
       simdOffsetsK = baseOffsetInc16AsSimd;
 
       simdOffsetsK =
-        simdOffsetsK * headKv * headDim * sizeof(uint8_t) +
+        (simdOffsetsK + pageTableOffset) * kvCacheTokenStride * sizeof(uint8_t) +
         offsetBaseK +
-        pageIdx * kvCacheBatchStride1 * sizeof(uint8_t) +
-        pageTableOffset * headKv * headDim * sizeof(uint8_t)
-        ;
+        pageIdx * kvCachePageStride * sizeof(uint8_t);
 
 #pragma unroll
       for (int kk = 0; kk < 2; kk++) {
@@ -938,8 +941,9 @@ ESIMD_INLINE void sdpaDecodeGqa2Phase2Fp8(
   uint32_t* pageTable,
   uint32_t* batchKvSeqLen,
   uint32_t batchSize,
-  uint32_t kvCacheBatchStride0,
-  uint32_t kvCacheBatchStride1,
+  uint32_t kvCachePageStride,
+  uint32_t kvCacheTokenStride,
+  uint32_t kvCacheHeadStride,
   uint32_t pageTableBatchStride,
   uint32_t pageTableSizeLog2,
   uint32_t pStride,
@@ -1000,16 +1004,16 @@ ESIMD_INLINE void sdpaDecodeGqa2Phase2Fp8(
   uint32_t offsetP = qBaseIdx * pStride + hh * 32 + groupIdx * 1024 + batchIdx * headQ * pStride;
   uint32_t offsetMax = qBaseIdx * maxStride + batchIdx * headQ * maxStride + groupIdx * 16;
   uint32_t offsetGlobalMax = batchIdx * headQ + qBaseIdx;
-  uint32_t widthV = headKv * headDim * sizeof(uint8_t) - 1;
+  uint32_t widthV = kvCacheTokenStride * sizeof(uint8_t) - 1;
   uint32_t heightV = pageTableSize - 1;
-  uint32_t vX = channelOffset * 16 + headDim * kvHeadIdx;
+  uint32_t vX = channelOffset * 16 + kvCacheHeadStride * kvHeadIdx;
   uint32_t vY = 32 * hh;
   uint32_t totalPages = (kvSeqLen + pageTableSize - 1) >> pageTableSizeLog2;
   uint32_t lastPageHeight = (kvSeqLen - 1) & (pageTableSize - 1);
   if (kvSeqLen == 0) {
     lastPageHeight = 0;
   }
-  uint8_t* vPtrBase = (uint8_t*)vState + kvCacheBatchStride0;
+  uint8_t* vPtrBase = (uint8_t*)vState;
 
   historicMax = FP32_MIN * matMulQuantCoeff;
   softmaxSum = 0;
@@ -1035,7 +1039,7 @@ ESIMD_INLINE void sdpaDecodeGqa2Phase2Fp8(
     1,
     uint32_t>(pageTable, pageTableOffsets, mask);
 
-  pageAlignedOffsets = pageNumbers * kvCacheBatchStride1;
+  pageAlignedOffsets = pageNumbers * kvCachePageStride;
   pageAlignedOffsets.merge(0, maskNeg);
   globalMax = block_load<float, QPER>(pGlobalMax + offsetGlobalMax);
 

--- a/vllm/custom-esimd-kernels-vllm/csrc/eagle/page.attn.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/eagle/page.attn.h
@@ -1,6 +1,8 @@
 #define FP32_MIN (-1e+38)
-// kv cache shape [2 (k/v), reserved size, page_size, head_num, head_dim]
-// kv cache strid: [2 * page_size * head_num * head_dim, page_size * head_num * head_dim, head_dim, head_dim, 1]
+// K and V are passed as separate base pointers.  The page, token, and head
+// strides are expressed in elements so the kernel can consume both the
+// legacy [2, blocks, page, heads, head_dim] cache and v0.26's packed
+// [blocks, page, heads, 2 * head_dim] cache without a copy.
 ESIMD_INLINE void sdpaDecodeGqa4Phase1(
   uint8_t* qState,
   uint8_t* kState,
@@ -11,8 +13,9 @@ ESIMD_INLINE void sdpaDecodeGqa4Phase1(
   uint32_t* pageTable,
   uint32_t* batchKvSeqLen,
   uint32_t batchSize,
-  uint32_t kvCacheBatchStride0, 
-  uint32_t kvCacheBatchStride1,
+  uint32_t kvCachePageStride,
+  uint32_t kvCacheTokenStride,
+  uint32_t kvCacheHeadStride,
   uint32_t pageTableBatchStride,
   uint32_t pageTableSizeLog2,
   uint32_t pStride,
@@ -57,7 +60,9 @@ ESIMD_INLINE void sdpaDecodeGqa4Phase1(
   uint32_t outputMaxOffset = qHeadIdx * maxStride + globalLinearId1 + hh * maxStride + batchIdx * headQ * maxStride;
   uint32_t offsetQ = qHeadIdx * headDim * sizeof(fp16) + hh * 32 * sizeof(fp16) + batchIdx * headQ * headDim * sizeof(fp16);
   uint32_t baseCoordK = globalLinearId1 * outputPerGroup;
-  uint32_t offsetBaseK = hh * 32 * sizeof(fp16) + headDim * kvHeadIdx * sizeof(fp16);
+  uint32_t offsetBaseK =
+    hh * 32 * sizeof(fp16) +
+    kvHeadIdx * kvCacheHeadStride * sizeof(fp16);
   uint32_t kvSeqOffset = baseCoordK;
 
   if (baseCoordK >= kvSeqLen) {
@@ -96,12 +101,10 @@ ESIMD_INLINE void sdpaDecodeGqa4Phase1(
       maskNeg = logicSimdOffsetK >= kvSeqLen;
       simdOffsetsK = baseOffsetInc16AsSimd;
 
-      simdOffsetsK = 
-        simdOffsetsK * headKv * headDim * sizeof(fp16) +
+      simdOffsetsK =
+        (simdOffsetsK + pageTableOffset) * kvCacheTokenStride * sizeof(fp16) +
         offsetBaseK +
-        pageIdx * kvCacheBatchStride1 * sizeof(fp16) +
-        pageTableOffset * headKv * headDim * sizeof(fp16)
-        ;
+        pageIdx * kvCachePageStride * sizeof(fp16);
 
 #pragma unroll
       for (int kk = 0; kk < 2; kk++) {
@@ -232,8 +235,9 @@ ESIMD_INLINE void sdpaDecodeGqa4Phase2(
   uint32_t* pageTable,
   uint32_t* batchKvSeqLen,
   uint32_t batchSize,
-  uint32_t kvCacheBatchStride0,
-  uint32_t kvCacheBatchStride1,
+  uint32_t kvCachePageStride,
+  uint32_t kvCacheTokenStride,
+  uint32_t kvCacheHeadStride,
   uint32_t pageTableBatchStride,
   uint32_t pageTableSizeLog2,
   uint32_t pStride,
@@ -298,16 +302,16 @@ ESIMD_INLINE void sdpaDecodeGqa4Phase2(
   uint32_t offsetP = qBaseIdx * pStride + hh * 32 + groupIdx * 1024 + batchIdx * headQ * pStride;
   uint32_t offsetMax = qBaseIdx * maxStride + batchIdx * headQ * maxStride + groupIdx * 16;
   uint32_t offsetGlobalMax = batchIdx * headQ + qBaseIdx;
-  uint32_t widthV = headKv * headDim * sizeof(fp16) - 1;
+  uint32_t widthV = kvCacheTokenStride * sizeof(fp16) - 1;
   uint32_t heightV = pageTableSize - 1;
-  uint32_t vX = channelOffset * 16 + headDim * kvHeadIdx;
+  uint32_t vX = channelOffset * 16 + kvCacheHeadStride * kvHeadIdx;
   uint32_t vY = 32 * hh;
   uint32_t totalPages = (kvSeqLen + pageTableSize - 1) >> pageTableSizeLog2;
   uint32_t lastPageHeight = (kvSeqLen - 1) & (pageTableSize - 1);
   if (kvSeqLen == 0) {
     lastPageHeight = 0;
   }
-  fp16* vPtrBase = (fp16*)vState + kvCacheBatchStride0;
+  fp16* vPtrBase = (fp16*)vState;
 
   historicMax = FP32_MIN * matMulQuantCoeff;
   softmaxSum = 0;
@@ -333,7 +337,7 @@ ESIMD_INLINE void sdpaDecodeGqa4Phase2(
     1,
     uint32_t>(pageTable, pageTableOffsets, mask);
 
-  pageAlignedOffsets = pageNumbers * kvCacheBatchStride1;
+  pageAlignedOffsets = pageNumbers * kvCachePageStride;
   pageAlignedOffsets.merge(0, maskNeg);
   globalMax = block_load<float, 4>(pGlobalMax + offsetGlobalMax);
 
@@ -574,8 +578,9 @@ ESIMD_INLINE void sdpaDecodeGqa2Phase1(
   uint32_t* pageTable,
   uint32_t* batchKvSeqLen,
   uint32_t batchSize,
-  uint32_t kvCacheBatchStride0,
-  uint32_t kvCacheBatchStride1,
+  uint32_t kvCachePageStride,
+  uint32_t kvCacheTokenStride,
+  uint32_t kvCacheHeadStride,
   uint32_t pageTableBatchStride,
   uint32_t pageTableSizeLog2,
   uint32_t pStride,
@@ -618,7 +623,9 @@ ESIMD_INLINE void sdpaDecodeGqa2Phase1(
   uint32_t outputMaxOffset = qHeadIdx * maxStride + globalLinearId1 + hh * maxStride + batchIdx * headQ * maxStride;
   uint32_t offsetQ = qHeadIdx * headDim * sizeof(fp16) + hh * 32 * sizeof(fp16) + batchIdx * headQ * headDim * sizeof(fp16);
   uint32_t baseCoordK = globalLinearId1 * outputPerGroup;
-  uint32_t offsetBaseK = hh * 32 * sizeof(fp16) + headDim * kvHeadIdx * sizeof(fp16);
+  uint32_t offsetBaseK =
+    hh * 32 * sizeof(fp16) +
+    kvHeadIdx * kvCacheHeadStride * sizeof(fp16);
   uint32_t kvSeqOffset = baseCoordK;
 
   if (baseCoordK >= kvSeqLen) {
@@ -658,11 +665,9 @@ ESIMD_INLINE void sdpaDecodeGqa2Phase1(
       simdOffsetsK = baseOffsetInc16AsSimd;
 
       simdOffsetsK =
-        simdOffsetsK * headKv * headDim * sizeof(fp16) +
+        (simdOffsetsK + pageTableOffset) * kvCacheTokenStride * sizeof(fp16) +
         offsetBaseK +
-        pageIdx * kvCacheBatchStride1 * sizeof(fp16) +
-        pageTableOffset * headKv * headDim * sizeof(fp16)
-        ;
+        pageIdx * kvCachePageStride * sizeof(fp16);
 
 #pragma unroll
       for (int kk = 0; kk < 2; kk++) {
@@ -795,8 +800,9 @@ ESIMD_INLINE void sdpaDecodeGqa2Phase2(
   uint32_t* pageTable,
   uint32_t* batchKvSeqLen,
   uint32_t batchSize,
-  uint32_t kvCacheBatchStride0,
-  uint32_t kvCacheBatchStride1,
+  uint32_t kvCachePageStride,
+  uint32_t kvCacheTokenStride,
+  uint32_t kvCacheHeadStride,
   uint32_t pageTableBatchStride,
   uint32_t pageTableSizeLog2,
   uint32_t pStride,
@@ -858,16 +864,16 @@ ESIMD_INLINE void sdpaDecodeGqa2Phase2(
   uint32_t offsetP = qBaseIdx * pStride + hh * 32 + groupIdx * 1024 + batchIdx * headQ * pStride;
   uint32_t offsetMax = qBaseIdx * maxStride + batchIdx * headQ * maxStride + groupIdx * 16;
   uint32_t offsetGlobalMax = batchIdx * headQ + qBaseIdx;
-  uint32_t widthV = headKv * headDim * sizeof(fp16) - 1;
+  uint32_t widthV = kvCacheTokenStride * sizeof(fp16) - 1;
   uint32_t heightV = pageTableSize - 1;
-  uint32_t vX = channelOffset * 16 + headDim * kvHeadIdx;
+  uint32_t vX = channelOffset * 16 + kvCacheHeadStride * kvHeadIdx;
   uint32_t vY = 32 * hh;
   uint32_t totalPages = (kvSeqLen + pageTableSize - 1) >> pageTableSizeLog2;
   uint32_t lastPageHeight = (kvSeqLen - 1) & (pageTableSize - 1);
   if (kvSeqLen == 0) {
     lastPageHeight = 0;
   }
-  fp16* vPtrBase = (fp16*)vState + kvCacheBatchStride0;
+  fp16* vPtrBase = (fp16*)vState;
 
   historicMax = FP32_MIN * matMulQuantCoeff;
   softmaxSum = 0;
@@ -893,7 +899,7 @@ ESIMD_INLINE void sdpaDecodeGqa2Phase2(
     1,
     uint32_t>(pageTable, pageTableOffsets, mask);
 
-  pageAlignedOffsets = pageNumbers * kvCacheBatchStride1;
+  pageAlignedOffsets = pageNumbers * kvCachePageStride;
   pageAlignedOffsets.merge(0, maskNeg);
   globalMax = block_load<float, QPER>(pGlobalMax + offsetGlobalMax);
 

--- a/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe.sycl
@@ -2240,6 +2240,81 @@ torch::Tensor moe_forward_full_gelu_tanh_decode(
     return final_out.narrow(0, 0, 1);
 }
 
+// Native XPU expert layout: gate_up [E, hidden, 2*inter],
+// down [E, inter, hidden]. Keeps the fully-fused decode contract without
+// materializing a canonical [E,N,K] copy for every layer.
+torch::Tensor moe_forward_full_gelu_tanh_decode_native(
+    torch::Tensor x, torch::Tensor logits,
+    torch::Tensor gate_up_weight, torch::Tensor gate_up_scale,
+    torch::Tensor down_weight, torch::Tensor down_scale,
+    torch::Tensor per_expert_scale,
+    int64_t top_k, int64_t n_routed_experts) {
+    TORCH_CHECK(x.scalar_type() == torch::kHalf);
+    TORCH_CHECK(x.size(0) == 1, "decode kernel requires n_tokens==1");
+    TORCH_CHECK(gate_up_weight.dim() == 3 && down_weight.dim() == 3);
+    int hidden_size = x.size(1);
+    TORCH_CHECK(gate_up_weight.size(1) == hidden_size);
+    TORCH_CHECK(gate_up_weight.size(2) % 2 == 0);
+    int intermediate_size = gate_up_weight.size(2) / 2;
+    TORCH_CHECK(down_weight.size(1) == intermediate_size);
+    TORCH_CHECK(down_weight.size(2) == hidden_size);
+    TORCH_CHECK(hidden_size % 16 == 0 && intermediate_size % 16 == 0);
+    int rows_per_token = top_k;
+    ensure_gemma4_moe_buffers(
+        1, top_k, hidden_size, intermediate_size, x.device());
+    sycl::queue& q =
+        c10::xpu::getCurrentXPUStream(x.device().index()).queue();
+
+    dispatch_moe_topk_forward<class MoeTopKGemma4DecodeNative>(
+        (const fp16*)logits.data_ptr(),
+        sg_topk_idx.data_ptr<int>(),
+        (fp16*)sg_topk_weight.data_ptr(),
+        1, (int)n_routed_experts, (int)top_k, /*norm=*/true,
+        logits.device());
+
+    q.submit([&](sycl::handler& h){
+        h.parallel_for(sycl::range<1>(top_k), MoeFoldExpertScale{
+            (fp16*)sg_topk_weight.data_ptr(),
+            sg_topk_idx.data_ptr<int>(),
+            per_expert_scale.data_ptr<float>(),
+            (int)top_k});
+    });
+
+    const int* idx_ptr = sg_topk_idx.data_ptr<int>();
+    const fp16* route_weight =
+        (const fp16*)sg_topk_weight.data_ptr();
+    q.submit([&](sycl::handler& h){
+        h.parallel_for(sycl::nd_range<2>(
+            sycl::range<2>(top_k, intermediate_size / 16),
+            sycl::range<2>(1, 1)), MoeUpDecodeGeluTanhNative{
+                (const fp16*)x.data_ptr(),
+                (const uint8_t*)gate_up_weight.data_ptr(),
+                gate_up_scale.data_ptr<float>(),
+                idx_ptr,
+                (fp16*)sg_intermediates.data_ptr(),
+                hidden_size, intermediate_size, (int)top_k});
+    });
+    q.submit([&](sycl::handler& h){
+        h.parallel_for(sycl::nd_range<2>(
+            sycl::range<2>(top_k, hidden_size / 16),
+            sycl::range<2>(1, 1)), MoeDownDecodeNative{
+                (const fp16*)sg_intermediates.data_ptr(),
+                (const uint8_t*)down_weight.data_ptr(),
+                down_scale.data_ptr<float>(),
+                route_weight,
+                idx_ptr,
+                (fp16*)sg_routed_output.data_ptr(),
+                hidden_size, intermediate_size, (int)top_k});
+    });
+
+    auto& final_out = sg_take_final_output();
+    moe_accumulate_kernel(
+        (const fp16*)sg_routed_output.data_ptr(),
+        (fp16*)final_out.data_ptr(),
+        1, hidden_size, rows_per_token, x.device());
+    return final_out.narrow(0, 0, 1);
+}
+
 // ========== gemma4: variant with externally supplied routing ==========
 // Skip the built-in softmax/topk. Caller passes per-token topk indices and
 // weights that already encode model-specific routing logic (e.g. gemma4's
@@ -2451,6 +2526,7 @@ TORCH_LIBRARY_FRAGMENT(moe_ops, m) {
     m.def("moe_forward_full_gelu_tanh_routed(Tensor x, Tensor topk_weights, Tensor topk_indices, Tensor gate_up_weight, Tensor gate_up_scale, Tensor down_weight, Tensor down_scale, int top_k, int n_routed_experts) -> Tensor");
     m.def("moe_forward_full_gelu_tanh_routed_decode(Tensor x, Tensor topk_weights, Tensor topk_indices, Tensor gate_up_weight, Tensor gate_up_scale, Tensor down_weight, Tensor down_scale, int top_k, int n_routed_experts) -> Tensor");
     m.def("moe_forward_full_gelu_tanh_decode(Tensor x, Tensor logits, Tensor gate_up_weight, Tensor gate_up_scale, Tensor down_weight, Tensor down_scale, Tensor per_expert_scale, int top_k, int n_routed_experts) -> Tensor");
+    m.def("moe_forward_full_gelu_tanh_decode_native(Tensor x, Tensor logits, Tensor gate_up_weight, Tensor gate_up_scale, Tensor down_weight, Tensor down_scale, Tensor per_expert_scale, int top_k, int n_routed_experts) -> Tensor");
     m.def("moe_up_fp8_grouped(Tensor x, Tensor gate_up_weight, Tensor gate_up_scale, Tensor expert_offsets, Tensor expert_tokens, int top_k, int n_routed_experts) -> Tensor");
     m.def("moe_down_fp8_grouped(Tensor intermediate, Tensor down_weight, Tensor down_scale, Tensor routing_weights, Tensor expert_offsets, Tensor expert_tokens, int top_k, int n_routed_experts) -> Tensor");
     m.def("moe_forward_full_fp8_grouped(Tensor x, Tensor gate_up_weight, Tensor gate_up_scale, Tensor down_weight, Tensor down_scale, Tensor routing_weights, Tensor expert_offsets, Tensor expert_tokens, int top_k, int n_routed_experts) -> Tensor");
@@ -2470,6 +2546,7 @@ TORCH_LIBRARY_IMPL(moe_ops, XPU, m) {
     m.impl("moe_forward_full_gelu_tanh_routed", &moe_forward_full_gelu_tanh_routed);
     m.impl("moe_forward_full_gelu_tanh_routed_decode", &moe_forward_full_gelu_tanh_routed_decode);
     m.impl("moe_forward_full_gelu_tanh_decode", &moe_forward_full_gelu_tanh_decode);
+    m.impl("moe_forward_full_gelu_tanh_decode_native", &moe_forward_full_gelu_tanh_decode_native);
     m.impl("moe_up_fp8_grouped", &moe_up_fp8_grouped);
     m.impl("moe_down_fp8_grouped", &moe_down_fp8_grouped);
     m.impl("moe_forward_full_fp8_grouped", &moe_forward_full_fp8_grouped);

--- a/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe.sycl
@@ -2283,29 +2283,59 @@ torch::Tensor moe_forward_full_gelu_tanh_decode_native(
     const int* idx_ptr = sg_topk_idx.data_ptr<int>();
     const fp16* route_weight =
         (const fp16*)sg_topk_weight.data_ptr();
-    q.submit([&](sycl::handler& h){
-        h.parallel_for(sycl::nd_range<2>(
-            sycl::range<2>(top_k, intermediate_size / 16),
-            sycl::range<2>(1, 1)), MoeUpDecodeGeluTanhNative{
-                (const fp16*)x.data_ptr(),
-                (const uint8_t*)gate_up_weight.data_ptr(),
-                gate_up_scale.data_ptr<float>(),
-                idx_ptr,
-                (fp16*)sg_intermediates.data_ptr(),
-                hidden_size, intermediate_size, (int)top_k});
-    });
-    q.submit([&](sycl::handler& h){
-        h.parallel_for(sycl::nd_range<2>(
-            sycl::range<2>(top_k, hidden_size / 16),
-            sycl::range<2>(1, 1)), MoeDownDecodeNative{
-                (const fp16*)sg_intermediates.data_ptr(),
-                (const uint8_t*)down_weight.data_ptr(),
-                down_scale.data_ptr<float>(),
-                route_weight,
-                idx_ptr,
-                (fp16*)sg_routed_output.data_ptr(),
-                hidden_size, intermediate_size, (int)top_k});
-    });
+    const char* disable_grouped =
+        std::getenv("DISABLE_GEMMA4_NATIVE_MOE_GROUPED");
+    const bool use_grouped_native =
+        disable_grouped == nullptr || disable_grouped[0] != '1';
+    if (use_grouped_native) {
+        q.submit([&](sycl::handler& h){
+            h.parallel_for(sycl::nd_range<2>(
+                sycl::range<2>(top_k, intermediate_size),
+                sycl::range<2>(1, 16)), MoeUpDecodeGeluTanhNativeGrouped{
+                    (const fp16*)x.data_ptr(),
+                    (const uint8_t*)gate_up_weight.data_ptr(),
+                    gate_up_scale.data_ptr<float>(),
+                    idx_ptr,
+                    (fp16*)sg_intermediates.data_ptr(),
+                    hidden_size, intermediate_size, (int)top_k});
+        });
+        q.submit([&](sycl::handler& h){
+            h.parallel_for(sycl::nd_range<2>(
+                sycl::range<2>(top_k, hidden_size),
+                sycl::range<2>(1, 16)), MoeDownDecodeNativeGrouped{
+                    (const fp16*)sg_intermediates.data_ptr(),
+                    (const uint8_t*)down_weight.data_ptr(),
+                    down_scale.data_ptr<float>(),
+                    route_weight,
+                    idx_ptr,
+                    (fp16*)sg_routed_output.data_ptr(),
+                    hidden_size, intermediate_size, (int)top_k});
+        });
+    } else {
+        q.submit([&](sycl::handler& h){
+            h.parallel_for(sycl::nd_range<2>(
+                sycl::range<2>(top_k, intermediate_size / 16),
+                sycl::range<2>(1, 1)), MoeUpDecodeGeluTanhNative{
+                    (const fp16*)x.data_ptr(),
+                    (const uint8_t*)gate_up_weight.data_ptr(),
+                    gate_up_scale.data_ptr<float>(),
+                    idx_ptr,
+                    (fp16*)sg_intermediates.data_ptr(),
+                    hidden_size, intermediate_size, (int)top_k});
+        });
+        q.submit([&](sycl::handler& h){
+            h.parallel_for(sycl::nd_range<2>(
+                sycl::range<2>(top_k, hidden_size / 16),
+                sycl::range<2>(1, 1)), MoeDownDecodeNative{
+                    (const fp16*)sg_intermediates.data_ptr(),
+                    (const uint8_t*)down_weight.data_ptr(),
+                    down_scale.data_ptr<float>(),
+                    route_weight,
+                    idx_ptr,
+                    (fp16*)sg_routed_output.data_ptr(),
+                    hidden_size, intermediate_size, (int)top_k});
+        });
+    }
 
     auto& final_out = sg_take_final_output();
     moe_accumulate_kernel(

--- a/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe.sycl
@@ -9,6 +9,8 @@
 #include <sycl/ext/intel/experimental/esimd/memory.hpp>
 
 #include <array>
+#include <unordered_map>
+#include <vector>
 
 #include "moe_topk.h"
 #include "moe_decode_gemv.h"
@@ -1976,9 +1978,9 @@ static void ensure_moe_buffers_v2(int n_tokens, int top_k, int num_shared_expert
 }
 
 // ========== gemma4: moe_forward_full_gelu_tanh (no shared expert) ==========
-// Scratch buffers (topk + intermediates + routed_output) are reused every
-// call — a single pair is fine because the next call overwrites them only
-// after the previous call's accumulate has consumed them.
+// Scratch buffers are reused only within the same stream and shape. Keeping
+// separate sets avoids retiring storage that an earlier asynchronous launch
+// still uses when callers alternate shapes or streams.
 //
 // The final output is different: callers (e.g. vllm Gemma4MoE.forward)
 // hold the returned tensor across the rest of the layer's compute (residual
@@ -1986,13 +1988,22 @@ static void ensure_moe_buffers_v2(int n_tokens, int top_k, int num_shared_expert
 // next call. Use a small ring of output buffers and rotate per call so each
 // returned tensor stays valid until at least SG_FINAL_RING-1 further calls
 // have happened — enough that the consuming work has finished by then.
-static thread_local torch::Tensor sg_topk_idx, sg_topk_weight;
-static thread_local torch::Tensor sg_intermediates, sg_routed_output;
-static thread_local int sg_cached_ntokens = -1;
-
 static constexpr int SG_FINAL_RING = 4;
-static thread_local torch::Tensor sg_final_outputs[SG_FINAL_RING];
-static thread_local int sg_final_ring_idx = 0;
+
+struct Gemma4MoeBuffers {
+    torch::Tensor topk_idx, topk_weight;
+    torch::Tensor intermediates, routed_output;
+    std::array<torch::Tensor, SG_FINAL_RING> final_outputs;
+    int final_ring_idx = 0;
+    int cached_ntokens = -1;
+    int cached_topk = -1;
+    int cached_hidden = -1;
+    int cached_intermediate = -1;
+};
+
+static thread_local std::unordered_map<
+    c10::xpu::XPUStream, std::vector<Gemma4MoeBuffers>>
+    sg_buffers_by_stream;
 
 static bool moe_kernel_debug_enabled() {
     static const bool enabled = [] {
@@ -2018,27 +2029,83 @@ static void moe_kernel_debug_check(
     std::fflush(stderr);
 }
 
-static void ensure_gemma4_moe_buffers(int n_tokens, int top_k,
+static Gemma4MoeBuffers& ensure_gemma4_moe_buffers(int n_tokens, int top_k,
     int hidden_size, int intermediate_size, const torch::Device& dev) {
+    auto stream = c10::xpu::getCurrentXPUStream(dev.index());
+    auto& stream_buffers = sg_buffers_by_stream[stream];
+    for (auto& buffers : stream_buffers) {
+        if (buffers.cached_ntokens >= n_tokens
+            && buffers.cached_topk == top_k
+            && buffers.cached_hidden == hidden_size
+            && buffers.cached_intermediate == intermediate_size) {
+            return buffers;
+        }
+    }
+
+    auto& buffers = stream_buffers.emplace_back();
     int rows_per_token = top_k;
-    if (sg_cached_ntokens >= n_tokens) return;
-    sg_topk_idx = torch::empty({n_tokens, top_k}, torch::device(dev).dtype(torch::kInt32));
-    sg_topk_weight = torch::empty({n_tokens, top_k}, torch::device(dev).dtype(torch::kHalf));
-    sg_intermediates = torch::empty({n_tokens * rows_per_token, intermediate_size},
+    buffers.topk_idx = torch::empty(
+        {n_tokens, top_k}, torch::device(dev).dtype(torch::kInt32));
+    buffers.topk_weight = torch::empty(
+        {n_tokens, top_k}, torch::device(dev).dtype(torch::kHalf));
+    buffers.intermediates = torch::empty(
+        {n_tokens * rows_per_token, intermediate_size},
         torch::device(dev).dtype(torch::kHalf));
-    sg_routed_output = torch::empty({n_tokens * rows_per_token, hidden_size},
+    buffers.routed_output = torch::empty(
+        {n_tokens * rows_per_token, hidden_size},
         torch::device(dev).dtype(torch::kHalf));
     for (int i = 0; i < SG_FINAL_RING; i++) {
-        sg_final_outputs[i] = torch::empty({n_tokens, hidden_size},
+        buffers.final_outputs[i] = torch::empty({n_tokens, hidden_size},
             torch::device(dev).dtype(torch::kHalf));
     }
-    sg_cached_ntokens = n_tokens;
+    buffers.final_ring_idx = 0;
+    buffers.cached_ntokens = n_tokens;
+    buffers.cached_topk = top_k;
+    buffers.cached_hidden = hidden_size;
+    buffers.cached_intermediate = intermediate_size;
+    return buffers;
 }
 
-static torch::Tensor& sg_take_final_output() {
-    auto& t = sg_final_outputs[sg_final_ring_idx];
-    sg_final_ring_idx = (sg_final_ring_idx + 1) % SG_FINAL_RING;
+static torch::Tensor& sg_take_final_output(Gemma4MoeBuffers& buffers) {
+    auto& t = buffers.final_outputs[buffers.final_ring_idx];
+    buffers.final_ring_idx =
+        (buffers.final_ring_idx + 1) % SG_FINAL_RING;
     return t;
+}
+
+static void dispatch_moe_up_decode(
+    sycl::queue& q, const fp16* x, const uint8_t* gate_up_weight,
+    const float* gate_up_scale, const int* selected_experts,
+    fp16* intermediates, int hidden_size, int intermediate_size,
+    int top_k) {
+    TORCH_CHECK(hidden_size % 32 == 0,
+                "decode hidden_size must be a multiple of 32");
+    auto kernel = MoeUpDecodeGeluTanh<256>{
+        x, gate_up_weight, gate_up_scale, selected_experts, intermediates,
+        hidden_size, intermediate_size, top_k, /*fp8_mode=*/0};
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(sycl::nd_range<2>(
+            sycl::range<2>(top_k, intermediate_size),
+            sycl::range<2>(1, 1)), kernel);
+    });
+}
+
+static void dispatch_moe_down_decode(
+    sycl::queue& q, const fp16* intermediates, const uint8_t* down_weight,
+    const float* down_scale, const fp16* routing_weights,
+    const int* selected_experts, fp16* output, int hidden_size,
+    int intermediate_size, int top_k) {
+    TORCH_CHECK(intermediate_size % 32 == 0,
+                "decode intermediate_size must be a multiple of 32");
+    auto kernel = MoeDownDecode<256>{
+        intermediates, down_weight, down_scale, routing_weights,
+        selected_experts, output, hidden_size, intermediate_size, top_k,
+        /*fp8_mode=*/0};
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(sycl::nd_range<2>(
+            sycl::range<2>(top_k, hidden_size),
+            sycl::range<2>(1, 1)), kernel);
+    });
 }
 
 torch::Tensor moe_forward_full_gelu_tanh(
@@ -2052,7 +2119,12 @@ torch::Tensor moe_forward_full_gelu_tanh(
     int intermediate_size = gate_up_weight.size(1) / 2;
     int rows_per_token = top_k;
 
-    ensure_gemma4_moe_buffers(n_tokens, top_k, hidden_size, intermediate_size, x.device());
+    auto& buffers = ensure_gemma4_moe_buffers(
+        n_tokens, top_k, hidden_size, intermediate_size, x.device());
+    auto& sg_topk_idx = buffers.topk_idx;
+    auto& sg_topk_weight = buffers.topk_weight;
+    auto& sg_intermediates = buffers.intermediates;
+    auto& sg_routed_output = buffers.routed_output;
 
     // TopK
     dispatch_moe_topk_forward<class MoeTopKGemma4>(
@@ -2081,7 +2153,7 @@ torch::Tensor moe_forward_full_gelu_tanh(
         top_k, rows_per_token, x.device());
 
     // Accumulate (sum over top_k experts per token)
-    auto& final_out = sg_take_final_output();
+    auto& final_out = sg_take_final_output(buffers);
     moe_accumulate_kernel(
         (const fp16*)sg_routed_output.data_ptr(),
         (fp16*)final_out.data_ptr(),
@@ -2107,7 +2179,10 @@ torch::Tensor moe_forward_full_gelu_tanh_routed_decode(
     int hidden_size = x.size(1);
     int intermediate_size = gate_up_weight.size(1) / 2;
     int rows_per_token = top_k;
-    ensure_gemma4_moe_buffers(1, top_k, hidden_size, intermediate_size, x.device());
+    auto& buffers = ensure_gemma4_moe_buffers(
+        1, top_k, hidden_size, intermediate_size, x.device());
+    auto& sg_intermediates = buffers.intermediates;
+    auto& sg_routed_output = buffers.routed_output;
 
     const int* idx_ptr = topk_indices.data_ptr<int>();
     const fp16* w_ptr  = (const fp16*)topk_weights.data_ptr();
@@ -2115,47 +2190,21 @@ torch::Tensor moe_forward_full_gelu_tanh_routed_decode(
     // moe_kernel_debug_check("routed_decode_input", x);
     // moe_kernel_debug_check("routed_decode_topk_weights", topk_weights);
 
-    // ---- Up + gelu_tanh: K = hidden_size ----
-    // gemma: hidden=2816 → VL=256 divides cleanly (tail 0).
-    {
-        const int VL = 256;
-        const int n_routes = top_k;
-        auto k = MoeUpDecodeGeluTanh<VL, 0>{
-            (const fp16*)x.data_ptr(),
-            (const uint8_t*)gate_up_weight.data_ptr(),
-            gate_up_scale.data_ptr<float>(),
-            idx_ptr,
-            (fp16*)sg_intermediates.data_ptr(),
-            hidden_size, intermediate_size, (int)top_k, /*fp8_mode=*/0};
-        q.submit([&](sycl::handler& h){
-            h.parallel_for(sycl::nd_range<2>(
-                sycl::range<2>(n_routes, intermediate_size),
-                sycl::range<2>(1, 1)), k);
-        });
-    }
+    dispatch_moe_up_decode(
+        q, (const fp16*)x.data_ptr(),
+        (const uint8_t*)gate_up_weight.data_ptr(),
+        gate_up_scale.data_ptr<float>(), idx_ptr,
+        (fp16*)sg_intermediates.data_ptr(),
+        hidden_size, intermediate_size, (int)top_k);
     // moe_kernel_debug_check("routed_decode_up_gelu", sg_intermediates);
-    // ---- Down: K = intermediate_size ----
-    // gemma per-card inter=1056 = 256*4 + 32 → VL=256 big chunks + 32 tail.
-    {
-        const int VL = 256;
-        const int VL_TAIL = 32;
-        const int n_routes = top_k;
-        auto k = MoeDownDecode<VL, VL_TAIL>{
-            (const fp16*)sg_intermediates.data_ptr(),
-            (const uint8_t*)down_weight.data_ptr(),
-            down_scale.data_ptr<float>(),
-            w_ptr, idx_ptr,
-            (fp16*)sg_routed_output.data_ptr(),
-            hidden_size, intermediate_size, (int)top_k, /*fp8_mode=*/0};
-        q.submit([&](sycl::handler& h){
-            h.parallel_for(sycl::nd_range<2>(
-                sycl::range<2>(n_routes, hidden_size),
-                sycl::range<2>(1, 1)), k);
-        });
-    }
+    dispatch_moe_down_decode(
+        q, (const fp16*)sg_intermediates.data_ptr(),
+        (const uint8_t*)down_weight.data_ptr(), down_scale.data_ptr<float>(),
+        w_ptr, idx_ptr, (fp16*)sg_routed_output.data_ptr(),
+        hidden_size, intermediate_size, (int)top_k);
     // moe_kernel_debug_check("routed_decode_down", sg_routed_output);
     // ---- Accumulate over top_k ----
-    auto& final_out = sg_take_final_output();
+    auto& final_out = sg_take_final_output(buffers);
     moe_accumulate_kernel(
         (const fp16*)sg_routed_output.data_ptr(),
         (fp16*)final_out.data_ptr(),
@@ -2180,7 +2229,12 @@ torch::Tensor moe_forward_full_gelu_tanh_decode(
     int hidden_size = x.size(1);
     int intermediate_size = gate_up_weight.size(1) / 2;
     int rows_per_token = top_k;
-    ensure_gemma4_moe_buffers(1, top_k, hidden_size, intermediate_size, x.device());
+    auto& buffers = ensure_gemma4_moe_buffers(
+        1, top_k, hidden_size, intermediate_size, x.device());
+    auto& sg_topk_idx = buffers.topk_idx;
+    auto& sg_topk_weight = buffers.topk_weight;
+    auto& sg_intermediates = buffers.intermediates;
+    auto& sg_routed_output = buffers.routed_output;
     sycl::queue& q = c10::xpu::getCurrentXPUStream(x.device().index()).queue();
 
     // ---- TopK (fp32-internal production kernel, norm=true) ----
@@ -2203,36 +2257,19 @@ torch::Tensor moe_forward_full_gelu_tanh_decode(
     const int* idx_ptr = sg_topk_idx.data_ptr<int>();
     const fp16* w_ptr  = (const fp16*)sg_topk_weight.data_ptr();
 
-    // ---- Up + gelu_tanh (1D-load GEMV) ----
-    {
-        const int VL = 256;
-        auto k = MoeUpDecodeGeluTanh<VL, 0>{
-            (const fp16*)x.data_ptr(),
-            (const uint8_t*)gate_up_weight.data_ptr(), gate_up_scale.data_ptr<float>(),
-            idx_ptr, (fp16*)sg_intermediates.data_ptr(),
-            hidden_size, intermediate_size, (int)top_k, /*fp8_mode=*/0};
-        q.submit([&](sycl::handler& h){
-            h.parallel_for(sycl::nd_range<2>(
-                sycl::range<2>(top_k, intermediate_size),
-                sycl::range<2>(1, 1)), k);
-        });
-    }
-    // ---- Down (1D-load GEMV, VL=256 + tail 32) ----
-    {
-        const int VL = 256; const int VL_TAIL = 32;
-        auto k = MoeDownDecode<VL, VL_TAIL>{
-            (const fp16*)sg_intermediates.data_ptr(),
-            (const uint8_t*)down_weight.data_ptr(), down_scale.data_ptr<float>(),
-            w_ptr, idx_ptr, (fp16*)sg_routed_output.data_ptr(),
-            hidden_size, intermediate_size, (int)top_k, /*fp8_mode=*/0};
-        q.submit([&](sycl::handler& h){
-            h.parallel_for(sycl::nd_range<2>(
-                sycl::range<2>(top_k, hidden_size),
-                sycl::range<2>(1, 1)), k);
-        });
-    }
+    dispatch_moe_up_decode(
+        q, (const fp16*)x.data_ptr(),
+        (const uint8_t*)gate_up_weight.data_ptr(),
+        gate_up_scale.data_ptr<float>(), idx_ptr,
+        (fp16*)sg_intermediates.data_ptr(),
+        hidden_size, intermediate_size, (int)top_k);
+    dispatch_moe_down_decode(
+        q, (const fp16*)sg_intermediates.data_ptr(),
+        (const uint8_t*)down_weight.data_ptr(), down_scale.data_ptr<float>(),
+        w_ptr, idx_ptr, (fp16*)sg_routed_output.data_ptr(),
+        hidden_size, intermediate_size, (int)top_k);
     // ---- Accumulate over top_k ----
-    auto& final_out = sg_take_final_output();
+    auto& final_out = sg_take_final_output(buffers);
     moe_accumulate_kernel(
         (const fp16*)sg_routed_output.data_ptr(),
         (fp16*)final_out.data_ptr(),
@@ -2260,8 +2297,12 @@ torch::Tensor moe_forward_full_gelu_tanh_decode_native(
     TORCH_CHECK(down_weight.size(2) == hidden_size);
     TORCH_CHECK(hidden_size % 16 == 0 && intermediate_size % 16 == 0);
     int rows_per_token = top_k;
-    ensure_gemma4_moe_buffers(
+    auto& buffers = ensure_gemma4_moe_buffers(
         1, top_k, hidden_size, intermediate_size, x.device());
+    auto& sg_topk_idx = buffers.topk_idx;
+    auto& sg_topk_weight = buffers.topk_weight;
+    auto& sg_intermediates = buffers.intermediates;
+    auto& sg_routed_output = buffers.routed_output;
     sycl::queue& q =
         c10::xpu::getCurrentXPUStream(x.device().index()).queue();
 
@@ -2337,7 +2378,7 @@ torch::Tensor moe_forward_full_gelu_tanh_decode_native(
         });
     }
 
-    auto& final_out = sg_take_final_output();
+    auto& final_out = sg_take_final_output(buffers);
     moe_accumulate_kernel(
         (const fp16*)sg_routed_output.data_ptr(),
         (fp16*)final_out.data_ptr(),
@@ -2367,7 +2408,10 @@ torch::Tensor moe_forward_full_gelu_tanh_routed(
     int intermediate_size = gate_up_weight.size(1) / 2;
     int rows_per_token = top_k;
 
-    ensure_gemma4_moe_buffers(n_tokens, top_k, hidden_size, intermediate_size, x.device());
+    auto& buffers = ensure_gemma4_moe_buffers(
+        n_tokens, top_k, hidden_size, intermediate_size, x.device());
+    auto& sg_intermediates = buffers.intermediates;
+    auto& sg_routed_output = buffers.routed_output;
 
     const int* idx_ptr = topk_indices.data_ptr<int>();
     const fp16* w_ptr  = (const fp16*)topk_weights.data_ptr();
@@ -2388,7 +2432,7 @@ torch::Tensor moe_forward_full_gelu_tanh_routed(
         n_tokens, hidden_size, intermediate_size,
         top_k, rows_per_token, x.device());
 
-    auto& final_out = sg_take_final_output();
+    auto& final_out = sg_take_final_output(buffers);
     moe_accumulate_kernel(
         (const fp16*)sg_routed_output.data_ptr(),
         (fp16*)final_out.data_ptr(),
@@ -2415,7 +2459,10 @@ torch::Tensor moe_forward_full_gelu_tanh_routed_no_accum(
     int intermediate_size = gate_up_weight.size(1) / 2;
     int rows_per_token = top_k;
 
-    ensure_gemma4_moe_buffers(n_tokens, top_k, hidden_size, intermediate_size, x.device());
+    auto& buffers = ensure_gemma4_moe_buffers(
+        n_tokens, top_k, hidden_size, intermediate_size, x.device());
+    auto& sg_intermediates = buffers.intermediates;
+    auto& sg_routed_output = buffers.routed_output;
 
     const int* idx_ptr = topk_indices.data_ptr<int>();
     const fp16* w_ptr  = (const fp16*)topk_weights.data_ptr();

--- a/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe.sycl
@@ -2454,6 +2454,7 @@ TORCH_LIBRARY_FRAGMENT(moe_ops, m) {
     m.def("moe_up_fp8_grouped(Tensor x, Tensor gate_up_weight, Tensor gate_up_scale, Tensor expert_offsets, Tensor expert_tokens, int top_k, int n_routed_experts) -> Tensor");
     m.def("moe_down_fp8_grouped(Tensor intermediate, Tensor down_weight, Tensor down_scale, Tensor routing_weights, Tensor expert_offsets, Tensor expert_tokens, int top_k, int n_routed_experts) -> Tensor");
     m.def("moe_forward_full_fp8_grouped(Tensor x, Tensor gate_up_weight, Tensor gate_up_scale, Tensor down_weight, Tensor down_scale, Tensor routing_weights, Tensor expert_offsets, Tensor expert_tokens, int top_k, int n_routed_experts) -> Tensor");
+    m.def("moe_forward_full_fp8_grouped_native(Tensor x, Tensor gate_up_weight, Tensor gate_up_scale, Tensor down_weight, Tensor down_scale, Tensor routing_weights, Tensor expert_offsets, Tensor expert_tokens, int top_k, int n_routed_experts) -> Tensor");
     m.def("moe_forward_full(Tensor x, Tensor logits, Tensor gate_up_weight, Tensor gate_up_scale, Tensor shared_gate_up_weight, Tensor shared_gate_up_scale, Tensor down_weight, Tensor down_scale, Tensor shared_down_weight, Tensor shared_down_scale, Tensor shared_expert_gate_weight, int top_k, int num_shared_experts, int n_routed_experts) -> Tensor");
     m.def("moe_forward_full_fp8_block(Tensor x, Tensor logits, Tensor(a!) output, Tensor gate_up_weight, Tensor gate_up_scale, Tensor shared_gate_up_weight, Tensor shared_gate_up_scale, Tensor down_weight, Tensor down_scale, Tensor shared_down_weight, Tensor shared_down_scale, Tensor shared_expert_gate_weight, int top_k, int num_shared_experts, int n_routed_experts) -> Tensor(a!)");
     m.def("moe_forward_full_v2(Tensor x, Tensor logits, Tensor gate_up_weight, Tensor gate_up_scale, Tensor shared_gate_up_weight, Tensor shared_gate_up_scale, Tensor down_weight, Tensor down_scale, Tensor shared_down_weight, Tensor shared_down_scale, Tensor shared_expert_gate_weight, int top_k, int num_shared_experts, int n_routed_experts) -> Tensor");
@@ -2472,6 +2473,7 @@ TORCH_LIBRARY_IMPL(moe_ops, XPU, m) {
     m.impl("moe_up_fp8_grouped", &moe_up_fp8_grouped);
     m.impl("moe_down_fp8_grouped", &moe_down_fp8_grouped);
     m.impl("moe_forward_full_fp8_grouped", &moe_forward_full_fp8_grouped);
+    m.impl("moe_forward_full_fp8_grouped_native", &moe_forward_full_fp8_grouped_native);
     m.impl("moe_forward_full_gelu_tanh_routed_no_accum", &moe_forward_full_gelu_tanh_routed_no_accum);
     m.impl("moe_forward_fused", &moe_forward_fused);
     m.impl("moe_forward_full", &moe_forward_full);

--- a/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe_decode_gemv.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe_decode_gemv.h
@@ -12,10 +12,17 @@
 // ============================================================================
 #pragma once
 #include <sycl/ext/intel/esimd.hpp>
+#include <sycl/ext/intel/experimental/esimd/memory.hpp>
+
+namespace xesimd = sycl::ext::intel::experimental::esimd;
+namespace esimd_math = sycl::ext::intel::esimd;
 
 // Forward decl: defined in moe.sycl above the include point's use site.
 template<int N>
 SYCL_ESIMD_FUNCTION simd<sycl::half, N> fp8e4m3_to_half(simd<uint8_t, N> raw);
+
+SYCL_ESIMD_FUNCTION simd<sycl::half, 256>
+fp8e4m3_block_to_vnni(simd<uint8_t, 256> raw);
 
 SYCL_ESIMD_FUNCTION inline simd<sycl::half, 256>
 fp8g_load_wtile_native(const uint8_t* base, uint32_t N_total,
@@ -243,6 +250,149 @@ struct MoeDownDecodeNative {
         block_store<fp16, 16>(
             output + (size_t)route * hidden + n0,
             convert<fp16>(row));
+    }
+};
+
+// Native-layout decode variant using a 16-thread K reduction. The serial
+// native kernel above performs the same number of DPAS operations per route,
+// but one work-item walks the entire hidden/intermediate dimension. Matching
+// the routed native kernel's local geometry exposes K parallelism and avoids
+// the transposed dword load/repack in fp8g_load_wtile_native.
+struct MoeUpDecodeGeluTanhNativeGrouped {
+    const fp16*    x;
+    const uint8_t* gate_up_weight;
+    const float*   gate_up_scale;
+    const int*     selected_experts;
+    fp16*          intermediates;
+    int hidden, inter, top_k;
+
+    void operator()(sycl::nd_item<2> item) const SYCL_ESIMD_KERNEL {
+        using namespace sycl::ext::intel::esimd;
+        using namespace sycl::ext::intel::esimd::xmx;
+        constexpr int GS = 16;
+        slm_init<GS * 32 * sizeof(float)>();
+
+        const int route = (int)item.get_group(0);
+        const int n_tile = (int)item.get_group(1);
+        const int tid = (int)item.get_local_id(1);
+        const int n0 = n_tile * 16;
+        if (n0 >= inter) return;
+
+        const int eid = selected_experts[route];
+        const int two_inter = 2 * inter;
+        const uint8_t* base = gate_up_weight
+            + (size_t)eid * hidden * two_inter;
+        const int up_n0 = inter + n0;
+        simd<float, 16> gate_acc(0.f), up_acc(0.f);
+
+        for (int k = 16 * tid; k < hidden; k += 16 * GS) {
+            simd<fp16, 16> a_tile = block_load<fp16, 16>(x + k);
+
+            xesimd::config_2d_mem_access<uint8_t, 16, 16, 1> gate_pay(
+                base, (uint32_t)two_inter - 1u, (uint32_t)hidden - 1u,
+                (uint32_t)two_inter - 1u, (uint32_t)n0, (uint32_t)k);
+            auto gate_raw = xesimd::lsc_load_2d<uint8_t, 16, 16, 1,
+                false, false, xesimd::cache_hint::cached,
+                xesimd::cache_hint::cached>(gate_pay);
+            gate_acc = dpas<8, 1, float, float, fp16, fp16>(
+                gate_acc, fp8e4m3_block_to_vnni(gate_raw), a_tile);
+
+            xesimd::config_2d_mem_access<uint8_t, 16, 16, 1> up_pay(
+                base, (uint32_t)two_inter - 1u, (uint32_t)hidden - 1u,
+                (uint32_t)two_inter - 1u, (uint32_t)up_n0, (uint32_t)k);
+            auto up_raw = xesimd::lsc_load_2d<uint8_t, 16, 16, 1,
+                false, false, xesimd::cache_hint::cached,
+                xesimd::cache_hint::cached>(up_pay);
+            up_acc = dpas<8, 1, float, float, fp16, fp16>(
+                up_acc, fp8e4m3_block_to_vnni(up_raw), a_tile);
+        }
+
+        const uint32_t slm_off = (uint32_t)(tid * 32) * 4u;
+        slm_block_store<float, 16>(slm_off, gate_acc);
+        slm_block_store<float, 16>(slm_off + 64u, up_acc);
+        barrier();
+
+        if (tid == 0) {
+            simd<float, 16> gate(0.f), up(0.f);
+            #pragma unroll
+            for (int i = 0; i < GS; i++) {
+                gate += slm_block_load<float, 16>((uint32_t)(i * 128));
+                up += slm_block_load<float, 16>((uint32_t)(i * 128 + 64));
+            }
+
+            const float scale = gate_up_scale[eid];
+            gate *= scale;
+            up *= scale;
+            constexpr float c0 = 0.7978845608f;
+            constexpr float c1 = 0.044715f;
+            simd<float, 16> inner = c0 * (gate + c1 * gate * gate * gate);
+            simd<float, 16> two_z = 2.0f * inner;
+            two_z.merge(simd<float, 16>(30.0f), two_z > 30.0f);
+            two_z.merge(simd<float, 16>(-30.0f), two_z < -30.0f);
+            simd<float, 16> exp2z = esimd_math::exp<float, 16>(two_z);
+            simd<float, 16> tanh_v = (exp2z - 1.0f) / (exp2z + 1.0f);
+            simd<float, 16> result = 0.5f * gate * (1.0f + tanh_v) * up;
+            block_store<fp16, 16>(
+                intermediates + (size_t)route * inter + n0,
+                convert<fp16>(result));
+        }
+    }
+};
+
+struct MoeDownDecodeNativeGrouped {
+    const fp16*    intermediates;
+    const uint8_t* down_weight;
+    const float*   down_scale;
+    const fp16*    routing_weights;
+    const int*     selected_experts;
+    fp16*          output;
+    int hidden, inter, top_k;
+
+    void operator()(sycl::nd_item<2> item) const SYCL_ESIMD_KERNEL {
+        using namespace sycl::ext::intel::esimd;
+        using namespace sycl::ext::intel::esimd::xmx;
+        constexpr int GS = 16;
+        slm_init<GS * 32 * sizeof(float)>();
+
+        const int route = (int)item.get_group(0);
+        const int n_tile = (int)item.get_group(1);
+        const int tid = (int)item.get_local_id(1);
+        const int n0 = n_tile * 16;
+        if (n0 >= hidden) return;
+
+        const int eid = selected_experts[route];
+        const uint8_t* base = down_weight
+            + (size_t)eid * inter * hidden;
+        const fp16* input = intermediates + (size_t)route * inter;
+        simd<float, 16> acc(0.f);
+
+        for (int k = 16 * tid; k < inter; k += 16 * GS) {
+            simd<fp16, 16> a_tile = block_load<fp16, 16>(input + k);
+            xesimd::config_2d_mem_access<uint8_t, 16, 16, 1> pay(
+                base, (uint32_t)hidden - 1u, (uint32_t)inter - 1u,
+                (uint32_t)hidden - 1u, (uint32_t)n0, (uint32_t)k);
+            auto raw = xesimd::lsc_load_2d<uint8_t, 16, 16, 1,
+                false, false, xesimd::cache_hint::cached,
+                xesimd::cache_hint::cached>(pay);
+            acc = dpas<8, 1, float, float, fp16, fp16>(
+                acc, fp8e4m3_block_to_vnni(raw), a_tile);
+        }
+
+        const uint32_t slm_off = (uint32_t)(tid * 16) * 4u;
+        slm_block_store<float, 16>(slm_off, acc);
+        barrier();
+
+        if (tid == 0) {
+            simd<float, 16> row(0.f);
+            #pragma unroll
+            for (int i = 0; i < GS; i++) {
+                row += slm_block_load<float, 16>((uint32_t)(i * 64));
+            }
+            row *= (float)routing_weights[route] * down_scale[eid];
+            block_store<fp16, 16>(
+                output + (size_t)route * hidden + n0,
+                convert<fp16>(row));
+        }
     }
 };
 

--- a/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe_decode_gemv.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe_decode_gemv.h
@@ -17,6 +17,10 @@
 template<int N>
 SYCL_ESIMD_FUNCTION simd<sycl::half, N> fp8e4m3_to_half(simd<uint8_t, N> raw);
 
+SYCL_ESIMD_FUNCTION inline simd<sycl::half, 256>
+fp8g_load_wtile_native(const uint8_t* base, uint32_t N_total,
+                       uint32_t K_total, uint32_t k0, uint32_t n0);
+
 // Fast E4M3→half: uint16 bit-twiddle for normals + correct subnormal handling.
 // e4m3 bias=7, fp16 bias=15 → exp_fp16 = exp_e4m3 + 8. mant 3b → fp16 mant top.
 // Subnormal (e==0): value = mant * 2^-9 (representable as normal fp16).
@@ -136,6 +140,109 @@ struct MoeDownDecode {
         float w = (float)routing_weights[route];
         float ds = down_scale[eid];
         output[(size_t)route*hidden + h] = fp16(s * w * ds);
+    }
+};
+
+// Native XPU weights are K-major: gate_up [E, hidden, 2*inter] and
+// down [E, inter, hidden]. One work-item computes 16 output channels for one
+// route. DPAS operates on an 8-row tile; decode fills row 0 and leaves the
+// remaining rows zero.
+struct MoeUpDecodeGeluTanhNative {
+    const fp16*    x;
+    const uint8_t* gate_up_weight;
+    const float*   gate_up_scale;
+    const int*     selected_experts;
+    fp16*          intermediates;
+    int hidden, inter, top_k;
+
+    void operator()(sycl::nd_item<2> item) const SYCL_ESIMD_KERNEL {
+        using namespace sycl::ext::intel::esimd;
+        using namespace sycl::ext::intel::esimd::xmx;
+        const int route = (int)item.get_global_id(0);
+        const int n0 = (int)item.get_global_id(1) * 16;
+        if (n0 >= inter) return;
+
+        const int eid = selected_experts[route];
+        const int two_inter = 2 * inter;
+        const uint8_t* wbase = gate_up_weight
+            + (size_t)eid * hidden * two_inter;
+        const fp16 scale = fp16(gate_up_scale[eid]);
+        simd<fp16, 128> gate_acc(fp16(0));
+        simd<fp16, 128> up_acc(fp16(0));
+
+        for (int k = 0; k < hidden; k += 16) {
+            simd<fp16, 128> input_tile(fp16(0));
+            input_tile.template select<16, 1>(0) =
+                block_load<fp16, 16>(x + k);
+            simd<fp16, 256> gate_tile = fp8g_load_wtile_native(
+                wbase, two_inter, hidden, k, n0);
+            simd<fp16, 256> up_tile = fp8g_load_wtile_native(
+                wbase, two_inter, hidden, k, inter + n0);
+            gate_acc = dpas<8, 8, fp16, fp16, fp16, fp16>(
+                gate_acc, gate_tile * scale, input_tile);
+            up_acc = dpas<8, 8, fp16, fp16, fp16, fp16>(
+                up_acc, up_tile * scale, input_tile);
+        }
+
+        simd<float, 16> gate =
+            simd<float, 16>(gate_acc.template select<16, 1>(0));
+        simd<float, 16> up =
+            simd<float, 16>(up_acc.template select<16, 1>(0));
+        constexpr float c0 = 0.7978845608f;
+        constexpr float c1 = 0.044715f;
+        simd<float, 16> inner = c0 * (gate + c1 * gate * gate * gate);
+        inner = min<float, 16>(
+            max<float, 16>(inner, simd<float, 16>(-30.0f)),
+            simd<float, 16>(30.0f));
+        simd<float, 16> e2 =
+            sycl::ext::intel::esimd::exp<float, 16>(2.0f * inner);
+        simd<float, 16> gelu = 0.5f * gate
+            * (1.0f + (e2 - 1.0f) / (e2 + 1.0f));
+        block_store<fp16, 16>(
+            intermediates + (size_t)route * inter + n0,
+            convert<fp16>(gelu * up));
+    }
+};
+
+struct MoeDownDecodeNative {
+    const fp16*    intermediates;
+    const uint8_t* down_weight;
+    const float*   down_scale;
+    const fp16*    routing_weights;
+    const int*     selected_experts;
+    fp16*          output;
+    int hidden, inter, top_k;
+
+    void operator()(sycl::nd_item<2> item) const SYCL_ESIMD_KERNEL {
+        using namespace sycl::ext::intel::esimd;
+        using namespace sycl::ext::intel::esimd::xmx;
+        const int route = (int)item.get_global_id(0);
+        const int n0 = (int)item.get_global_id(1) * 16;
+        if (n0 >= hidden) return;
+
+        const int eid = selected_experts[route];
+        const uint8_t* wbase = down_weight
+            + (size_t)eid * inter * hidden;
+        const fp16* input = intermediates + (size_t)route * inter;
+        const fp16 scale = fp16(down_scale[eid]);
+        simd<fp16, 128> acc(fp16(0));
+
+        for (int k = 0; k < inter; k += 16) {
+            simd<fp16, 128> input_tile(fp16(0));
+            input_tile.template select<16, 1>(0) =
+                block_load<fp16, 16>(input + k);
+            simd<fp16, 256> weight_tile = fp8g_load_wtile_native(
+                wbase, hidden, inter, k, n0);
+            acc = dpas<8, 8, fp16, fp16, fp16, fp16>(
+                acc, weight_tile * scale, input_tile);
+        }
+
+        simd<float, 16> row =
+            simd<float, 16>(acc.template select<16, 1>(0));
+        row *= (float)routing_weights[route];
+        block_store<fp16, 16>(
+            output + (size_t)route * hidden + n0,
+            convert<fp16>(row));
     }
 };
 

--- a/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe_decode_gemv.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe_decode_gemv.h
@@ -52,9 +52,9 @@ SYCL_ESIMD_FUNCTION simd<float, N> fp8e4m3_dequant_fast(simd<uint8_t, N> raw) {
 }
 
 
-// VL_BIG full chunks + one VL_TAIL chunk (VL_TAIL may be 0). KS=1.
+// VL-wide full chunks plus 32-element tail chunks. KS=1.
 // Up + gelu_tanh. gate_up_weight [E, 2*inter, hidden], K = hidden.
-template<int VL, int VL_TAIL>
+template<int VL>
 struct MoeUpDecodeGeluTanh {
     const fp16*    x;
     const uint8_t* gate_up_weight;
@@ -85,13 +85,16 @@ struct MoeUpDecodeGeluTanh {
         }
         float g_sum = reduce<float>(g_acc, std::plus<>());
         float u_sum = reduce<float>(u_acc, std::plus<>());
-        if constexpr (VL_TAIL > 0) {
-            int kt = kp_full;
-            simd<fp16, VL_TAIL> xv = block_load<fp16, VL_TAIL>(x + kt);
-            simd<float, VL_TAIL> xf = xv;
-            g_sum += reduce<float>(xf * fp8e4m3_dequant_fast<VL_TAIL>((block_load<uint8_t, VL_TAIL>(w_gate + kt))), std::plus<>());
-            u_sum += reduce<float>(xf * fp8e4m3_dequant_fast<VL_TAIL>((block_load<uint8_t, VL_TAIL>(w_up + kt))), std::plus<>());
+        simd<float, 32> g_tail(0.f), u_tail(0.f);
+        for (int k = kp_full; k < hidden; k += 32) {
+            simd<float, 32> xf = block_load<fp16, 32>(x + k);
+            g_tail += xf * fp8e4m3_dequant_fast<32>(
+                block_load<uint8_t, 32>(w_gate + k));
+            u_tail += xf * fp8e4m3_dequant_fast<32>(
+                block_load<uint8_t, 32>(w_up + k));
         }
+        g_sum += reduce<float>(g_tail, std::plus<>());
+        u_sum += reduce<float>(u_tail, std::plus<>());
 
         float scale = gate_up_scale[eid];
         float gs = g_sum * scale, us = u_sum * scale;
@@ -109,7 +112,7 @@ struct MoeUpDecodeGeluTanh {
 };
 
 // Down. down_weight [E, hidden, inter], K = inter.
-template<int VL, int VL_TAIL>
+template<int VL>
 struct MoeDownDecode {
     const fp16*    intermediates;   // [top_k, inter]
     const uint8_t* down_weight;
@@ -137,12 +140,13 @@ struct MoeDownDecode {
             acc += hf * fp8e4m3_dequant_fast<VL>((block_load<uint8_t, VL>(wrow + k)));
         }
         float s = reduce<float>(acc, std::plus<>());
-        if constexpr (VL_TAIL > 0) {
-            int kt = kp_full;
-            simd<fp16, VL_TAIL> hv = block_load<fp16, VL_TAIL>(hi + kt);
-            simd<float, VL_TAIL> hf = hv;
-            s += reduce<float>(hf * fp8e4m3_dequant_fast<VL_TAIL>((block_load<uint8_t, VL_TAIL>(wrow + kt))), std::plus<>());
+        simd<float, 32> tail(0.f);
+        for (int k = kp_full; k < inter; k += 32) {
+            simd<float, 32> hf = block_load<fp16, 32>(hi + k);
+            tail += hf * fp8e4m3_dequant_fast<32>(
+                block_load<uint8_t, 32>(wrow + k));
         }
+        s += reduce<float>(tail, std::plus<>());
 
         float w = (float)routing_weights[route];
         float ds = down_scale[eid];

--- a/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe_fp8_grouped.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe_fp8_grouped.h
@@ -478,9 +478,19 @@ inline torch::Tensor moe_up_fp8_grouped_impl(
     TORCH_CHECK(x.scalar_type() == torch::kHalf);
     int n_tokens = x.size(0);
     int hidden_size = x.size(1);
+    TORCH_CHECK(gate_up_weight.dim() == 3);
+    TORCH_CHECK(
+        (NATIVE_LAYOUT && gate_up_weight.size(1) == hidden_size
+            && gate_up_weight.size(2) % 2 == 0)
+        || (!NATIVE_LAYOUT && gate_up_weight.size(2) == hidden_size
+            && gate_up_weight.size(1) % 2 == 0),
+        "gate_up_weight does not match the selected grouped FP8 layout");
     int intermediate_size = NATIVE_LAYOUT
         ? gate_up_weight.size(2) / 2
         : gate_up_weight.size(1) / 2;
+    TORCH_CHECK(
+        hidden_size % 16 == 0 && intermediate_size % 16 == 0,
+        "grouped FP8 hidden and intermediate sizes must be multiples of 16");
     int total_routes = n_tokens * (int)top_k;
     auto intermediate = torch::empty({total_routes, intermediate_size},
         torch::device(x.device()).dtype(torch::kHalf));
@@ -568,9 +578,17 @@ inline torch::Tensor moe_down_fp8_grouped_impl(
     TORCH_CHECK(intermediate.scalar_type() == torch::kHalf);
     int total_routes = intermediate.size(0);
     int intermediate_size = intermediate.size(1);
+    TORCH_CHECK(down_weight.dim() == 3);
+    TORCH_CHECK(
+        (NATIVE_LAYOUT && down_weight.size(1) == intermediate_size)
+        || (!NATIVE_LAYOUT && down_weight.size(2) == intermediate_size),
+        "down_weight does not match the selected grouped FP8 layout");
     int hidden_size = NATIVE_LAYOUT
         ? down_weight.size(2)
         : down_weight.size(1);
+    TORCH_CHECK(
+        hidden_size % 16 == 0 && intermediate_size % 16 == 0,
+        "grouped FP8 hidden and intermediate sizes must be multiples of 16");
     auto output = torch::empty({total_routes, hidden_size},
         torch::device(intermediate.device()).dtype(torch::kHalf));
     moe_down_fp8_grouped_kernel<16, NATIVE_LAYOUT>(

--- a/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe_fp8_grouped.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe_fp8_grouped.h
@@ -80,13 +80,80 @@ fp8g_load_wtile_native(const uint8_t* base, uint32_t N_total,
     return b_vnni_u16.template bit_cast_view<fp16>().read();
 }
 
-template <bool NATIVE_LAYOUT>
+SYCL_ESIMD_FUNCTION inline simd<fp16, 256>
+fp8g_load_wtile_native_packed(const uint8_t* base, uint32_t N_total,
+                              uint32_t K_total, uint32_t k0, uint32_t n0) {
+    xesimd::config_2d_mem_access<uint32_t, 4, 16, 1> pay(
+        reinterpret_cast<const uint32_t*>(base),
+        N_total - 1u, K_total - 1u, N_total - 1u,
+        n0 / 4u, k0);
+    auto raw_t = xesimd::lsc_load_2d<uint32_t, 4, 16, 1, true, false,
+        xesimd::cache_hint::cached, xesimd::cache_hint::cached>(pay);
+
+    // Keep the low-K path's small conversion footprint, but write the VNNI
+    // pairs with strided SIMD selects instead of extracting 128 scalar lanes.
+    simd<uint16_t, 256> b_vnni_u16;
+    #pragma unroll
+    for (int ng = 0; ng < 4; ng++) {
+        simd<uint32_t, 16> k_rows = raw_t.template select<16, 1>(ng * 16);
+        #pragma unroll
+        for (int n = 0; n < 4; n++) {
+            simd<uint8_t, 16> raw_k = convert<uint8_t>(
+                (k_rows >> (8 * n)) & 0xFF);
+            simd<fp16, 16> w = fp8e4m3_to_half<16>(raw_k);
+            simd<uint16_t, 16> w_u16 =
+                w.template bit_cast_view<uint16_t>().read();
+            const int n_global = ng * 4 + n;
+            b_vnni_u16.template select<8, 32>(2 * n_global) =
+                w_u16.template select<8, 2>(0);
+            b_vnni_u16.template select<8, 32>(2 * n_global + 1) =
+                w_u16.template select<8, 2>(1);
+        }
+    }
+    return b_vnni_u16.template bit_cast_view<fp16>().read();
+}
+
+SYCL_ESIMD_FUNCTION inline simd<fp16, 256>
+fp8g_load_wtile_native_fast(const uint8_t* base, uint32_t N_total,
+                            uint32_t K_total, uint32_t k0, uint32_t n0) {
+    xesimd::config_2d_mem_access<uint32_t, 4, 16, 1> pay(
+        reinterpret_cast<const uint32_t*>(base),
+        N_total - 1u, K_total - 1u, N_total - 1u,
+        n0 / 4u, k0);
+    auto raw_t = xesimd::lsc_load_2d<uint32_t, 4, 16, 1, true, false,
+        xesimd::cache_hint::cached, xesimd::cache_hint::cached>(pay);
+
+    // The transposed load is laid out as four-byte N groups for each K row.
+    // Deinterleave those groups with SIMD selects, then reuse the vectorized
+    // canonical FP8 conversion and VNNI pack instead of doing 128 scalar
+    // element extractions and stores.
+    simd<uint8_t, 256> raw_bytes =
+        raw_t.template bit_cast_view<uint8_t>().read();
+    simd<uint8_t, 256> raw_nk;
+    #pragma unroll
+    for (int ng = 0; ng < 4; ng++) {
+        #pragma unroll
+        for (int n = 0; n < 4; n++) {
+            const int n_global = ng * 4 + n;
+            raw_nk.template select<16, 1>(n_global * 16) =
+                raw_bytes.template select<16, 4>(ng * 64 + n);
+        }
+    }
+    return fp8e4m3_block_to_vnni_nk(raw_nk);
+}
+
+template <bool NATIVE_LAYOUT, bool FAST_NATIVE>
 SYCL_ESIMD_FUNCTION inline simd<fp16, 256>
 fp8g_load_wtile_layout(const uint8_t* base, uint32_t K_total,
                        uint32_t n_rows_total, uint32_t k0, uint32_t n0) {
     if constexpr (NATIVE_LAYOUT) {
-        return fp8g_load_wtile_native(
-            base, n_rows_total, K_total, k0, n0);
+        if constexpr (FAST_NATIVE) {
+            return fp8g_load_wtile_native_fast(
+                base, n_rows_total, K_total, k0, n0);
+        } else {
+            return fp8g_load_wtile_native_packed(
+                base, n_rows_total, K_total, k0, n0);
+        }
     } else {
         return fp8g_load_wtile(
             base, K_total, n_rows_total, k0, n0);
@@ -223,10 +290,12 @@ void moe_up_fp8_grouped_gelu_tanh_kernel(
                     for (int g = 0; g < MG; g++) { g_acc[g] = fp16(0); u_acc[g] = fp16(0); }
 
                     for (int k = 0; k < hidden_size; k += 16) {
-                        simd<fp16, 256> bg = fp8g_load_wtile_layout<NATIVE_LAYOUT>(
+                        simd<fp16, 256> bg =
+                            fp8g_load_wtile_layout<NATIVE_LAYOUT, true>(
                             wbase, (uint32_t)hidden_size,
                             (uint32_t)(2 * intermediate_size), (uint32_t)k, (uint32_t)ng);
-                        simd<fp16, 256> bu = fp8g_load_wtile_layout<NATIVE_LAYOUT>(
+                        simd<fp16, 256> bu =
+                            fp8g_load_wtile_layout<NATIVE_LAYOUT, true>(
                             wbase, (uint32_t)hidden_size,
                             (uint32_t)(2 * intermediate_size), (uint32_t)k, (uint32_t)nu);
                         // Fold per-tensor scale pre-DPAS (fp16-accum overflow
@@ -349,7 +418,8 @@ void moe_down_fp8_grouped_kernel(
                     for (int g = 0; g < MGD; g++) acc[g] = fp16(0);
 
                     for (int k = 0; k < intermediate_size; k += 16) {
-                        simd<fp16, 256> bd = fp8g_load_wtile_layout<NATIVE_LAYOUT>(
+                        simd<fp16, 256> bd =
+                            fp8g_load_wtile_layout<NATIVE_LAYOUT, false>(
                             wbase, (uint32_t)intermediate_size,
                             (uint32_t)hidden_size, (uint32_t)k, (uint32_t)ng);
                         // Fold per-tensor down_scale pre-DPAS (fp16-accum overflow

--- a/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe_fp8_grouped.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe_fp8_grouped.h
@@ -45,6 +45,54 @@ fp8g_load_wtile(const uint8_t* base, uint32_t K_total, uint32_t n_rows_total,
     return fp8e4m3_block_to_vnni_nk(raw);
 }
 
+// Load the same logical [16 N, 16 K] tile from native XPU [K, N] storage.
+// A transposed dword load gives four contiguous N bytes for each K row.
+// Repack those four-byte groups directly into the DPAS VNNI layout instead
+// of materializing a full canonical [N, K] copy in HBM.
+SYCL_ESIMD_FUNCTION inline simd<fp16, 256>
+fp8g_load_wtile_native(const uint8_t* base, uint32_t N_total,
+                       uint32_t K_total, uint32_t k0, uint32_t n0) {
+    xesimd::config_2d_mem_access<uint32_t, 4, 16, 1> pay(
+        reinterpret_cast<const uint32_t*>(base),
+        N_total - 1u, K_total - 1u, N_total - 1u,
+        n0 / 4u, k0);
+    auto raw_t = xesimd::lsc_load_2d<uint32_t, 4, 16, 1, true, false,
+        xesimd::cache_hint::cached, xesimd::cache_hint::cached>(pay);
+
+    simd<uint16_t, 256> b_vnni_u16;
+    #pragma unroll
+    for (int ng = 0; ng < 4; ng++) {
+        simd<uint32_t, 16> k_rows = raw_t.template select<16, 1>(ng * 16);
+        #pragma unroll
+        for (int n = 0; n < 4; n++) {
+            simd<uint8_t, 16> raw_k = convert<uint8_t>(
+                (k_rows >> (8 * n)) & 0xFF);
+            simd<fp16, 16> w = fp8e4m3_to_half<16>(raw_k);
+            simd<uint16_t, 16> w_u16 =
+                w.template bit_cast_view<uint16_t>().read();
+            const int n_global = ng * 4 + n;
+            for (int kp = 0; kp < 8; kp++) {
+                b_vnni_u16[kp * 32 + 2 * n_global] = w_u16[2 * kp];
+                b_vnni_u16[kp * 32 + 2 * n_global + 1] = w_u16[2 * kp + 1];
+            }
+        }
+    }
+    return b_vnni_u16.template bit_cast_view<fp16>().read();
+}
+
+template <bool NATIVE_LAYOUT>
+SYCL_ESIMD_FUNCTION inline simd<fp16, 256>
+fp8g_load_wtile_layout(const uint8_t* base, uint32_t K_total,
+                       uint32_t n_rows_total, uint32_t k0, uint32_t n0) {
+    if constexpr (NATIVE_LAYOUT) {
+        return fp8g_load_wtile_native(
+            base, n_rows_total, K_total, k0, n0);
+    } else {
+        return fp8g_load_wtile(
+            base, K_total, n_rows_total, k0, n0);
+    }
+}
+
 // ---- Tile map builder: even out the per-expert token skew ------------------
 // The up GEMM was gridded (num_experts, n_ntiles): one work-item walked ALL of
 // an expert's token tiles serially. With skewed routing (one expert up to ~164
@@ -91,10 +139,11 @@ inline void moe_build_tile_map_kernel(
 // One work-item == one TILE_M-row tile (expert from tile_expert[tile]), so the
 // per-expert token skew no longer serializes inside a work-item.
 // Output written to intermediate[routed_row, n] for each gathered route row.
-template <bool FUSE_TILE_MAP>
+template <bool FUSE_TILE_MAP, bool NATIVE_LAYOUT>
 class MoeUpFp8Grouped;
 
-template <int TILE_M = 8, bool FUSE_TILE_MAP = false>
+template <int TILE_M = 8, bool FUSE_TILE_MAP = false,
+          bool NATIVE_LAYOUT = false>
 void moe_up_fp8_grouped_gelu_tanh_kernel(
     const fp16* x,                       // [n_tokens, hidden]
     const uint8_t* gate_up_weight,       // [E, 2*inter, hidden] e4m3
@@ -110,7 +159,7 @@ void moe_up_fp8_grouped_gelu_tanh_kernel(
     const int n_ntiles = intermediate_size / 16;
 
     auto cgf = [&](sycl::handler& cgh) {
-        cgh.parallel_for<MoeUpFp8Grouped<FUSE_TILE_MAP>>(
+        cgh.parallel_for<MoeUpFp8Grouped<FUSE_TILE_MAP, NATIVE_LAYOUT>>(
             sycl::range<2>(max_tiles, n_ntiles),
             [=](sycl::item<2> item) SYCL_ESIMD_KERNEL {
                 const int tile   = (int)item.get_id(0);
@@ -174,10 +223,10 @@ void moe_up_fp8_grouped_gelu_tanh_kernel(
                     for (int g = 0; g < MG; g++) { g_acc[g] = fp16(0); u_acc[g] = fp16(0); }
 
                     for (int k = 0; k < hidden_size; k += 16) {
-                        simd<fp16, 256> bg = fp8g_load_wtile(
+                        simd<fp16, 256> bg = fp8g_load_wtile_layout<NATIVE_LAYOUT>(
                             wbase, (uint32_t)hidden_size,
                             (uint32_t)(2 * intermediate_size), (uint32_t)k, (uint32_t)ng);
-                        simd<fp16, 256> bu = fp8g_load_wtile(
+                        simd<fp16, 256> bu = fp8g_load_wtile_layout<NATIVE_LAYOUT>(
                             wbase, (uint32_t)hidden_size,
                             (uint32_t)(2 * intermediate_size), (uint32_t)k, (uint32_t)nu);
                         // Fold per-tensor scale pre-DPAS (fp16-accum overflow
@@ -243,7 +292,10 @@ void moe_up_fp8_grouped_gelu_tanh_kernel(
 // Grid: (num_experts, hidden_size / 16). TILE_M=8.
 // Reads intermediate[routed_row, :inter], writes output[routed_row, :hidden]
 // (per-route output rows; Python accumulate folds top_k rows back per token).
-template <int TILE_M = 8>
+template <bool NATIVE_LAYOUT>
+class MoeDownFp8Grouped;
+
+template <int TILE_M = 8, bool NATIVE_LAYOUT = false>
 void moe_down_fp8_grouped_kernel(
     const fp16* intermediate,            // [n_tokens*top_k, inter]
     const uint8_t* down_weight,          // [E, hidden, inter] e4m3
@@ -258,7 +310,7 @@ void moe_down_fp8_grouped_kernel(
     const int n_ntiles = hidden_size / 16;
 
     auto cgf = [&](sycl::handler& cgh) {
-        cgh.parallel_for<class MoeDownFp8Grouped>(
+        cgh.parallel_for<MoeDownFp8Grouped<NATIVE_LAYOUT>>(
             sycl::range<2>(num_experts, n_ntiles),
             [=](sycl::item<2> item) SYCL_ESIMD_KERNEL {
                 const int eid    = (int)item.get_id(0);
@@ -297,7 +349,7 @@ void moe_down_fp8_grouped_kernel(
                     for (int g = 0; g < MGD; g++) acc[g] = fp16(0);
 
                     for (int k = 0; k < intermediate_size; k += 16) {
-                        simd<fp16, 256> bd = fp8g_load_wtile(
+                        simd<fp16, 256> bd = fp8g_load_wtile_layout<NATIVE_LAYOUT>(
                             wbase, (uint32_t)intermediate_size,
                             (uint32_t)hidden_size, (uint32_t)k, (uint32_t)ng);
                         // Fold per-tensor down_scale pre-DPAS (fp16-accum overflow
@@ -345,9 +397,10 @@ void moe_down_fp8_grouped_kernel(
 // These two ops are the fp8 grouped GEMMs.
 
 // Up: returns intermediate [n_tokens*top_k, inter] (gelu_tanh(gate)*up).
-inline torch::Tensor moe_up_fp8_grouped(
+template <bool NATIVE_LAYOUT>
+inline torch::Tensor moe_up_fp8_grouped_impl(
     torch::Tensor x,                 // [n_tokens, hidden] fp16
-    torch::Tensor gate_up_weight,    // [E, 2*inter, hidden] e4m3 (uint8 view)
+    torch::Tensor gate_up_weight,    // [E, 2*inter, hidden] or [E, hidden, 2*inter]
     torch::Tensor gate_up_scale,     // [E] float
     torch::Tensor expert_offsets,    // [E] int32
     torch::Tensor expert_tokens,     // [total_routes] int32
@@ -355,7 +408,9 @@ inline torch::Tensor moe_up_fp8_grouped(
     TORCH_CHECK(x.scalar_type() == torch::kHalf);
     int n_tokens = x.size(0);
     int hidden_size = x.size(1);
-    int intermediate_size = gate_up_weight.size(1) / 2;
+    int intermediate_size = NATIVE_LAYOUT
+        ? gate_up_weight.size(2) / 2
+        : gate_up_weight.size(1) / 2;
     int total_routes = n_tokens * (int)top_k;
     auto intermediate = torch::empty({total_routes, intermediate_size},
         torch::device(x.device()).dtype(torch::kHalf));
@@ -370,7 +425,7 @@ inline torch::Tensor moe_up_fp8_grouped(
         enable_env != nullptr && enable_env[0] == '1'
         && std::getenv("DISABLE_MOE_GROUPED_TILEMAP_FUSION") == nullptr;
     if (enable_fusion) {
-        moe_up_fp8_grouped_gelu_tanh_kernel<TILE_M, true>(
+        moe_up_fp8_grouped_gelu_tanh_kernel<TILE_M, true, NATIVE_LAYOUT>(
             (const fp16*)x.data_ptr(),
             (const uint8_t*)gate_up_weight.data_ptr(),
             gate_up_scale.data_ptr<float>(),
@@ -390,7 +445,7 @@ inline torch::Tensor moe_up_fp8_grouped(
             tile_expert.data_ptr<int>(),
             tile_mbase.data_ptr<int>(),
             (int)n_routed_experts, total_routes, max_tiles, TILE_M, x.device());
-        moe_up_fp8_grouped_gelu_tanh_kernel<TILE_M, false>(
+        moe_up_fp8_grouped_gelu_tanh_kernel<TILE_M, false, NATIVE_LAYOUT>(
             (const fp16*)x.data_ptr(),
             (const uint8_t*)gate_up_weight.data_ptr(),
             gate_up_scale.data_ptr<float>(),
@@ -405,9 +460,34 @@ inline torch::Tensor moe_up_fp8_grouped(
     return intermediate;
 }
 
+inline torch::Tensor moe_up_fp8_grouped(
+    torch::Tensor x,
+    torch::Tensor gate_up_weight,
+    torch::Tensor gate_up_scale,
+    torch::Tensor expert_offsets,
+    torch::Tensor expert_tokens,
+    int64_t top_k, int64_t n_routed_experts) {
+    return moe_up_fp8_grouped_impl<false>(
+        x, gate_up_weight, gate_up_scale, expert_offsets, expert_tokens,
+        top_k, n_routed_experts);
+}
+
+inline torch::Tensor moe_up_fp8_grouped_native(
+    torch::Tensor x,
+    torch::Tensor gate_up_weight,
+    torch::Tensor gate_up_scale,
+    torch::Tensor expert_offsets,
+    torch::Tensor expert_tokens,
+    int64_t top_k, int64_t n_routed_experts) {
+    return moe_up_fp8_grouped_impl<true>(
+        x, gate_up_weight, gate_up_scale, expert_offsets, expert_tokens,
+        top_k, n_routed_experts);
+}
+
 // Down: returns per-route output [n_tokens*top_k, hidden] (routing-weighted).
 // Python then sums the top_k rows per token (moe_prefill_accumulate or a view-sum).
-inline torch::Tensor moe_down_fp8_grouped(
+template <bool NATIVE_LAYOUT>
+inline torch::Tensor moe_down_fp8_grouped_impl(
     torch::Tensor intermediate,      // [n_tokens*top_k, inter] fp16
     torch::Tensor down_weight,       // [E, hidden, inter] e4m3 (uint8 view)
     torch::Tensor down_scale,        // [E] float
@@ -418,10 +498,12 @@ inline torch::Tensor moe_down_fp8_grouped(
     TORCH_CHECK(intermediate.scalar_type() == torch::kHalf);
     int total_routes = intermediate.size(0);
     int intermediate_size = intermediate.size(1);
-    int hidden_size = down_weight.size(1);
+    int hidden_size = NATIVE_LAYOUT
+        ? down_weight.size(2)
+        : down_weight.size(1);
     auto output = torch::empty({total_routes, hidden_size},
         torch::device(intermediate.device()).dtype(torch::kHalf));
-    moe_down_fp8_grouped_kernel<16>(
+    moe_down_fp8_grouped_kernel<16, NATIVE_LAYOUT>(
         (const fp16*)intermediate.data_ptr(),
         (const uint8_t*)down_weight.data_ptr(),
         down_scale.data_ptr<float>(),
@@ -432,6 +514,32 @@ inline torch::Tensor moe_down_fp8_grouped(
         (int)n_routed_experts, total_routes,
         hidden_size, intermediate_size, (int)top_k, intermediate.device());
     return output;
+}
+
+inline torch::Tensor moe_down_fp8_grouped(
+    torch::Tensor intermediate,
+    torch::Tensor down_weight,
+    torch::Tensor down_scale,
+    torch::Tensor routing_weights,
+    torch::Tensor expert_offsets,
+    torch::Tensor expert_tokens,
+    int64_t top_k, int64_t n_routed_experts) {
+    return moe_down_fp8_grouped_impl<false>(
+        intermediate, down_weight, down_scale, routing_weights,
+        expert_offsets, expert_tokens, top_k, n_routed_experts);
+}
+
+inline torch::Tensor moe_down_fp8_grouped_native(
+    torch::Tensor intermediate,
+    torch::Tensor down_weight,
+    torch::Tensor down_scale,
+    torch::Tensor routing_weights,
+    torch::Tensor expert_offsets,
+    torch::Tensor expert_tokens,
+    int64_t top_k, int64_t n_routed_experts) {
+    return moe_down_fp8_grouped_impl<true>(
+        intermediate, down_weight, down_scale, routing_weights,
+        expert_offsets, expert_tokens, top_k, n_routed_experts);
 }
 
 template <int TILE_N = 16>
@@ -468,7 +576,8 @@ void moe_grouped_accumulate_kernel(
 // the caller because Gemma folds per_expert_scale before this op; the up,
 // down, and route accumulation launches stay inside one C++ dispatch so the
 // Python layer does not rebuild intermediate tensors or launch reductions.
-inline torch::Tensor moe_forward_full_fp8_grouped(
+template <bool NATIVE_LAYOUT>
+inline torch::Tensor moe_forward_full_fp8_grouped_impl(
     torch::Tensor x,
     torch::Tensor gate_up_weight,
     torch::Tensor gate_up_scale,
@@ -479,10 +588,10 @@ inline torch::Tensor moe_forward_full_fp8_grouped(
     torch::Tensor expert_tokens,
     int64_t top_k,
     int64_t n_routed_experts) {
-    auto intermediate = moe_up_fp8_grouped(
+    auto intermediate = moe_up_fp8_grouped_impl<NATIVE_LAYOUT>(
         x, gate_up_weight, gate_up_scale, expert_offsets, expert_tokens,
         top_k, n_routed_experts);
-    auto partials = moe_down_fp8_grouped(
+    auto partials = moe_down_fp8_grouped_impl<NATIVE_LAYOUT>(
         intermediate, down_weight, down_scale, routing_weights,
         expert_offsets, expert_tokens, top_k, n_routed_experts);
     const int n_tokens = x.size(0);
@@ -494,4 +603,38 @@ inline torch::Tensor moe_forward_full_fp8_grouped(
         (fp16*)output.data_ptr(),
         n_tokens, hidden_size, (int)top_k, x.device());
     return output;
+}
+
+inline torch::Tensor moe_forward_full_fp8_grouped(
+    torch::Tensor x,
+    torch::Tensor gate_up_weight,
+    torch::Tensor gate_up_scale,
+    torch::Tensor down_weight,
+    torch::Tensor down_scale,
+    torch::Tensor routing_weights,
+    torch::Tensor expert_offsets,
+    torch::Tensor expert_tokens,
+    int64_t top_k,
+    int64_t n_routed_experts) {
+    return moe_forward_full_fp8_grouped_impl<false>(
+        x, gate_up_weight, gate_up_scale, down_weight, down_scale,
+        routing_weights, expert_offsets, expert_tokens, top_k,
+        n_routed_experts);
+}
+
+inline torch::Tensor moe_forward_full_fp8_grouped_native(
+    torch::Tensor x,
+    torch::Tensor gate_up_weight,
+    torch::Tensor gate_up_scale,
+    torch::Tensor down_weight,
+    torch::Tensor down_scale,
+    torch::Tensor routing_weights,
+    torch::Tensor expert_offsets,
+    torch::Tensor expert_tokens,
+    int64_t top_k,
+    int64_t n_routed_experts) {
+    return moe_forward_full_fp8_grouped_impl<true>(
+        x, gate_up_weight, gate_up_scale, down_weight, down_scale,
+        routing_weights, expert_offsets, expert_tokens, top_k,
+        n_routed_experts);
 }

--- a/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe_int4.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe_int4.sycl
@@ -1505,7 +1505,7 @@ class MoeTinyMUpCutlassInt4;
 template <typename IndexT>
 class MoeTinyMUpCutlassInt4GeluTanh;
 template <typename IndexT>
-class MoeTinyMDownCutlassInt4G32;
+class MoeTinyMDownCutlassInt4Grouped;
 template <typename IndexT>
 class MoeTinyMDownCutlassInt4;
 template <typename IndexT>
@@ -1822,11 +1822,13 @@ void moe_tiny_m_up_cutlass_int4_gelu_tanh_kernel(
     const IndexT* topk_idx,
     fp16* intermediates,
     const int n_tokens, const int top_k, const int hidden_size, const int intermediate_size,
+    const int group_size,
     const torch::Device& device) {
 
     const int two_inter = 2 * intermediate_size;
     const int k_bytes = hidden_size / 2;
-    const int k_groups = hidden_size / 32;  // gemma QK4_GROUP_SIZE=32
+    const int k_groups = hidden_size / group_size;
+    const int group_bytes = group_size / 2;
     constexpr int WG_SIZE = 64;
 
     auto cgf = [&](sycl::handler& cgh) {
@@ -1856,7 +1858,7 @@ void moe_tiny_m_up_cutlass_int4_gelu_tanh_kernel(
                 float up_sum = 0.0f;
                 for (int kb = lid; kb < k_bytes; kb += WG_SIZE) {
                     int k0 = kb << 1;
-                    int group = kb >> 4;  // group=32 -> 16 bytes/group
+                    int group = kb / group_bytes;
                     uint8_t gate_packed = gate_row[kb];
                     uint8_t up_packed = up_row[kb];
                     int gate0 = decode_s4_nibble(gate_packed & 0x0F);
@@ -3770,9 +3772,9 @@ torch::Tensor moe_forward_cutlass_nmajor_int4_full(
 }
 
 
-// ── gemma int4: group=32 down kernel (QK4_GROUP_SIZE=32, applies routing weight + accumulate) ──
+// ── gemma int4: grouped down kernel (applies routing weight + accumulate) ──
 template <typename IndexT>
-void moe_tiny_m_down_cutlass_int4_g32_kernel(
+void moe_tiny_m_down_cutlass_int4_grouped_kernel(
     const fp16* intermediates,
     const uint8_t* w2,
     const fp16* w2_scales,
@@ -3780,15 +3782,16 @@ void moe_tiny_m_down_cutlass_int4_g32_kernel(
     const IndexT* topk_idx,
     fp16* output,
     const int n_tokens, const int top_k, const int hidden_size, const int intermediate_size,
+    const int group_size,
     const torch::Device& device) {
 
     const int k_bytes = intermediate_size / 2;
-    const int k_groups = intermediate_size / 32;  // gemma QK4_GROUP_SIZE=32
+    const int k_groups = intermediate_size / group_size;
     constexpr int WG_SIZE = 64;
 
     auto cgf = [&](sycl::handler& cgh) {
         sycl::local_accessor<float, 1> local_acc(sycl::range<1>(WG_SIZE), cgh);
-        cgh.parallel_for<class MoeTinyMDownCutlassInt4G32<IndexT>>(
+        cgh.parallel_for<class MoeTinyMDownCutlassInt4Grouped<IndexT>>(
             sycl::nd_range<1>(sycl::range<1>(n_tokens * hidden_size * WG_SIZE),
                               sycl::range<1>(WG_SIZE)),
             [=](sycl::nd_item<1> item) {
@@ -3807,7 +3810,7 @@ void moe_tiny_m_down_cutlass_int4_g32_kernel(
                         uint8_t packed = w_row[k >> 1];
                         uint8_t nibble = (k & 1) ? ((packed >> 4) & 0x0F) : (packed & 0x0F);
                         int v = decode_s4_nibble(nibble);
-                        float scale = (float)s_row[k >> 5];  // group=32
+                        float scale = (float)s_row[k / group_size];
                         sum += route_weight * (float)in_row[k] * ((float)v * scale);
                     }
                 }
@@ -3826,8 +3829,8 @@ void moe_tiny_m_down_cutlass_int4_g32_kernel(
 
 // ── gemma int4 decode: 内部 topk(fp32-internal) + per_expert_scale fold +
 // gelu_tanh up + down(+routing weight & accumulate). M==1 (decode). ──
-// w13_qweight_s4 [E, 2*inter, hidden/2] uint8, w13_scales [E, 2*inter, hidden/128] fp16
-// w2_qweight_s4  [E, hidden, inter/2] uint8,   w2_scales  [E, hidden, inter/128] fp16
+// w13_qweight_s4 [E, 2*inter, hidden/2] uint8, w13_scales [E, 2*inter, hidden/group] fp16
+// w2_qweight_s4  [E, hidden, inter/2] uint8,   w2_scales  [E, hidden, inter/group] fp16
 // per_expert_scale [E] float32. logits [n_tokens, E] fp16.
 torch::Tensor moe_forward_gelu_tanh_int4_decode(
     torch::Tensor x, torch::Tensor logits,
@@ -3839,10 +3842,28 @@ torch::Tensor moe_forward_gelu_tanh_int4_decode(
     TORCH_CHECK(logits.scalar_type() == torch::kHalf);
     TORCH_CHECK(w13_qweight_s4.scalar_type() == torch::kByte);
     TORCH_CHECK(w2_qweight_s4.scalar_type() == torch::kByte);
+    TORCH_CHECK(w13_scales.scalar_type() == torch::kHalf &&
+                w2_scales.scalar_type() == torch::kHalf);
+    TORCH_CHECK(w13_scales.dim() == 3 && w2_scales.dim() == 3);
+    TORCH_CHECK(w13_scales.size(2) > 0 && w2_scales.size(2) > 0);
     int n_tokens = x.size(0);
     int two_inter = w13_qweight_s4.size(1);
     int intermediate_size = two_inter / 2;
     int hidden_size = x.size(1);
+    TORCH_CHECK(w13_qweight_s4.size(2) * 2 == hidden_size);
+    TORCH_CHECK(w2_qweight_s4.size(2) * 2 == intermediate_size);
+    TORCH_CHECK(w13_scales.size(0) == w13_qweight_s4.size(0) &&
+                w13_scales.size(1) == two_inter);
+    TORCH_CHECK(w2_scales.size(0) == w2_qweight_s4.size(0) &&
+                w2_scales.size(1) == w2_qweight_s4.size(1));
+    TORCH_CHECK(hidden_size % w13_scales.size(2) == 0 &&
+                intermediate_size % w2_scales.size(2) == 0);
+    const int up_group_size = hidden_size / w13_scales.size(2);
+    const int down_group_size = intermediate_size / w2_scales.size(2);
+    TORCH_CHECK(up_group_size == down_group_size &&
+                up_group_size > 0 && (up_group_size & 1) == 0,
+                "Gemma INT4 MoE requires the same even group size for up/down");
+    const int group_size = up_group_size;
     sycl::queue& q = c10::xpu::getCurrentXPUStream(x.device().index()).queue();
 
     // internal topk (fp32-internal softmax+top8+norm) — same v2 kernel as fp8 path
@@ -3879,17 +3900,18 @@ torch::Tensor moe_forward_gelu_tanh_int4_decode(
         (const fp16*)x.data_ptr(), (const uint8_t*)w13_qweight_s4.data_ptr(),
         (const fp16*)w13_scales.data_ptr(), topk_idx.data_ptr<int>(),
         (fp16*)intermediates.data_ptr(), n_tokens, (int)top_k, hidden_size,
-        intermediate_size, x.device());
+        intermediate_size, group_size, x.device());
 
-    // down (group=32, applies routing weight + accumulate over top_k) -> [n_tokens, hidden]
+    // down (the runtime group size is derived from the scale tensor)
     int hidden_out = w2_qweight_s4.size(1);
     auto output = torch::empty({n_tokens, hidden_out},
         torch::device(x.device()).dtype(torch::kHalf));
-    moe_tiny_m_down_cutlass_int4_g32_kernel<int32_t>(
+    moe_tiny_m_down_cutlass_int4_grouped_kernel<int32_t>(
         (const fp16*)intermediates.data_ptr(), (const uint8_t*)w2_qweight_s4.data_ptr(),
         (const fp16*)w2_scales.data_ptr(), (const fp16*)topk_weight.data_ptr(),
         topk_idx.data_ptr<int32_t>(), (fp16*)output.data_ptr(),
-        n_tokens, (int)top_k, hidden_out, intermediate_size, x.device());
+        n_tokens, (int)top_k, hidden_out, intermediate_size, group_size,
+        x.device());
     return output;
 }
 

--- a/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe_int4.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/moe_batch/moe_int4.sycl
@@ -3829,8 +3829,8 @@ void moe_tiny_m_down_cutlass_int4_grouped_kernel(
 
 // ── gemma int4 decode: 内部 topk(fp32-internal) + per_expert_scale fold +
 // gelu_tanh up + down(+routing weight & accumulate). M==1 (decode). ──
-// w13_qweight_s4 [E, 2*inter, hidden/2] uint8, w13_scales [E, 2*inter, hidden/group] fp16
-// w2_qweight_s4  [E, hidden, inter/2] uint8,   w2_scales  [E, hidden, inter/group] fp16
+// w13_qweight_s4 [E, 2*inter, hidden/2] uint8, w13_scales [E, 2*inter, hidden/up_group] fp16
+// w2_qweight_s4  [E, hidden, inter/2] uint8,   w2_scales  [E, hidden, inter/down_group] fp16
 // per_expert_scale [E] float32. logits [n_tokens, E] fp16.
 torch::Tensor moe_forward_gelu_tanh_int4_decode(
     torch::Tensor x, torch::Tensor logits,
@@ -3860,10 +3860,9 @@ torch::Tensor moe_forward_gelu_tanh_int4_decode(
                 intermediate_size % w2_scales.size(2) == 0);
     const int up_group_size = hidden_size / w13_scales.size(2);
     const int down_group_size = intermediate_size / w2_scales.size(2);
-    TORCH_CHECK(up_group_size == down_group_size &&
-                up_group_size > 0 && (up_group_size & 1) == 0,
-                "Gemma INT4 MoE requires the same even group size for up/down");
-    const int group_size = up_group_size;
+    TORCH_CHECK(up_group_size > 0 && (up_group_size & 1) == 0 &&
+                down_group_size > 0 && (down_group_size & 1) == 0,
+                "Gemma INT4 MoE requires even up/down group sizes");
     sycl::queue& q = c10::xpu::getCurrentXPUStream(x.device().index()).queue();
 
     // internal topk (fp32-internal softmax+top8+norm) — same v2 kernel as fp8 path
@@ -3900,7 +3899,7 @@ torch::Tensor moe_forward_gelu_tanh_int4_decode(
         (const fp16*)x.data_ptr(), (const uint8_t*)w13_qweight_s4.data_ptr(),
         (const fp16*)w13_scales.data_ptr(), topk_idx.data_ptr<int>(),
         (fp16*)intermediates.data_ptr(), n_tokens, (int)top_k, hidden_size,
-        intermediate_size, group_size, x.device());
+        intermediate_size, up_group_size, x.device());
 
     // down (the runtime group size is derived from the scale tensor)
     int hidden_out = w2_qweight_s4.size(1);
@@ -3910,7 +3909,7 @@ torch::Tensor moe_forward_gelu_tanh_int4_decode(
         (const fp16*)intermediates.data_ptr(), (const uint8_t*)w2_qweight_s4.data_ptr(),
         (const fp16*)w2_scales.data_ptr(), (const fp16*)topk_weight.data_ptr(),
         topk_idx.data_ptr<int32_t>(), (fp16*)output.data_ptr(),
-        n_tokens, (int)top_k, hidden_out, intermediate_size, group_size,
+        n_tokens, (int)top_k, hidden_out, intermediate_size, down_group_size,
         x.device());
     return output;
 }

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/int4_GEMM.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/int4_GEMM.h
@@ -296,7 +296,12 @@ inline void GEMM_int4_pgrp_host(
     int n_wgs = ((int)N + 15) / 16;
     int k_threads = std::max(1, std::min(4, 640 / std::max(n_wgs, 1)));
     while (k_threads > 1 && ((int)K % (k_threads * INT4_GEMM_GROUP_SIZE) != 0)) k_threads--;
-    if (k_threads == 3) k_threads = 2;
+    if (k_threads == 3) {
+        // Avoid the 3-thread variant only after preserving whole scale groups
+        // per thread.  For example, K=1152 is divisible by 3*128 but not
+        // 2*128, so forcing 2 here would start a thread inside a scale group.
+        k_threads = ((int)K % (2 * INT4_GEMM_GROUP_SIZE) == 0) ? 2 : 1;
+    }
 
     #define DISPATCH(KT, MT) gemm_int4_pgrp_host_impl<KT, MT>( \
         input, weight, scale, output, M, N, K, q)

--- a/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/__init__.py
+++ b/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/__init__.py
@@ -67,6 +67,7 @@ from custom_esimd_kernels_vllm.ops import (
     # Eagle ops
     eagle_gdn,
     eagle_page_attn_decode,
+    eagle_page_attn_decode_separate,
     # MoE Batch ops
     moe_router_forward,
     moe_batch_topk,

--- a/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/ops.py
+++ b/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/ops.py
@@ -938,6 +938,8 @@ def eagle_page_attn_decode(
     out: torch.Tensor,
     max_query_len: int,
     max_seq_len: int,
+    k_scale: float = 1.0,
+    v_scale: float = 1.0,
 ) -> None:
     """Eagle paged attention decode.
 
@@ -949,7 +951,30 @@ def eagle_page_attn_decode(
     """
     return _eagle_ops.page_attn_decode(
         query, kv_cache, block_table, seq_lens, out,
-        max_query_len, max_seq_len)
+        max_query_len, max_seq_len, k_scale, v_scale)
+
+
+def eagle_page_attn_decode_separate(
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    block_table: torch.Tensor,
+    seq_lens: torch.Tensor,
+    out: torch.Tensor,
+    max_query_len: int,
+    max_seq_len: int,
+    k_scale: float = 1.0,
+    v_scale: float = 1.0,
+) -> None:
+    """Eagle paged attention for v0.26's separate K/V cache views.
+
+    key_cache and value_cache are [num_blocks, page_size, num_kv_heads,
+    head_dim] views into the packed vLLM cache.  The kernel consumes their
+    strides directly, so this path does not materialize a reordered cache.
+    """
+    return _eagle_ops.page_attn_decode_separate(
+        query, key_cache, value_cache, block_table, seq_lens, out,
+        max_query_len, max_seq_len, k_scale, v_scale)
 
 
 # ---- MoE Batch Ops (Router, TopK, Up/Down, Accumulate) ----

--- a/vllm/custom-esimd-kernels-vllm/tests/test_moe_decode_gelu_tanh.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/test_moe_decode_gelu_tanh.py
@@ -1,0 +1,149 @@
+import math
+
+import custom_esimd_kernels_vllm  # noqa: F401
+import pytest
+import torch
+
+
+def _gelu_tanh(value):
+    return 0.5 * value * (
+        1.0
+        + torch.tanh(
+            math.sqrt(2 / math.pi) * (value + 0.044715 * value**3)
+        )
+    )
+
+
+def _make_case(hidden, intermediate, seed):
+    num_experts, top_k = 8, 2
+    scale = 0.3
+    torch.manual_seed(seed)
+    device = torch.device("xpu")
+    x = torch.randn((1, hidden), dtype=torch.float16, device=device) * 0.05
+    logits = torch.randn(
+        (1, num_experts), dtype=torch.float16, device=device
+    )
+    gate_up = (
+        (
+            torch.randn(
+                (num_experts, 2 * intermediate, hidden), device=device
+            )
+            * 0.05
+        )
+        .clamp(-scale, scale)
+        .div(scale)
+        .to(torch.float8_e4m3fn)
+    )
+    down = (
+        (
+            torch.randn(
+                (num_experts, hidden, intermediate), device=device
+            )
+            * 0.05
+        )
+        .clamp(-scale, scale)
+        .div(scale)
+        .to(torch.float8_e4m3fn)
+    )
+    gate_up_scale = torch.full(
+        (num_experts,), scale, dtype=torch.float32, device=device
+    )
+    down_scale = torch.full(
+        (num_experts,), scale, dtype=torch.float32, device=device
+    )
+    expert_scale = torch.ones(
+        (num_experts,), dtype=torch.float32, device=device
+    )
+
+    probabilities = torch.softmax(logits.float(), dim=-1)
+    routing_weights, routing_indices = torch.topk(
+        probabilities, top_k, dim=-1
+    )
+    routing_weights = (
+        routing_weights / routing_weights.sum(dim=-1, keepdim=True)
+    ).to(torch.float16)
+    reference = torch.zeros_like(x)
+    for route in range(top_k):
+        expert = routing_indices[0, route].item()
+        projected = (
+            gate_up[expert].to(torch.float16) * gate_up_scale[expert]
+        ) @ x[0]
+        gate, up = projected.split(intermediate)
+        activated = _gelu_tanh(gate.float()).to(torch.float16) * up
+        reference[0] += (
+            (down[expert].to(torch.float16) * down_scale[expert]) @ activated
+        ) * routing_weights[0, route]
+
+    args = (
+        x,
+        logits,
+        gate_up,
+        gate_up_scale,
+        down,
+        down_scale,
+        expert_scale,
+        top_k,
+        num_experts,
+    )
+    return args, reference
+
+
+@pytest.mark.parametrize(
+    ("hidden", "intermediate"),
+    [(256, 192), (288, 64), (2816, 704)],
+)
+def test_canonical_decode_handles_32_element_tail_chunks(
+    hidden, intermediate
+):
+    args, reference = _make_case(hidden, intermediate, seed=hidden)
+    output = torch.ops.moe_ops.moe_forward_full_gelu_tanh_decode(*args)
+    torch.xpu.synchronize()
+    torch.testing.assert_close(output, reference, atol=3e-2, rtol=3e-2)
+
+
+def test_decode_scratch_cache_reallocates_for_new_shape():
+    first_args, first_reference = _make_case(256, 192, seed=1)
+    second_args, second_reference = _make_case(288, 64, seed=2)
+
+    first_output = (
+        torch.ops.moe_ops.moe_forward_full_gelu_tanh_decode(*first_args).clone()
+    )
+    second_output = (
+        torch.ops.moe_ops.moe_forward_full_gelu_tanh_decode(*second_args).clone()
+    )
+    torch.xpu.synchronize()
+
+    torch.testing.assert_close(
+        first_output, first_reference, atol=3e-2, rtol=3e-2
+    )
+    torch.testing.assert_close(
+        second_output, second_reference, atol=3e-2, rtol=3e-2
+    )
+
+
+def test_decode_scratch_cache_isolated_per_stream():
+    first_args, first_reference = _make_case(256, 192, seed=3)
+    second_args, second_reference = _make_case(256, 192, seed=4)
+    first_stream = torch.xpu.Stream()
+    second_stream = torch.xpu.Stream()
+
+    with torch.xpu.stream(first_stream):
+        first_output = (
+            torch.ops.moe_ops.moe_forward_full_gelu_tanh_decode(
+                *first_args
+            ).clone()
+        )
+    with torch.xpu.stream(second_stream):
+        second_output = (
+            torch.ops.moe_ops.moe_forward_full_gelu_tanh_decode(
+                *second_args
+            ).clone()
+        )
+    torch.xpu.synchronize()
+
+    torch.testing.assert_close(
+        first_output, first_reference, atol=3e-2, rtol=3e-2
+    )
+    torch.testing.assert_close(
+        second_output, second_reference, atol=3e-2, rtol=3e-2
+    )

--- a/vllm/custom-esimd-kernels-vllm/tests/test_moe_fp8_grouped.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/test_moe_fp8_grouped.py
@@ -1,42 +1,115 @@
-import math, time, torch
+import math
+
 import custom_esimd_kernels_vllm
-import custom_esimd_kernels_vllm.moe_int4_prefill_ops
-dev=torch.device("xpu")
-def gelu_tanh(t): return 0.5*t*(1.0+torch.tanh(math.sqrt(2/math.pi)*(t+0.044715*t**3)))
-def ref_moe(x,w_,idx_,w13,w2,gu_s,dn_s,top_k,inter):
-    out=torch.zeros_like(x)
+import custom_esimd_kernels_vllm.moe_int4_prefill_ops  # noqa: F401
+import pytest
+import torch
+
+DEV = torch.device("xpu")
+
+
+def gelu_tanh(t):
+    return 0.5 * t * (
+        1.0 + torch.tanh(math.sqrt(2 / math.pi) * (t + 0.044715 * t**3))
+    )
+
+
+def ref_moe(x, weights, indices, w13, w2, gu_s, dn_s, top_k, inter):
+    out = torch.zeros_like(x)
     for t in range(x.shape[0]):
         for k in range(top_k):
-            eid=idx_[t,k].item()
-            g=(w13[eid].to(torch.float16)*float(gu_s[eid]))@x[t]
-            gate,up=g.split(inter); mid=gelu_tanh(gate.float()).to(torch.float16)*up
-            out[t]+=((w2[eid].to(torch.float16)*float(dn_s[eid]))@mid)*w_[t,k]
+            eid = indices[t, k].item()
+            g = (w13[eid].to(torch.float16) * float(gu_s[eid])) @ x[t]
+            gate, up = g.split(inter)
+            mid = gelu_tanh(gate.float()).to(torch.float16) * up
+            out[t] += (
+                (w2[eid].to(torch.float16) * float(dn_s[eid])) @ mid
+            ) * weights[t, k]
     return out
-E,K,H,I=128,8,2816,704; sc=0.3
-for T in [256]:
+
+
+@pytest.mark.parametrize("native_layout", [False, True])
+def test_grouped_fp8_matches_reference(native_layout):
+    num_experts, top_k, hidden, intermediate, tokens = 8, 2, 256, 64, 8
+    scale = 0.3
     torch.manual_seed(42)
-    x=torch.randn(T,H,dtype=torch.float16,device=dev)*0.05
-    logits=torch.randn(T,E,dtype=torch.float16,device=dev)
-    probs=torch.softmax(logits.float(),-1); pw,pi=torch.topk(probs,K,-1)
-    pw=(pw/pw.sum(-1,keepdim=True)).to(torch.float16); pi=pi.to(torch.int32)
-    w13=(torch.randn(E,2*I,H,device=dev)*0.05).clamp(-sc,sc).div(sc).to(torch.float8_e4m3fn)
-    w2=(torch.randn(E,H,I,device=dev)*0.05).clamp(-sc,sc).div(sc).to(torch.float8_e4m3fn)
-    gu_s=torch.full((E,),sc,dtype=torch.float32,device=dev); dn_s=torch.full((E,),sc,dtype=torch.float32,device=dev)
-    r=ref_moe(x,pw,pi,w13,w2,gu_s,dn_s,K,I)
-    # gather
-    go=torch.ops.moe_int4_prefill_ops.moe_prefill_gather_forward_v2(pi.contiguous(),E)
+    x = torch.randn(tokens, hidden, dtype=torch.float16, device=DEV) * 0.05
+    logits = torch.randn(tokens, num_experts, dtype=torch.float16, device=DEV)
+    probs = torch.softmax(logits.float(), -1)
+    routing_weights, routing_indices = torch.topk(probs, top_k, -1)
+    routing_weights = (
+        routing_weights / routing_weights.sum(-1, keepdim=True)
+    ).to(torch.float16)
+    routing_indices = routing_indices.to(torch.int32)
+    w13 = (
+        (torch.randn(num_experts, 2 * intermediate, hidden, device=DEV) * 0.05)
+        .clamp(-scale, scale)
+        .div(scale)
+        .to(torch.float8_e4m3fn)
+    )
+    w2 = (
+        (torch.randn(num_experts, hidden, intermediate, device=DEV) * 0.05)
+        .clamp(-scale, scale)
+        .div(scale)
+        .to(torch.float8_e4m3fn)
+    )
+    gu_s = torch.full(
+        (num_experts,), scale, dtype=torch.float32, device=DEV
+    )
+    dn_s = torch.full(
+        (num_experts,), scale, dtype=torch.float32, device=DEV
+    )
+    reference = ref_moe(
+        x,
+        routing_weights,
+        routing_indices,
+        w13,
+        w2,
+        gu_s,
+        dn_s,
+        top_k,
+        intermediate,
+    )
+    go = torch.ops.moe_int4_prefill_ops.moe_prefill_gather_forward_v2(
+        routing_indices.contiguous(), num_experts
+    )
     expert_offsets, expert_tokens = go[0], go[1]
-    # flat routing weights pair-indexed: pair = token*K + k
-    rw_flat = pw.reshape(-1).contiguous()  # [T*K], pair-indexed
-    w13u=w13.view(torch.uint8); w2u=w2.view(torch.uint8)
-    def run():
-        inter=torch.ops.moe_ops.moe_up_fp8_grouped(x.contiguous(),w13u,gu_s,expert_offsets,expert_tokens,K,E)
-        outp=torch.ops.moe_ops.moe_down_fp8_grouped(inter,w2u,dn_s,rw_flat,expert_offsets,expert_tokens,K,E)
-        return outp.view(T,K,H).sum(1)
-    o=run(); torch.xpu.synchronize()
-    diff=(o.float()-r.float()).abs().max().item(); isnan=bool(torch.isnan(o).any())
-    for _ in range(3): run()
-    torch.xpu.synchronize(); t0=time.perf_counter()
-    for _ in range(10): run()
-    torch.xpu.synchronize(); dt=(time.perf_counter()-t0)/10*1000
-    print("GROUPED T=%d max_diff=%.3e nan=%s %.2fms/call %s"%(T,diff,isnan,dt,"OK" if diff<3e-2 else "FAIL"))
+    routing_weights = routing_weights.reshape(-1).contiguous()
+    if native_layout:
+        op = torch.ops.moe_ops.moe_forward_full_fp8_grouped_native
+        w13_arg = w13.transpose(1, 2).contiguous().view(torch.uint8)
+        w2_arg = w2.transpose(1, 2).contiguous().view(torch.uint8)
+    else:
+        op = torch.ops.moe_ops.moe_forward_full_fp8_grouped
+        w13_arg = w13.view(torch.uint8)
+        w2_arg = w2.view(torch.uint8)
+
+    output = op(
+        x.contiguous(),
+        w13_arg,
+        gu_s,
+        w2_arg,
+        dn_s,
+        routing_weights,
+        expert_offsets,
+        expert_tokens,
+        top_k,
+        num_experts,
+    )
+    torch.xpu.synchronize()
+
+    assert not torch.isnan(output).any()
+    torch.testing.assert_close(output, reference, atol=3e-2, rtol=3e-2)
+
+
+def test_grouped_fp8_rejects_unaligned_hidden_size():
+    x = torch.empty((1, 24), dtype=torch.float16, device=DEV)
+    gate_up = torch.empty((1, 32, 24), dtype=torch.uint8, device=DEV)
+    scale = torch.ones((1,), dtype=torch.float32, device=DEV)
+    offsets = torch.zeros((1,), dtype=torch.int32, device=DEV)
+    tokens = torch.zeros((1,), dtype=torch.int32, device=DEV)
+
+    with pytest.raises(RuntimeError, match="must be multiples of 16"):
+        torch.ops.moe_ops.moe_up_fp8_grouped(
+            x, gate_up, scale, offsets, tokens, 1, 1
+        )

--- a/vllm/custom-esimd-kernels-vllm/tests/test_moe_full_gelu_tanh.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/test_moe_full_gelu_tanh.py
@@ -3,8 +3,11 @@ weight layout: w13 [E, 2*inter, hidden], w2 [E, hidden, inter] fp8_e4m3fn.
 
 Reference uses fp16 dequant + matmul; tolerates fp8 quant noise (~1e-2).
 """
-import math, sys, torch
+import math
+import sys
+
 import custom_esimd_kernels_vllm  # noqa: F401  (registers torch.ops.moe_ops)
+import torch
 
 
 def gelu_tanh(t):
@@ -53,7 +56,5 @@ def run(n_experts, top_k, hidden, inter, tokens, seed, tol):
 
 if __name__ == "__main__":
     # gemma4 real shape (E=128, top_k=8, hidden=2816, inter=704).
-    # Note: kernel reuses internal buffers across calls keyed by n_tokens only,
-    # so a single shape per test process is the safe pattern.
     ok = run(128, 8, 2816, 704, 2, 42, 2e-2)
     sys.exit(0 if ok else 1)


### PR DESCRIPTION
# [XPU] Add Gemma4 ESIMD MoE kernels for v0.26.0

**Repository:** `custom-esimd-kernels-vllm`
**Target base:** `origin/upgrade/v0.26.0` (`25095b4`)
**Source branch:** `optimize_gemma4` (`881d1c7`)

## Summary

This PR adds the Gemma4 v0.26 custom ESIMD kernel series used by the vLLM
`optimize_gemma` branch.

The series supports:

- native-layout FP8 MoE decode and grouped batch execution;
- Gemma GELU-tanh full-fused and routed decode;
- Gemma INT4 mixed group sizes and scale-group partitioning;
- v0.26 custom-op bindings and page-attention/eagle integration;
- safe asynchronous scratch-buffer reuse across shapes and XPU streams.

The functional kernel series is based on the v0.26 custom-kernel line at
`255986a`; the current `optimize_gemma4` branch also contains the final safety
hardening commit `881d1c7`.

The local checkout's `upgrade/v0.26.0` reference is already at `85d10fe`.
Opening the PR against that local ref would show only the final safety commit.
Use the remote target above if the PR is intended to carry the complete
Gemma4 series.

## Main changes

### FP8 MoE

- Add native expert-layout FP8 grouped-weight support.
- Add Gemma FP8 decode GEMV using 1D weight loads for the M=1 regime.
- Add tail-safe handling for non-256-aligned K dimensions.
- Add full-fused GELU-tanh decode and routed decode operations.
- Preserve FP32-internal top-k routing and per-expert scaling semantics.
- Keep canonical-layout and native-layout dispatches separate so v0.26
  weights do not require an unnecessary compatibility transpose.

### INT4

- Derive the effective Gemma group size from the actual weight/scale shape.
- Support mixed group sizes used by Gemma W13 and W2 projections.
- Fix INT4 GEMM scale-group thread partitioning.
- Keep scale and packed-weight addressing consistent with the v0.26
  `RoutedExperts` layout.
- Retain explicit unsupported-shape checks instead of reading past a tile or
  silently producing an incorrect result.

### Buffer lifetime and dispatch safety

- Replace one global Gemma scratch-buffer set with per-stream, per-shape
  storage.
- Keep a ring of final output buffers so an asynchronous consumer cannot read a
  buffer overwritten by the next MoE call.
- Reallocate when token count, top-k, hidden size, or intermediate size changes.
- Add explicit dtype, contiguity, dimensionality, alignment, and layout checks.
- Centralize decode up/down dispatch and validate the hidden/intermediate
  dimensions before launching the kernel.
- Preserve generic top-k and native fallback implementations for unsupported
  expert counts or top-k values.

### v0.26 integration

- Update `moe.sycl` registrations and dispatch for the v0.26 Gemma operations.
- Update `moe_decode_gemv.h` and `moe_fp8_grouped.h` for the native expert
  layout.
- Update `moe_int4.sycl` and `int4_GEMM.h` for mixed Gemma group sizes.
- Update the eagle/page-attention implementation used by the v0.26 XPU path.
- Export the new operations through the Python package bindings.

## Tests

The PR adds or updates:

- `tests/test_moe_decode_gelu_tanh.py`
  - canonical decode with 32-element tail chunks;
  - scratch-cache reallocation across shapes;
  - scratch-cache isolation across XPU streams.
- `tests/test_moe_fp8_grouped.py`
  - canonical and native FP8 layouts;
  - numerical comparison against an FP16 reference;
  - rejection of unaligned hidden sizes.
- `tests/test_moe_full_gelu_tanh.py`
  - real Gemma-like shape coverage: E=128, top-k=8, hidden=2816,
    intermediate=704.

Recorded numerical validation includes:

- fused/native INT4 A/B cosine similarity at least `0.99999982`;
- fused/native INT4 max absolute error no greater than `0.001465`;
- FP8 grouped and full-fused results within the expected FP8 quantization
  tolerance;
- Gemma4 GSM8K accuracy preserved at `0.95` with `invalid_rate=0` in the
  matching vLLM integration tests.

## Runtime behavior

- Decode-only fused paths are selected for supported shapes.
- Unsupported M, alignment, layout, dtype, and expert-count combinations fall
  back to the existing vLLM/native implementation.
- INT4 fused MoE is intended for M=1 by default; larger M values are not forced
  onto the decode kernel because native W4A16 was faster in the tested batch
  sweep.
- The extension must be rebuilt against the same Torch/XPU ABI as the v0.26
  vLLM installation.

## Known limitations

- Validated on Intel BMG with the v0.26 Torch/XPU toolchain and TP=2.
- Kernel-level performance numbers are shape- and M-dependent; the PR does not
  enable every experimental grouped/batch path by default.
- Sliding-window attention must continue to use the vLLM fallback path when the
  page-attention kernel cannot represent the model window.
- Building or copying an extension compiled against a different Torch ABI is
  unsupported.

## Scope

This PR contains kernel source, bindings, and focused kernel tests only. It does
not include vLLM Python integration changes, dependency updates, generated
shared libraries, or unrelated workspace modifications.
