### PR TITLE
docs: remove obsolete oneAPI setup instructions

### DIFF
--- a/vllm/KNOWN_ISSUES.md
+++ b/vllm/KNOWN_ISSUES.md
@@ -11,15 +11,3 @@ When using a single GPU card over a x16 PCIe connection without a PCIe switch, t
 Workaround: Change the PCIe slot configuration in BIOS from Auto/x16 to x8/x8.
 With this change, over 40 GB/s bi-directional P2P bandwidth can be achieved.
 Root cause analysis is still in progress.
-
-# 03. Container OOM killed (and vllm performance drop) when starting container not by /bin/bash and not run `source /opt/intel/oneapi/setvars.sh`
-
-When using `--enable-auto-tool-choice` and deploy container by docker-compose without `source /opt/intel/oneapi/setvars.sh`, the LD_LIBRARY_PATH will be different and cause the container OOM (or performance drop). It can be reproduced by this two command:
-
-```bash
-docker run --rm  --entrypoint "/bin/bash" --name=test intel/llm-scaler-vllm:latest -c env | grep LD_LIBRARY_PATH
- 
-docker run --rm --entrypoint "/bin/bash" --name=test intel/llm-scaler-vllm:latest -c "source /opt/intel/oneapi/setvars.sh --force && env | grep LD_LIBRARY_PATH"
-```
-
-So we need to run `source /opt/intel/oneapi/setvars.sh --force` to ensure some configurations are consistent.

--- a/vllm/README.md
+++ b/vllm/README.md
@@ -235,21 +235,12 @@ This way, only the first GPU will be mapped into the Docker container.
 
 ---
 
-**Note — Intel oneAPI Environment**
-> How you start the container determines whether you need to manually source the Intel oneAPI environment (`source /opt/intel/oneapi/setvars.sh --force`):
->
-> * **Interactive shell (`docker exec -it <container> bash`)**  
->   `/root/.bashrc` already sources the oneAPI environment. No manual action needed.
->
-> * **Docker Compose, overridden ENTRYPOINT, or direct `docker run` without interactive bash**  
->   The environment is **not automatically loaded** if no shell is involved. Prepend your command with `source /opt/intel/oneapi/setvars.sh --force &&` to ensure proper GPU/XPU setup.
->   
->   ```yaml
->   entrypoint: >
->     entrypoint: source /opt/intel/oneapi/setvars.sh --force && vllm serve --model /llm/models/Qwen3-14B
->   ```
->
-> **Summary:** Automated starts require sourcing the oneAPI script; interactive bash sessions are ready to use.
+**Note — Intel XPU Runtime Environment**
+> The image includes the required Intel XPU runtime libraries and configures
+> `/opt/venv/bin` in `PATH`. Do not source `/opt/intel/oneapi/setvars.sh`;
+> the runtime image does not include that script. Commands such as `vllm serve`
+> can be invoked directly from interactive shells, Docker Compose, or an
+> overridden entrypoint.
 
 ---
 

--- a/vllm/README.md
+++ b/vllm/README.md
@@ -235,17 +235,6 @@ This way, only the first GPU will be mapped into the Docker container.
 
 ---
 
-**Note — Intel XPU Runtime Environment**
-> The image includes the required Intel XPU runtime libraries and configures
-> `/opt/venv/bin` in `PATH`. Do not source `/opt/intel/oneapi/setvars.sh`;
-> the runtime image does not include that script. Commands such as `vllm serve`
-> can be invoked directly from interactive shells, Docker Compose, or an
-> overridden entrypoint.
-
----
-
-
-
 ### 1.4 Launching the Serving Service
 
 ### 1.4.0 (Optional)

--- a/vllm/docker-compose/load_balancer/docker-compose.yml
+++ b/vllm/docker-compose/load_balancer/docker-compose.yml
@@ -9,8 +9,7 @@ services:
     shm_size: "32gb"
     working_dir: /llm
     entrypoint: >
-      bash -lc "source /opt/intel/oneapi/setvars.sh --force &&
-      vllm serve
+      bash -lc "exec vllm serve
       --model /llm/models/DeepSeek-R1-Distill-Qwen-7B
       --served-model-name model
       --dtype=float16
@@ -44,8 +43,7 @@ services:
     shm_size: "32gb"
     working_dir: /llm
     entrypoint: >
-      bash -lc "source /opt/intel/oneapi/setvars.sh --force &&
-      vllm serve
+      bash -lc "exec vllm serve
       --model /llm/models/DeepSeek-R1-Distill-Qwen-7B
       --served-model-name model
       --dtype=float16


### PR DESCRIPTION
## Summary
- remove obsolete instructions to source `/opt/intel/oneapi/setvars.sh`
- remove the corresponding resolved known issue
- update the load-balancer Compose example to invoke vLLM directly

## Validation
- verified `sj-dev-container` does not contain `/opt/intel/oneapi/setvars.sh`
- verified PyTorch detects 7 XPU devices without sourcing oneAPI
- validated the updated Compose YAML syntax