### PR TITLE
omni: W4A8 s8u4 oneDNN GEMM + s8 activation quantizer (per-block zero point)

### DIFF
--- a/omni/omni_xpu_kernel/omni_xpu_kernel/csrc/bindings.cpp
+++ b/omni/omni_xpu_kernel/omni_xpu_kernel/csrc/bindings.cpp
@@ -61,8 +61,13 @@ namespace svdq {
     torch::Tensor unpack_svdq_int4(const torch::Tensor& packed, bool is_signed);
     std::tuple<torch::Tensor, torch::Tensor> quantize_svdq_act_int4(const torch::Tensor& input, int64_t group_size);
     std::tuple<torch::Tensor, torch::Tensor> quantize_svdq_act_uint4(const torch::Tensor& input, int64_t group_size);
+    std::tuple<torch::Tensor, torch::Tensor> quantize_svdq_act_s8(const torch::Tensor& input, int64_t group_size);
     torch::Tensor onednn_int4_gemm(const torch::Tensor& act, const torch::Tensor& packed, const torch::Tensor& wscales);
     torch::Tensor onednn_int4_gemm_preconverted(const torch::Tensor& act, const torch::Tensor& packed_u4, const torch::Tensor& scales_f16);
+    torch::Tensor onednn_s8u4_gemm(
+        const torch::Tensor& act, const torch::Tensor& xscales,
+        const torch::Tensor& packed_u4, const torch::Tensor& scales_f16,
+        torch::ScalarType out_dtype, std::optional<torch::Tensor> zp_u8);
     void onednn_int4_gemm_add_to_output(const torch::Tensor& act, const torch::Tensor& packed_u4, const torch::Tensor& scales_f16, torch::Tensor& dst);
     void fused_convert_add(torch::Tensor& out, const torch::Tensor& result, const torch::Tensor& residual);
     torch::Tensor fused_smooth_convert(const torch::Tensor& x, const torch::Tensor& smooth_factor);
@@ -436,6 +441,19 @@ PYBIND11_MODULE(_C, m) {
         "Input: act [M, K] f16, packed_u4 [N, K/2] uint8, scales_f16 [G, N] f16, dst [M, N] bf16\n"
         "Output: dst modified in-place (dst += GEMM result)",
         py::arg("act"), py::arg("packed_u4"), py::arg("scales_f16"), py::arg("dst"));
+
+    svdq.def("quantize_svdq_act_s8", &omni_xpu::svdq::quantize_svdq_act_s8,
+        "Per-group symmetric s8 activation quantization for onednn_s8u4_gemm.\n"
+        "Returns (a8 [M, K] int8, scales [M, K/gs] f32)",
+        py::arg("input"), py::arg("group_size"));
+
+    svdq.def("onednn_s8u4_gemm", &omni_xpu::svdq::onednn_s8u4_gemm,
+        "W4A8 GEMM: s8 act x u4 packed weights via oneDNN. zp_u8=None 走标量 "
+        "zp=8（wa4）；zp_u8=[G_wei, N] 走 per-block zp（tint4/torchao 非对称，"
+        "w=(q-zp)*scale 在 oneDNN 内完成）",
+        py::arg("act"), py::arg("xscales"), py::arg("packed_u4"),
+        py::arg("scales_f16"), py::arg("out_dtype") = torch::kBFloat16,
+        py::arg("zp_u8") = py::none());
 
     svdq.def("fused_convert_add", &omni_xpu::svdq::fused_convert_add,
         "Fused f16->bf16 conversion + bf16 addition in single ESIMD kernel\n"

--- a/omni/omni_xpu_kernel/omni_xpu_kernel/csrc/onednn_s8u4_gemm.cpp
+++ b/omni/omni_xpu_kernel/omni_xpu_kernel/csrc/onednn_s8u4_gemm.cpp
@@ -112,13 +112,17 @@ static CachedPrimitive& get_or_create_s8u4(
 
     dnnl::matmul::primitive_desc pd(cp.eng, cp.src_md, cp.wei_md, cp.dst_md, attr);
     std::string impl_info = pd.impl_info_str();
-    fprintf(stderr,
-            "[onednn_s8u4_gemm] CACHE MISS: impl=%s (M=%ld K=%ld N=%ld "
-            "act_gs=%ld wei_gs=%ld zp=%d)\n",
-            impl_info.c_str(), (long)M, (long)K, (long)N,
-            (long)act_gs, (long)wei_gs, (int)per_block_zp);
-    if (impl_info.find("ref") != std::string::npos) {
-        fprintf(stderr, "[onednn_s8u4_gemm] WARNING: reference fallback (slow)\n");
+    // Primitive cache misses are expected during warm-up (one per new shape).
+    // Print only when requested: OMNI_XPU_DEBUG=gemm (or =1 / =all).
+    if (omni_xpu::debug::is_enabled("gemm")) {
+        fprintf(stderr,
+                "[onednn_s8u4_gemm] CACHE MISS: impl=%s (M=%ld K=%ld N=%ld "
+                "act_gs=%ld wei_gs=%ld zp=%d)\n",
+                impl_info.c_str(), (long)M, (long)K, (long)N,
+                (long)act_gs, (long)wei_gs, (int)per_block_zp);
+        if (impl_info.find("ref") != std::string::npos) {
+            fprintf(stderr, "[onednn_s8u4_gemm] WARNING: reference fallback (slow)\n");
+        }
     }
     cp.prim = dnnl::matmul(pd);
     auto [ins, _] = g_cache.emplace(key, std::move(cp));
@@ -162,6 +166,9 @@ torch::Tensor onednn_s8u4_gemm(
     TORCH_CHECK(act.dim() == 2, "act must be [M, K]");
     TORCH_CHECK(act.scalar_type() == torch::kInt8, "act must be int8");
     TORCH_CHECK(act.device().is_xpu(), "act must be on XPU");
+    TORCH_CHECK(xscales.device().is_xpu(), "xscales must be on XPU");
+    TORCH_CHECK(packed_u4.device().is_xpu(), "packed_u4 must be on XPU");
+    TORCH_CHECK(scales_f16.device().is_xpu(), "scales_f16 must be on XPU");
     TORCH_CHECK(packed_u4.scalar_type() == torch::kUInt8, "packed_u4 must be uint8");
     TORCH_CHECK(xscales.scalar_type() == torch::kFloat16 ||
                     xscales.scalar_type() == torch::kFloat,
@@ -195,6 +202,7 @@ torch::Tensor onednn_s8u4_gemm(
         TORCH_CHECK(zpt.dim() == 2, "zp_u8 must be [G_wei, N]");
         TORCH_CHECK(zpt.size(0) == G_wei && zpt.size(1) == N,
                     "zp_u8 must be [G_wei, N]");
+        TORCH_CHECK(zpt.device().is_xpu(), "zp_u8 must be on XPU");
         zp_c = zpt.contiguous();
         zp_ptr = zp_c.data_ptr();
     } else {

--- a/omni/omni_xpu_kernel/omni_xpu_kernel/csrc/onednn_s8u4_gemm.cpp
+++ b/omni/omni_xpu_kernel/omni_xpu_kernel/csrc/onednn_s8u4_gemm.cpp
@@ -1,0 +1,242 @@
+// ============================================================================
+// oneDNN W4A8 GEMM: s8 activations x u4 weights, per-group scales, optional
+// per-block zero points (TINT4/torchao asymmetric INT4).
+//
+// src scales f32 (QW-class bf16 activations can have group absmax > 8.3e6,
+// which overflows an f16 scale to inf -> dequant NaN -> black image);
+// wei scales f16; wei zero point = scalar 8 (wa4) or per-block [G_wei, N]
+// (tint4/torchao, w = (q - zp) * scale inside oneDNN, no Python correction).
+// src/wei group sizes are decoupled (src 32/64, wei up to 128).
+// ============================================================================
+
+#include "oneapi/dnnl/dnnl.hpp"
+#include "oneapi/dnnl/dnnl_sycl.hpp"
+#include <torch/extension.h>
+
+#include <cstdio>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <tuple>
+#include <unordered_map>
+
+#include "utils.h"
+
+namespace omni_xpu {
+namespace svdq {
+
+// Cache key: (dst_dtype_int, M, K, N, shape_id(+zp flag))
+using CacheKey = std::tuple<int, int64_t, int64_t, int64_t, int64_t>;
+
+struct CachedPrimitive {
+    dnnl::engine eng;
+    dnnl::stream strm;
+    dnnl::matmul prim;
+    dnnl::memory::desc src_md;
+    dnnl::memory::desc wei_md;
+    dnnl::memory::desc dst_md;
+    dnnl::memory::desc xscale_md;
+    dnnl::memory::desc wscale_md;
+    dnnl::memory::desc zp_md;
+};
+
+static std::map<CacheKey, CachedPrimitive> g_cache;
+static std::mutex g_cache_mutex;
+
+static std::map<int, std::pair<dnnl::engine, dnnl::stream>> g_engine_map;
+
+static std::pair<dnnl::engine, dnnl::stream>& ensure_engine_initialized(
+    const torch::Device& device) {
+    int dev_idx = device.index();
+    auto it = g_engine_map.find(dev_idx);
+    if (it != g_engine_map.end()) return it->second;
+    sycl::queue& q = omni_xpu::utils::get_queue(device);
+    auto eng = dnnl::sycl_interop::make_engine(q.get_device(), q.get_context());
+    auto strm = dnnl::sycl_interop::make_stream(eng, q);
+    auto [ins, _] = g_engine_map.emplace(
+        dev_idx, std::make_pair(std::move(eng), std::move(strm)));
+    return ins->second;
+}
+
+template <dnnl::memory::data_type DstDT>
+static CachedPrimitive& get_or_create_s8u4(
+    const CacheKey& key,
+    int64_t M, int64_t K, int64_t N,
+    int64_t act_gs, int64_t wei_gs, bool per_block_zp,
+    const dnnl::engine& eng,
+    const dnnl::stream& strm) {
+    auto it = g_cache.find(key);
+    if (it != g_cache.end()) return it->second;
+
+    CachedPrimitive cp;
+    cp.eng = eng;
+    cp.strm = strm;
+    cp.src_md = dnnl::memory::desc({M, K}, dnnl::memory::data_type::s8,
+                                   dnnl::memory::format_tag::ab);
+    cp.wei_md = dnnl::memory::desc({K, N}, dnnl::memory::data_type::u4,
+                                   dnnl::memory::format_tag::ba);
+    cp.dst_md = dnnl::memory::desc({M, N}, DstDT, dnnl::memory::format_tag::ab);
+    const int64_t G_src = K / act_gs;
+    const int64_t G_wei = K / wei_gs;
+    cp.xscale_md = dnnl::memory::desc({M, G_src}, dnnl::memory::data_type::f32,
+                                      dnnl::memory::format_tag::ab);
+    // wei scale f16（与 a16 tint4 gs=128 路径一致；f32 wei scale 在 gs=128
+    // 下输出全零）。src scale f32 防激活溢出。
+    cp.wscale_md = dnnl::memory::desc({G_wei, N}, dnnl::memory::data_type::f16,
+                                      dnnl::memory::format_tag::ab);
+    cp.zp_md = per_block_zp
+        ? dnnl::memory::desc({G_wei, N}, dnnl::memory::data_type::u8,
+                             dnnl::memory::format_tag::ab)
+        : dnnl::memory::desc({1}, dnnl::memory::data_type::u8,
+                             dnnl::memory::format_tag::a);
+
+    dnnl::primitive_attr attr;
+    // src scales: per-row per-K-group — mask3 {1, gs}
+    attr.set_scales(DNNL_ARG_SRC, (1 << 0) | (1 << 1),
+                    {1, act_gs}, dnnl::memory::data_type::f32);
+    // weight scales: per-group per-N — mask3 {gs, 1}
+    attr.set_scales(DNNL_ARG_WEIGHTS, (1 << 0) | (1 << 1),
+                    {wei_gs, 1}, dnnl::memory::data_type::f16);
+    if (per_block_zp) {
+        // TINT4/torchao 非对称：per-block zero points（mask3 {gs, 1}）
+        attr.set_zero_points(DNNL_ARG_WEIGHTS, (1 << 0) | (1 << 1),
+                             {wei_gs, 1}, dnnl::memory::data_type::u8);
+    } else {
+        // signed int4 -> u4 需要标量 zp=8
+        attr.set_zero_points(DNNL_ARG_WEIGHTS, 0, {},
+                             dnnl::memory::data_type::u8);
+    }
+    // A770 u4 matmul: fp16-class accumulation overflows to NaN at Qwen-scale
+    // K; fpmath any allows bf16 accumulation (wide exponent).
+    attr.set_fpmath_mode(dnnl::fpmath_mode::any, true);
+
+    dnnl::matmul::primitive_desc pd(cp.eng, cp.src_md, cp.wei_md, cp.dst_md, attr);
+    std::string impl_info = pd.impl_info_str();
+    fprintf(stderr,
+            "[onednn_s8u4_gemm] CACHE MISS: impl=%s (M=%ld K=%ld N=%ld "
+            "act_gs=%ld wei_gs=%ld zp=%d)\n",
+            impl_info.c_str(), (long)M, (long)K, (long)N,
+            (long)act_gs, (long)wei_gs, (int)per_block_zp);
+    if (impl_info.find("ref") != std::string::npos) {
+        fprintf(stderr, "[onednn_s8u4_gemm] WARNING: reference fallback (slow)\n");
+    }
+    cp.prim = dnnl::matmul(pd);
+    auto [ins, _] = g_cache.emplace(key, std::move(cp));
+    return ins->second;
+}
+
+template <dnnl::memory::data_type DstDT>
+static void onednn_s8u4_kernel(
+    void* act_ptr, void* xscales_ptr, void* packed_ptr, void* wscales_ptr,
+    void* zp_ptr, void* output_ptr,
+    int64_t M, int64_t K, int64_t N,
+    int64_t act_gs, int64_t wei_gs, bool per_block_zp,
+    const torch::Device& device) {
+    CacheKey key(static_cast<int>(DstDT), M, K, N,
+                 (act_gs * 1000 + wei_gs) + (per_block_zp ? (1 << 21) : 0));
+    CachedPrimitive* cached = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(g_cache_mutex);
+        auto& [eng, strm] = ensure_engine_initialized(device);
+        cached = &get_or_create_s8u4<DstDT>(
+            key, M, K, N, act_gs, wei_gs, per_block_zp, eng, strm);
+    }
+    std::unordered_map<int, dnnl::memory> args = {
+        {DNNL_ARG_SRC,                            dnnl::memory(cached->src_md,   cached->eng, act_ptr)},
+        {DNNL_ARG_WEIGHTS,                        dnnl::memory(cached->wei_md,   cached->eng, packed_ptr)},
+        {DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC,     dnnl::memory(cached->xscale_md, cached->eng, xscales_ptr)},
+        {DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS, dnnl::memory(cached->wscale_md, cached->eng, wscales_ptr)},
+        {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS, dnnl::memory(cached->zp_md, cached->eng, zp_ptr)},
+        {DNNL_ARG_DST,                            dnnl::memory(cached->dst_md,   cached->eng, output_ptr)},
+    };
+    cached->prim.execute(cached->strm, args);
+}
+
+torch::Tensor onednn_s8u4_gemm(
+    const torch::Tensor& act,
+    const torch::Tensor& xscales,
+    const torch::Tensor& packed_u4,
+    const torch::Tensor& scales_f16,
+    torch::ScalarType out_dtype,
+    std::optional<torch::Tensor> zp_u8) {
+    TORCH_CHECK(act.dim() == 2, "act must be [M, K]");
+    TORCH_CHECK(act.scalar_type() == torch::kInt8, "act must be int8");
+    TORCH_CHECK(act.device().is_xpu(), "act must be on XPU");
+    TORCH_CHECK(packed_u4.scalar_type() == torch::kUInt8, "packed_u4 must be uint8");
+    TORCH_CHECK(xscales.scalar_type() == torch::kFloat16 ||
+                    xscales.scalar_type() == torch::kFloat,
+                "xscales must be f16 or f32");
+    TORCH_CHECK(scales_f16.scalar_type() == torch::kFloat16 ||
+                    scales_f16.scalar_type() == torch::kFloat,
+                "scales_f16 must be f16 or f32");
+
+    const int64_t M = act.size(0);
+    const int64_t K = act.size(1);
+    const int64_t N = packed_u4.size(0);
+    TORCH_CHECK(packed_u4.size(1) == K / 2, "packed_u4.size(1) must equal K/2");
+    const int64_t G_src = xscales.size(1);
+    const int64_t G_wei = scales_f16.size(0);
+    TORCH_CHECK(G_src > 0, "xscales must have at least one group column");
+    TORCH_CHECK(xscales.size(0) == M, "xscales must be [M, G_src]");
+    TORCH_CHECK(scales_f16.size(1) == N, "scales_f16 must be [G_wei, N]");
+    const int64_t act_gs = K / G_src;
+    const int64_t wei_gs = K / G_wei;
+    TORCH_CHECK(act_gs * G_src == K, "K must be divisible by G_src");
+    TORCH_CHECK(wei_gs * G_wei == K, "K must be divisible by G_wei");
+
+    const bool per_block_zp = zp_u8.has_value()
+        && zp_u8->defined() && zp_u8->numel() > 0;
+    torch::Tensor zp_c;   // 持久的连续副本（per-block）
+    static torch::Tensor zp_scalar;
+    const void* zp_ptr;
+    if (per_block_zp) {
+        const torch::Tensor& zpt = zp_u8.value();
+        TORCH_CHECK(zpt.scalar_type() == torch::kUInt8, "zp_u8 must be uint8");
+        TORCH_CHECK(zpt.dim() == 2, "zp_u8 must be [G_wei, N]");
+        TORCH_CHECK(zpt.size(0) == G_wei && zpt.size(1) == N,
+                    "zp_u8 must be [G_wei, N]");
+        zp_c = zpt.contiguous();
+        zp_ptr = zp_c.data_ptr();
+    } else {
+        if (!zp_scalar.defined() || zp_scalar.device() != act.device()) {
+            zp_scalar = torch::tensor({8},
+                torch::TensorOptions().dtype(torch::kUInt8).device(act.device()));
+        }
+        zp_ptr = zp_scalar.data_ptr();
+    }
+
+    torch::Tensor output = torch::empty({M, N},
+        torch::TensorOptions().dtype(out_dtype).device(act.device()));
+    const auto act_c = act.contiguous();
+    const auto xs_c = xscales.contiguous();
+    const auto wu_c = packed_u4.contiguous();
+    const auto ws_c = scales_f16.contiguous();
+    const auto xs_f32 = xs_c.scalar_type() == torch::kFloat
+                            ? xs_c
+                            : xs_c.to(torch::kFloat);
+
+    switch (out_dtype) {
+        case torch::kFloat:
+            onednn_s8u4_kernel<dnnl::memory::data_type::f32>(
+                act_c.data_ptr(), xs_f32.data_ptr(), wu_c.data_ptr(),
+                ws_c.data_ptr(), const_cast<void*>(zp_ptr), output.data_ptr(),
+                M, K, N, act_gs, wei_gs, per_block_zp, act_c.device());
+            break;
+        case torch::kHalf:
+            onednn_s8u4_kernel<dnnl::memory::data_type::f16>(
+                act_c.data_ptr(), xs_f32.data_ptr(), wu_c.data_ptr(),
+                ws_c.data_ptr(), const_cast<void*>(zp_ptr), output.data_ptr(),
+                M, K, N, act_gs, wei_gs, per_block_zp, act_c.device());
+            break;
+        default:
+            onednn_s8u4_kernel<dnnl::memory::data_type::bf16>(
+                act_c.data_ptr(), xs_f32.data_ptr(), wu_c.data_ptr(),
+                ws_c.data_ptr(), const_cast<void*>(zp_ptr), output.data_ptr(),
+                M, K, N, act_gs, wei_gs, per_block_zp, act_c.device());
+            break;
+    }
+    return output;
+}
+
+}  // namespace svdq
+}  // namespace omni_xpu

--- a/omni/omni_xpu_kernel/omni_xpu_kernel/csrc/svdq_dequant.cpp
+++ b/omni/omni_xpu_kernel/omni_xpu_kernel/csrc/svdq_dequant.cpp
@@ -909,5 +909,117 @@ std::tuple<torch::Tensor, torch::Tensor> quantize_svdq_act_uint4(
 }
 
 
+// ============================================================================
+// per-group symmetric s8 activation quantization for onednn_s8u4_gemm.
+//   input  [M, K]  fp16/bf16
+//   output [M, K]  int8   (q = round(v * 127/absmax), clamped to [-127, 127])
+//   scales [M, G]  f32    (per-group, row-major; matches onednn src scales.
+//   f32 not f16: QW-style bf16 models can have group absmax > 8.3e6, which
+//   overflows an f16 scale (65504) to inf -> dequant NaN -> black image.)
+// ============================================================================
+template<typename IT, int GS, int GroupsPerWorkItem = 8, int WorkGroupSize = 64>
+void quantize_svdq_act_s8_kernel(
+    const IT* __restrict__ input,
+    int8_t* __restrict__ output,
+    float* __restrict__ scales,
+    const int64_t M,
+    const int64_t K,
+    const int64_t num_groups,
+    const at::Device& device) {
+  const int64_t group_chunks =
+      (num_groups + GroupsPerWorkItem - 1) / GroupsPerWorkItem;
+  const int64_t total_items = M * group_chunks;
+  constexpr int WG = WorkGroupSize;
+  const int64_t padded_size = (total_items + WG - 1) / WG * WG;
+  auto cgf = [&](sycl::handler& handle) {
+    handle.parallel_for(
+        sycl::nd_range<1>(sycl::range<1>(padded_size), sycl::range<1>(WG)),
+        [=](sycl::nd_item<1> item) SYCL_ESIMD_KERNEL {
+          const int64_t gid = item.get_global_id(0);
+          if (gid >= total_items) return;
+          const int64_t row = gid / group_chunks;
+          const int64_t first_grp = (gid % group_chunks) * GroupsPerWorkItem;
+          for (int local_grp = 0; local_grp < GroupsPerWorkItem; ++local_grp) {
+            const int64_t grp = first_grp + local_grp;
+            if (grp >= num_groups) break;
+            const IT* src = input + row * K + grp * GS;
+            int8_t* dst = output + row * K + grp * GS;
+            simd<float, GS> vals;
+            if constexpr (std::is_same_v<IT, fp16>) {
+              vals = block_load<fp16, GS>(
+                  reinterpret_cast<const fp16*>(src), overaligned_tag<16>{});
+            } else {
+              vals = block_load<bf16, GS>(
+                  reinterpret_cast<const bf16*>(src), overaligned_tag<16>{});
+            }
+            const float m = hmax<float>(abs<float, GS>(vals));
+            const float rscale = (m > 1e-10f) ? (127.0f / m) : 1.27e12f;
+            const float scale = (m > 1e-10f) ? (m / 127.0f) : 1e-10f;
+            simd<float, GS> q = rnde<float, GS>(vals * rscale);
+            q = max<float, GS>(min<float, GS>(q, simd<float, GS>(127.0f)),
+                               simd<float, GS>(-127.0f));
+            block_store<int8_t, GS>(dst, simd<int8_t, GS>(q),
+                                    overaligned_tag<16>{});
+            scales[row * num_groups + grp] = scale;
+          }
+        });
+  };
+  utils::submit_kernel(cgf, device, "quantize_svdq_act_s8");
+}
+
+std::tuple<torch::Tensor, torch::Tensor> quantize_svdq_act_s8(
+    const torch::Tensor& input,
+    int64_t group_size
+) {
+    TORCH_CHECK(input.is_contiguous(), "input tensor must be contiguous");
+    TORCH_CHECK(input.dim() == 2, "input must be 2D [M, K]");
+    TORCH_CHECK(input.scalar_type() == torch::kFloat16 ||
+                input.scalar_type() == torch::kBFloat16,
+                "input must be fp16 or bf16");
+    TORCH_CHECK(group_size == 32 || group_size == 64,
+                "Only group_size=32/64 is supported, got ", group_size);
+    const int64_t M = input.size(0);
+    const int64_t K = input.size(1);
+    TORCH_CHECK(K % group_size == 0, "K must be divisible by group_size");
+    const int64_t num_groups = K / group_size;
+
+    auto output = torch::empty({M, K},
+        torch::TensorOptions().dtype(torch::kChar).device(input.device()));
+    auto scales_out = torch::empty({M, num_groups},
+        torch::TensorOptions().dtype(torch::kFloat).device(input.device()));
+
+    if (input.scalar_type() == torch::kFloat16) {
+        if (group_size == 32) {
+            quantize_svdq_act_s8_kernel<fp16, 32>(
+                reinterpret_cast<const fp16*>(input.data_ptr()),
+                output.data_ptr<int8_t>(),
+                scales_out.data_ptr<float>(),
+                M, K, num_groups, input.device());
+        } else {
+            quantize_svdq_act_s8_kernel<fp16, 64>(
+                reinterpret_cast<const fp16*>(input.data_ptr()),
+                output.data_ptr<int8_t>(),
+                scales_out.data_ptr<float>(),
+                M, K, num_groups, input.device());
+        }
+    } else {
+        if (group_size == 32) {
+            quantize_svdq_act_s8_kernel<bf16, 32>(
+                reinterpret_cast<const bf16*>(input.data_ptr()),
+                output.data_ptr<int8_t>(),
+                scales_out.data_ptr<float>(),
+                M, K, num_groups, input.device());
+        } else {
+            quantize_svdq_act_s8_kernel<bf16, 64>(
+                reinterpret_cast<const bf16*>(input.data_ptr()),
+                output.data_ptr<int8_t>(),
+                scales_out.data_ptr<float>(),
+                M, K, num_groups, input.device());
+        }
+    }
+    return {output, scales_out};
+}
+
+
 }  // namespace svdq
 }  // namespace omni_xpu

--- a/omni/omni_xpu_kernel/omni_xpu_kernel/svdq/__init__.py
+++ b/omni/omni_xpu_kernel/omni_xpu_kernel/svdq/__init__.py
@@ -125,6 +125,37 @@ def onednn_int4_gemm_preconverted(
     return _get_native().onednn_int4_gemm_preconverted(act, packed_u4, scales_f16)
 
 
+def quantize_act_s8(
+    input: torch.Tensor,
+    group_size: int = 64,
+) -> tuple:
+    """Per-group symmetric s8 activation quantization for onednn_s8u4_gemm.
+
+    Returns:
+        (act_s8 [M, K] int8, scales [M, K/gs] f32)
+    """
+    return _get_native().quantize_svdq_act_s8(input, group_size)
+
+
+def onednn_s8u4_gemm(
+    act: torch.Tensor,
+    xscales: torch.Tensor,
+    packed_u4: torch.Tensor,
+    scales_f16: torch.Tensor,
+    out_dtype: torch.dtype = torch.bfloat16,
+    zp_u8: torch.Tensor = None,
+) -> torch.Tensor:
+    """W4A8 GEMM: s8 act x u4 packed weights via oneDNN.
+
+    zp_u8=None 走标量 zp=8（wa4）；zp_u8=[G_wei, N] 走 per-block zp
+    （tint4/torchao 非对称，w=(q-zp)*scale 在 oneDNN 内完成）。
+    src/wei 分组解耦：src 32/64、wei 可到 128。
+    """
+    out = _get_native().onednn_s8u4_gemm(
+        act, xscales, packed_u4, scales_f16, out_dtype, zp_u8)
+    return out.to(out_dtype)
+
+
 def onednn_int4_gemm_add_to_output(
     act: torch.Tensor,
     packed_u4: torch.Tensor,
@@ -229,8 +260,10 @@ __all__ = [
     "unpack_int4",
     "quantize_act_int4",
     "quantize_act_uint4",
+    "quantize_act_s8",
     "onednn_int4_gemm",
     "onednn_int4_gemm_preconverted",
+    "onednn_s8u4_gemm",
     "onednn_int4_gemm_add_to_output",
     "prepare_onednn_weights",
     "fused_convert_add",

--- a/omni/omni_xpu_kernel/tests/test_s8u4_correctness.py
+++ b/omni/omni_xpu_kernel/tests/test_s8u4_correctness.py
@@ -1,0 +1,170 @@
+"""
+Correctness tests for the W4A8 s8u4 path (onednn_s8u4_gemm + quantize_act_s8).
+
+Regression-protects the A770 verification from Blackwood416's review:
+- quantize_act_s8 vs manual q = round(clamp(v*127/absmax, -127, 127)),
+  scale = absmax/127 (f32), incl. QW-class large-absmax groups
+  (fp16 ~3.4e4, bf16 ~2.3e6) that overflowed f16 scales -> NaN -> black.
+- onednn_s8u4_gemm vs manual w = (q - zp) * scale reference for both the
+  wa4 scalar-zp=8 path and the tint4 per-block-zp path, up to K=12288.
+- Device checks: xscales / packed_u4 / scales_f16 / zp_u8 must be on XPU.
+"""
+
+import pytest
+import torch
+
+
+def has_xpu():
+    try:
+        return torch.xpu.is_available()
+    except AttributeError:
+        return False
+
+
+@pytest.fixture
+def xpu_device():
+    if not has_xpu():
+        pytest.skip("XPU not available")
+    return torch.device("xpu")
+
+
+def _native_svdq():
+    try:
+        from omni_xpu_kernel import svdq
+        return svdq
+    except (ImportError, AttributeError):
+        pytest.skip("omni_xpu_kernel svdq extension not available")
+
+
+def _quantize_ref(x, group_size):
+    """Manual per-group symmetric s8 quantization (reference)."""
+    M, K = x.shape
+    G = K // group_size
+    xg = x.float().view(M, G, group_size)
+    absmax = xg.abs().amax(dim=-1).clamp(min=1e-10)
+    scale = absmax / 127.0
+    q = torch.round(xg / scale.unsqueeze(-1)).clamp(-127, 127).to(torch.int8)
+    return q.view(M, K), scale  # [M, G] f32
+
+
+def _signed_to_unsigned_packed(q_signed):
+    """Signed int4 [-8,7] packed bytes -> unsigned u4 (^0x88, zp=8)."""
+    return (q_signed.to(torch.uint8) ^ 0x88)
+
+
+def _pack_signed_nibbles(q_nk):
+    """[N, K] signed int4 values -> [N, K/2] uint8 (lo | hi << 4)."""
+    v = q_nk.to(torch.int16)
+    lo = v[..., 0::2] & 0x0F
+    hi = (v[..., 1::2] & 0x0F) << 4
+    return (lo | hi).to(torch.uint8)
+
+
+def _s8u4_reference(act_s8, xscales, q_u4, zp, scale, act_gs, wei_gs):
+    """Manual out = (act_s8 * xscale) @ ((q_u4 - zp) * scale)."""
+    M, K = act_s8.shape
+    N = q_u4.shape[0]
+    G_wei = K // wei_gs
+    act_deq = act_s8.float() * xscales.float().repeat_interleave(act_gs, dim=1)
+    q_t = q_u4.float().t()                                    # [K, N]
+    w = (q_t - zp.float().repeat_interleave(wei_gs, dim=0)) * scale.float().repeat_interleave(wei_gs, dim=0)
+    return act_deq @ w
+
+
+def _build_weights(K, N, wei_gs, device, seed, signed=True, scale_max=2.0):
+    torch.manual_seed(seed)
+    G = K // wei_gs
+    if signed:
+        q = torch.randint(-8, 8, (N, K), device=device)
+        packed = _pack_signed_nibbles(q)
+        q_u4 = (q.to(torch.uint8) & 0x0F).to(torch.float32)
+    else:
+        q_u4 = torch.randint(0, 16, (N, K), device=device).to(torch.float32)
+        packed = _pack_signed_nibbles(q_u4.to(torch.int16))
+    scale = (torch.rand(G, N, device=device) * (scale_max - 0.05) + 0.05).to(torch.float16)
+    return packed, q_u4, scale
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("group_size", [32, 64])
+def test_quantize_act_s8_matches_reference(xpu_device, dtype, group_size):
+    svdq = _native_svdq()
+    torch.manual_seed(3)
+    M, K = 64, 4096
+    x = torch.randn(M, K, dtype=dtype, device=xpu_device)
+
+    # QW-class large-absmax groups: fp16 ~3.4e4, bf16 ~2.3e6 (f16 scale overflow).
+    big = torch.finfo(torch.float16).max * 0.55 if dtype == torch.float16 else 2.3e6
+    for g in range(1, 4):
+        xg = torch.randn(1, group_size, dtype=dtype, device=xpu_device)
+        x[:, g * group_size:(g + 1) * group_size] = xg * (big / xg.abs().amax())
+
+    q, scale = svdq.quantize_act_s8(x, group_size)
+    q_ref, scale_ref = _quantize_ref(x, group_size)
+
+    assert q.shape == x.shape and q.dtype == torch.int8
+    assert scale.shape == (M, K // group_size) and scale.dtype == torch.float32
+    assert torch.isfinite(q).all() and torch.isfinite(scale).all()
+    # Kernel rounding may differ from torch.round by at most 1 on ties.
+    assert (q.to(torch.int16) - q_ref.to(torch.int16)).abs().max().item() <= 1
+    assert torch.allclose(scale, scale_ref, atol=1e-6, rtol=1e-4)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("act_gs", [32, 64])
+@pytest.mark.parametrize("wei_gs", [64, 128])
+@pytest.mark.parametrize("K", [4096, 8192, 12288])
+@pytest.mark.parametrize("per_block_zp", [False, True])
+def test_s8u4_gemm_matches_reference(xpu_device, dtype, act_gs, wei_gs, K, per_block_zp):
+    svdq = _native_svdq()
+    M, N = 32, 256
+    torch.manual_seed(5)
+
+    act_s8 = torch.randint(-127, 128, (M, K), dtype=torch.int8, device=xpu_device)
+    G_src = K // act_gs
+    G_wei = K // wei_gs
+    # Keep act_dequant magnitude ~O(1) so fp16/bf16 outputs stay finite at K=12288:
+    # int8 act in [-127,127] with per-group scales ~1/127.
+    xscales = ((torch.rand(M, G_src, device=xpu_device) * 0.5 + 0.001) / 127.0).to(torch.float32)
+
+    packed, q_u4, scale = _build_weights(K, N, wei_gs, xpu_device, 9, signed=not per_block_zp)
+    if per_block_zp:
+        zp = torch.randint(0, 16, (G_wei, N), dtype=torch.uint8, device=xpu_device)
+        out = svdq.onednn_s8u4_gemm(
+            act_s8, xscales, packed, scale, out_dtype=dtype, zp_u8=zp)
+        ref = _s8u4_reference(act_s8, xscales, q_u4, zp.float(), scale, act_gs, wei_gs)
+    else:
+        out = svdq.onednn_s8u4_gemm(
+            act_s8, xscales, packed, scale, out_dtype=dtype, zp_u8=None)
+        # wa4: scalar zp=8, q_u4 already mapped as signed values (q_signed = q_u4 - 8).
+        ref = _s8u4_reference(act_s8, xscales, q_u4 - 8.0,
+                              torch.zeros(G_wei, N, device=xpu_device),
+                              scale, act_gs, wei_gs)
+
+    assert out.shape == (M, N) and out.dtype == dtype
+    assert torch.isfinite(out).all(), "s8u4 GEMM produced NaN/inf"
+    assert torch.allclose(out.to(torch.float32), ref, atol=1.0, rtol=5e-2), (
+        f"s8u4 mismatch: max abs {torch.abs(out - ref).max().item():.3e}")
+
+
+@pytest.mark.parametrize("cpu_arg", ["xscales", "packed", "scales", "zp"])
+def test_s8u4_gemm_rejects_cpu_side_args(xpu_device, cpu_arg):
+    """Device checks: every GEMM argument must be XPU-resident."""
+    svdq = _native_svdq()
+    M, K, N, act_gs, wei_gs = 16, 512, 64, 64, 64
+    G_src = K // act_gs
+    G_wei = K // wei_gs
+
+    act_s8 = torch.randint(-127, 128, (M, K), dtype=torch.int8, device=xpu_device)
+    xscales = torch.rand(M, G_src, dtype=torch.float32, device=xpu_device)
+    packed, _, scale = _build_weights(K, N, wei_gs, xpu_device, 13)
+    zp = torch.randint(0, 16, (G_wei, N), dtype=torch.uint8, device=xpu_device)
+
+    args = {
+        "xscales": (act_s8, xscales.cpu(), packed, scale, torch.float32, None),
+        "packed": (act_s8, xscales, packed.cpu(), scale, torch.float32, None),
+        "scales": (act_s8, xscales, packed, scale.cpu(), torch.float32, None),
+        "zp": (act_s8, xscales, packed, scale, torch.float32, zp.cpu()),
+    }
+    with pytest.raises(RuntimeError, match="XPU"):
+        svdq.onednn_s8u4_gemm(*args[cpu_arg])


### PR DESCRIPTION
This PR carries the **W4A8 s8u4 GEMM** (s8 activations × u4 weights, torchao asymmetric format family) plus the ESIMD s8 activation quantizer:

- `onednn_s8u4_gemm`: per-block zero points, decoupled src/weight group sizes (src 32/64, wei up to 128), f32 source scales.
- `quantize_act_s8`: ESIMD per-group symmetric s8 activation quantization (f32 scales).
- Tests: `tests/test_s8u4_correctness.py`.

Status:

- **A770 (DG2): verified** — all s8u4 tests pass.
- **B580 (BMG, reported by yzwzhanghao2): blocked** — `quantize_act_s8` passes 4/4, but `onednn_s8u4_gemm` dies with a native access violation inside the oneDNN s8×u4 primitive path under oneDNN 3.13. A 12-variant bisect (src-scale dtype/value/attribute, zero point, dst dtype, group sizes, M) crashes in every case, and oneDNN verbose emits no matmul execution line — pointing at the oneDNN 3.13 s8×u4 path on BMG rather than this wrapper (the diff contains no architecture-specific code; the same wheel's controls pass).
- The INT4 (a16) GEMM originally bundled here is split out into a separate PR so it can merge independently.
- Short-term plan for BMG: non-DG2 capability guard with w4a16 fallback; root-cause work needs a pure-oneDNN 3.13 reproducer (or a oneDNN 3.11.2 cross-test on B580).
