### PR TITLE
vLLM: integrate FP16 packed QSA extension

### DIFF
--- a/vllm/custom-esimd-kernels-vllm/csrc/qsa/qsa_ops.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/qsa/qsa_ops.h
@@ -1,0 +1,21 @@
+// Copyright 2026
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <ATen/ATen.h>
+
+namespace qsa {
+
+at::Tensor select_paged_tokens(
+    const at::Tensor& q,
+    const at::Tensor& compressed_key_cache,
+    const at::Tensor& page_table,
+    const at::Tensor& token_to_req,
+    const at::Tensor& query_positions,
+    const at::Tensor& sequence_lengths,
+    int64_t token_topk,
+    int64_t compress_ratio,
+    at::Tensor out);
+
+}  // namespace qsa

--- a/vllm/custom-esimd-kernels-vllm/csrc/qsa/qsa_select_paged_tokens.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/qsa/qsa_select_paged_tokens.sycl
@@ -1,0 +1,311 @@
+// Copyright 2026
+// SPDX-License-Identifier: Apache-2.0
+//
+// Fused Qwen3.8 TP8-rank compressed-key scoring, top-k and token expansion.
+
+#include "qsa_ops.h"
+
+#include <c10/xpu/XPUStream.h>
+#include <torch/extension.h>
+
+#include <sycl/sycl.hpp>
+
+#include <cstdint>
+#include <limits>
+
+namespace qsa {
+namespace {
+
+using activation_t = sycl::half;
+
+constexpr int64_t kIndexHeads = 4;
+constexpr int64_t kHeadDim = 128;
+constexpr int64_t kCompressedPageSize = 128;
+constexpr int64_t kTokenTopk = 2048;
+constexpr int64_t kCompressRatio = 4;
+constexpr int64_t kBlockTopk = kTokenTopk / kCompressRatio;
+constexpr int64_t kOutputWidth = kTokenTopk + kCompressRatio - 1;
+constexpr int64_t kChunkBlocks = kBlockTopk;
+constexpr int64_t kSortSize = 2 * kBlockTopk;
+constexpr int64_t kSubgroup = 32;
+constexpr int64_t kWorkgroup = 256;
+constexpr int64_t kSubgroups = kWorkgroup / kSubgroup;
+constexpr float kScoreScale = 0.08838834764831845f;
+
+class QsaSelectPagedTokensKernel;
+
+void check_fp16_xpu(
+    const at::Tensor& tensor, const char* name, bool require_contiguous) {
+  TORCH_CHECK(tensor.device().is_xpu(), name, " must be on XPU");
+  TORCH_CHECK(tensor.scalar_type() == at::kHalf, name, " must be float16");
+  TORCH_CHECK(
+      !require_contiguous || tensor.is_contiguous(),
+      name,
+      " must be contiguous");
+}
+
+void check_int32_xpu(const at::Tensor& tensor, const char* name) {
+  TORCH_CHECK(tensor.device().is_xpu(), name, " must be on XPU");
+  TORCH_CHECK(tensor.scalar_type() == at::kInt, name, " must be int32");
+  TORCH_CHECK(tensor.is_contiguous(), name, " must be contiguous");
+}
+
+void check_int64_xpu(const at::Tensor& tensor, const char* name) {
+  TORCH_CHECK(tensor.device().is_xpu(), name, " must be on XPU");
+  TORCH_CHECK(tensor.scalar_type() == at::kLong, name, " must be int64");
+  TORCH_CHECK(tensor.is_contiguous(), name, " must be contiguous");
+}
+
+}  // namespace
+
+at::Tensor select_paged_tokens(
+    const at::Tensor& q,
+    const at::Tensor& compressed_key_cache,
+    const at::Tensor& page_table,
+    const at::Tensor& token_to_req,
+    const at::Tensor& query_positions,
+    const at::Tensor& sequence_lengths,
+    int64_t token_topk,
+    int64_t compress_ratio,
+    at::Tensor out) {
+  check_fp16_xpu(q, "q", true);
+  check_fp16_xpu(compressed_key_cache, "compressed_key_cache", true);
+  check_int32_xpu(page_table, "page_table");
+  check_int32_xpu(token_to_req, "token_to_req");
+  check_int64_xpu(query_positions, "query_positions");
+  check_int32_xpu(sequence_lengths, "sequence_lengths");
+  check_int32_xpu(out, "out");
+  TORCH_CHECK(
+      q.dim() == 3 && q.size(1) == kIndexHeads && q.size(2) == kHeadDim,
+      "q must have shape [R,4,128]");
+  TORCH_CHECK(
+      compressed_key_cache.dim() == 4 &&
+          compressed_key_cache.size(1) == kCompressedPageSize &&
+          compressed_key_cache.size(2) == 1 &&
+          compressed_key_cache.size(3) == kHeadDim,
+      "compressed_key_cache must have shape [P,128,1,128]");
+  TORCH_CHECK(
+      page_table.dim() == 2 && page_table.size(0) > 0 &&
+          page_table.size(1) > 0,
+      "page_table must have shape [requests,pages]");
+  TORCH_CHECK(
+      token_to_req.dim() == 1 && token_to_req.size(0) == q.size(0),
+      "token_to_req must have shape [R]");
+  TORCH_CHECK(
+      query_positions.dim() == 1 && query_positions.size(0) == q.size(0),
+      "query_positions must have shape [R]");
+  TORCH_CHECK(
+      sequence_lengths.dim() == 1 &&
+          sequence_lengths.size(0) == page_table.size(0),
+      "sequence_lengths must have shape [requests]");
+  TORCH_CHECK(
+      out.dim() == 2 && out.size(0) == q.size(0) &&
+          out.size(1) == kOutputWidth,
+      "out must have shape [R,2051]");
+  TORCH_CHECK(token_topk == kTokenTopk, "token_topk must be 2048");
+  TORCH_CHECK(compress_ratio == kCompressRatio, "compress_ratio must be 4");
+  TORCH_CHECK(
+      q.device() == compressed_key_cache.device() &&
+          q.device() == page_table.device() &&
+          q.device() == token_to_req.device() &&
+          q.device() == query_positions.device() &&
+          q.device() == sequence_lengths.device() && q.device() == out.device(),
+      "all tensors must share one XPU device");
+
+  const int64_t rows = q.size(0);
+  if (rows == 0) {
+    return out;
+  }
+  const int64_t physical_pages = compressed_key_cache.size(0);
+  const int64_t requests = page_table.size(0);
+  const int64_t pages_per_request = page_table.size(1);
+  const int64_t cache_page_stride = compressed_key_cache.stride(0);
+  const int64_t cache_token_stride = compressed_key_cache.stride(1);
+  const auto* q_ptr = reinterpret_cast<const activation_t*>(q.data_ptr());
+  const auto* cache_ptr = reinterpret_cast<const activation_t*>(
+      compressed_key_cache.data_ptr());
+  const auto* page_table_ptr = page_table.data_ptr<int32_t>();
+  const auto* request_ptr = token_to_req.data_ptr<int32_t>();
+  const auto* position_ptr = query_positions.data_ptr<int64_t>();
+  const auto* sequence_ptr = sequence_lengths.data_ptr<int32_t>();
+  auto* out_ptr = out.data_ptr<int32_t>();
+
+  auto& queue = c10::xpu::getCurrentXPUStream(q.device().index()).queue();
+  queue.submit([&](sycl::handler& cgh) {
+    sycl::local_accessor<float, 1> scores(
+        sycl::range<1>(kSortSize), cgh);
+    sycl::local_accessor<int32_t, 1> indices(
+        sycl::range<1>(kSortSize), cgh);
+    cgh.parallel_for<QsaSelectPagedTokensKernel>(
+        sycl::nd_range<1>(
+            sycl::range<1>(static_cast<size_t>(rows * kWorkgroup)),
+            sycl::range<1>(static_cast<size_t>(kWorkgroup))),
+        [=](sycl::nd_item<1> item)
+            [[sycl::reqd_sub_group_size(kSubgroup)]] {
+          const int64_t row = item.get_group_linear_id();
+          const int64_t local = item.get_local_linear_id();
+          const int64_t subgroup_id = local / kSubgroup;
+          const int64_t lane = local % kSubgroup;
+          const int32_t request = request_ptr[row];
+          const bool request_valid = request >= 0 && request < requests;
+          const int64_t sequence_length = request_valid
+              ? static_cast<int64_t>(sequence_ptr[request])
+              : 0;
+          const int64_t visible_tokens = position_ptr[row] + 1;
+          const int64_t position_blocks = visible_tokens > 0
+              ? visible_tokens / kCompressRatio
+              : 0;
+          const int64_t sequence_blocks = sequence_length > 0
+              ? sequence_length / kCompressRatio
+              : 0;
+          const int64_t visible_blocks = sycl::min(
+              position_blocks, sequence_blocks);
+
+          for (int64_t slot = local; slot < kBlockTopk;
+               slot += kWorkgroup) {
+            scores[slot] = -std::numeric_limits<float>::infinity();
+            indices[slot] = -1;
+          }
+          item.barrier(sycl::access::fence_space::local_space);
+
+          for (int64_t chunk_start = 0; chunk_start < visible_blocks;
+               chunk_start += kChunkBlocks) {
+            for (int64_t block_in_chunk = subgroup_id;
+                 block_in_chunk < kChunkBlocks;
+                 block_in_chunk += kSubgroups) {
+              const int64_t logical_block = chunk_start + block_in_chunk;
+              bool valid = logical_block < visible_blocks && request_valid;
+              int64_t cache_base = -1;
+              if (valid) {
+                const int64_t page_column =
+                    logical_block / kCompressedPageSize;
+                valid = page_column < pages_per_request;
+                if (valid) {
+                  const int32_t physical_page = page_table_ptr[
+                      static_cast<int64_t>(request) * pages_per_request +
+                      page_column];
+                  valid = physical_page >= 0 && physical_page < physical_pages;
+                  if (valid) {
+                    cache_base =
+                        static_cast<int64_t>(physical_page) *
+                            cache_page_stride +
+                        (logical_block % kCompressedPageSize) *
+                            cache_token_stride;
+                  }
+                }
+              }
+
+              float partial[kIndexHeads] = {0.0f, 0.0f, 0.0f, 0.0f};
+#pragma unroll
+              for (int64_t fragment = 0; fragment < kHeadDim / kSubgroup;
+                   ++fragment) {
+                const int64_t dim = lane + fragment * kSubgroup;
+                const float key = valid
+                    ? static_cast<float>(cache_ptr[cache_base + dim])
+                    : 0.0f;
+#pragma unroll
+                for (int64_t head = 0; head < kIndexHeads; ++head) {
+                  const float query = static_cast<float>(
+                      q_ptr[(row * kIndexHeads + head) * kHeadDim + dim]);
+                  partial[head] += query * key;
+                }
+              }
+              float score = 0.0f;
+#pragma unroll
+              for (int64_t head = 0; head < kIndexHeads; ++head) {
+                const float dot = sycl::reduce_over_group(
+                    item.get_sub_group(), partial[head], sycl::plus<float>());
+                score += sycl::fmax(dot, 0.0f);
+              }
+              if (lane == 0) {
+                const int64_t slot = kBlockTopk + block_in_chunk;
+                scores[slot] = valid
+                    ? score * kScoreScale
+                    : -std::numeric_limits<float>::infinity();
+                indices[slot] = valid
+                    ? static_cast<int32_t>(logical_block)
+                    : -1;
+              }
+            }
+            item.barrier(sycl::access::fence_space::local_space);
+
+            // Ascending (score, descending-index) bitonic order. Reversing the
+            // retained high half yields torch.topk-compatible descending score
+            // order with ascending logical indices for exact score ties.
+            for (int64_t size = 2; size <= kSortSize; size <<= 1) {
+              for (int64_t stride = size >> 1; stride > 0; stride >>= 1) {
+                for (int64_t left = local; left < kSortSize;
+                     left += kWorkgroup) {
+                  const int64_t right = left ^ stride;
+                  if (right > left) {
+                    const float left_score = scores[left];
+                    const float right_score = scores[right];
+                    const int32_t left_index = indices[left];
+                    const int32_t right_index = indices[right];
+                    const bool ascending = (left & size) == 0;
+                    const bool swap = ascending
+                        ? (left_score > right_score ||
+                           (left_score == right_score &&
+                            left_index < right_index))
+                        : (left_score < right_score ||
+                           (left_score == right_score &&
+                            left_index > right_index));
+                    if (swap) {
+                      scores[left] = right_score;
+                      scores[right] = left_score;
+                      indices[left] = right_index;
+                      indices[right] = left_index;
+                    }
+                  }
+                }
+                item.barrier(sycl::access::fence_space::local_space);
+              }
+            }
+            for (int64_t rank = local; rank < kBlockTopk;
+                 rank += kWorkgroup) {
+              const int64_t source = kSortSize - 1 - rank;
+              scores[rank] = scores[source];
+              indices[rank] = indices[source];
+            }
+            item.barrier(sycl::access::fence_space::local_space);
+          }
+
+          const int64_t output_base = row * kOutputWidth;
+          for (int64_t column = local; column < kOutputWidth;
+               column += kWorkgroup) {
+            out_ptr[output_base + column] = -1;
+          }
+          item.barrier(sycl::access::fence_space::global_and_local);
+
+          const int64_t selected_blocks = sycl::min(
+              visible_blocks, kBlockTopk);
+          const int64_t expanded_tokens =
+              selected_blocks * kCompressRatio;
+          for (int64_t column = local; column < expanded_tokens;
+               column += kWorkgroup) {
+            const int64_t rank = column / kCompressRatio;
+            const int64_t offset = column % kCompressRatio;
+            const int32_t block = indices[rank];
+            const int64_t token =
+                static_cast<int64_t>(block) * kCompressRatio + offset;
+            if (block >= 0 && token < sequence_length) {
+              out_ptr[output_base + column] = static_cast<int32_t>(token);
+            }
+          }
+          if (local < kCompressRatio - 1) {
+            const int64_t tail_start =
+                visible_tokens / kCompressRatio * kCompressRatio;
+            const int64_t tail_count = visible_tokens - tail_start;
+            const int64_t tail_token = tail_start + local;
+            if (local < tail_count && tail_token >= 0 &&
+                tail_token < sequence_length) {
+              out_ptr[output_base + expanded_tokens + local] =
+                  static_cast<int32_t>(tail_token);
+            }
+          }
+        });
+  });
+  return out;
+}
+
+}  // namespace qsa

--- a/vllm/custom-esimd-kernels-vllm/csrc/qsa/qsa_sparse_attention.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/qsa/qsa_sparse_attention.sycl
@@ -1,0 +1,754 @@
+// Copyright 2026
+// SPDX-License-Identifier: Apache-2.0
+//
+// Fixed-contract Qwen3.8 TP8-rank sparse paged attention for Intel XPU.
+
+#include <ATen/ATen.h>
+#include <c10/xpu/XPUStream.h>
+#include <torch/extension.h>
+
+#include <sycl/sycl.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <limits>
+
+namespace {
+
+#ifndef QSA_NATIVE_ACTIVATION_FP16
+#define QSA_NATIVE_ACTIVATION_FP16 0
+#endif
+
+#if QSA_NATIVE_ACTIVATION_FP16
+using activation_t = sycl::half;
+constexpr at::ScalarType kActivationScalarType = at::kHalf;
+constexpr const char* kActivationName = "float16";
+#else
+using activation_t = sycl::ext::oneapi::bfloat16;
+constexpr at::ScalarType kActivationScalarType = at::kBFloat16;
+constexpr const char* kActivationName = "bfloat16";
+#endif
+
+#ifndef QSA_NATIVE_KV_TILE
+#define QSA_NATIVE_KV_TILE 32
+#endif
+
+#ifndef QSA_NATIVE_SUBGROUP
+#define QSA_NATIVE_SUBGROUP 16
+#endif
+
+#ifndef QSA_NATIVE_TOKEN_LOADER
+#define QSA_NATIVE_TOKEN_LOADER 0
+#endif
+
+#ifndef QSA_NATIVE_TRIM_VALID_WIDTH
+#define QSA_NATIVE_TRIM_VALID_WIDTH 0
+#endif
+
+#ifndef QSA_NATIVE_PACKED_KV
+#define QSA_NATIVE_PACKED_KV 0
+#endif
+
+#ifndef QSA_NATIVE_PIPELINED_LOADER
+#define QSA_NATIVE_PIPELINED_LOADER 0
+#endif
+
+#ifndef QSA_NATIVE_STAGE_VALIDITY
+#define QSA_NATIVE_STAGE_VALIDITY 0
+#endif
+
+#ifndef QSA_NATIVE_BOUNDED_SCAN
+#define QSA_NATIVE_BOUNDED_SCAN 0
+#endif
+
+#ifndef QSA_NATIVE_SINGLE_EXP
+#define QSA_NATIVE_SINGLE_EXP 0
+#endif
+
+#ifndef QSA_NATIVE_BLOCK_SOFTMAX
+#define QSA_NATIVE_BLOCK_SOFTMAX 0
+#endif
+
+#ifndef QSA_NATIVE_FAST_EXP
+#define QSA_NATIVE_FAST_EXP 0
+#endif
+
+#ifndef QSA_NATIVE_EXACT_PACKED_CACHE
+#define QSA_NATIVE_EXACT_PACKED_CACHE 0
+#endif
+
+constexpr int64_t kQueryHeads = 3;
+constexpr int64_t kKvHeads = 1;
+constexpr int64_t kHeadDim = 256;
+constexpr int64_t kPageSize = 512;
+constexpr int64_t kIndexWidth = 2051;
+constexpr int64_t kSubgroup = QSA_NATIVE_SUBGROUP;
+constexpr int64_t kWorkgroup = 4 * kSubgroup;
+constexpr int64_t kValuesPerLane = kHeadDim / kSubgroup;
+constexpr int64_t kTile = QSA_NATIVE_KV_TILE;
+constexpr int64_t kTileElements = kTile * kHeadDim;
+constexpr int64_t kPackedTokenStride = 2 * kHeadDim;
+constexpr int64_t kPackedPageStride = kPageSize * kPackedTokenStride;
+
+static_assert(
+    kTile == 4 || kTile == 8 || kTile == 16 || kTile == 32 || kTile == 64);
+static_assert(kSubgroup == 16 || kSubgroup == 32);
+static_assert(kHeadDim % kSubgroup == 0);
+#if QSA_NATIVE_TOKEN_LOADER
+static_assert(kWorkgroup % kTile == 0);
+constexpr int64_t kWorkersPerToken = kWorkgroup / kTile;
+static_assert(kSubgroup % kWorkersPerToken == 0);
+static_assert(kHeadDim % kWorkersPerToken == 0);
+constexpr int64_t kDimsPerWorker = kHeadDim / kWorkersPerToken;
+#if QSA_NATIVE_PACKED_KV
+constexpr int64_t kPackedElements = 8;
+static_assert(kDimsPerWorker % kPackedElements == 0);
+#endif
+#endif
+#if QSA_NATIVE_PIPELINED_LOADER
+static_assert(QSA_NATIVE_TOKEN_LOADER);
+static_assert(QSA_NATIVE_PACKED_KV);
+static_assert(kTile == 16);
+static_assert(kSubgroup == 32);
+constexpr int64_t kPipelineLoaderSubgroup = kQueryHeads;
+constexpr int64_t kPipelineWorkersPerToken = kSubgroup / kTile;
+constexpr int64_t kPipelineDimsPerWorker =
+    kHeadDim / kPipelineWorkersPerToken;
+static_assert(kSubgroup % kTile == 0);
+static_assert(kHeadDim % kPipelineWorkersPerToken == 0);
+static_assert(kPipelineDimsPerWorker % kPackedElements == 0);
+#endif
+#if QSA_NATIVE_STAGE_VALIDITY
+static_assert(QSA_NATIVE_TOKEN_LOADER);
+static_assert(!QSA_NATIVE_PIPELINED_LOADER);
+#endif
+#if QSA_NATIVE_BLOCK_SOFTMAX
+static_assert(!QSA_NATIVE_SINGLE_EXP);
+#endif
+
+class SparsePagedAttentionKernel;
+
+inline float qsa_exp(float value) {
+#if QSA_NATIVE_FAST_EXP
+  return sycl::native::exp(value);
+#else
+  return sycl::exp(value);
+#endif
+}
+
+void check_activation_xpu(const at::Tensor& tensor, const char* name,
+                          bool require_contiguous) {
+  TORCH_CHECK(tensor.device().is_xpu(), name, " must be on XPU");
+  TORCH_CHECK(tensor.scalar_type() == kActivationScalarType,
+              name, " must be ", kActivationName);
+  TORCH_CHECK(!require_contiguous || tensor.is_contiguous(),
+              name, " must be contiguous");
+}
+
+void check_int32_xpu(const at::Tensor& tensor, const char* name) {
+  TORCH_CHECK(tensor.device().is_xpu(), name, " must be on XPU");
+  TORCH_CHECK(tensor.scalar_type() == at::kInt,
+              name, " must be int32");
+  TORCH_CHECK(tensor.is_contiguous(), name, " must be contiguous");
+}
+
+at::Tensor sparse_paged_attention_impl(
+    const at::Tensor& q,
+    const at::Tensor& k_cache,
+    const at::Tensor& v_cache,
+    const at::Tensor& logical_indices,
+    const at::Tensor& block_table,
+    const at::Tensor& token_to_req,
+    int64_t valid_width_scan_bound,
+    at::Tensor out) {
+  check_activation_xpu(q, "q", true);
+  check_activation_xpu(k_cache, "k_cache", false);
+  check_activation_xpu(v_cache, "v_cache", false);
+  check_activation_xpu(out, "out", true);
+  check_int32_xpu(logical_indices, "logical_indices");
+  check_int32_xpu(block_table, "block_table");
+  check_int32_xpu(token_to_req, "token_to_req");
+  TORCH_CHECK(q.dim() == 3 && q.size(1) == kQueryHeads &&
+                  q.size(2) == kHeadDim,
+              "q must have shape [R,3,256]");
+  TORCH_CHECK(k_cache.dim() == 4 && k_cache.size(1) == kPageSize &&
+                  k_cache.size(2) == kKvHeads &&
+                  k_cache.size(3) == kHeadDim,
+              "k_cache must have shape [P,512,1,256]");
+  TORCH_CHECK(v_cache.sizes() == k_cache.sizes(),
+              "v_cache must match k_cache");
+  TORCH_CHECK(k_cache.stride(0) > 0 && k_cache.stride(1) >= kHeadDim &&
+                  k_cache.stride(3) == 1,
+              "k_cache must have positive page stride, token stride >= 256, "
+              "and unit head-dimension stride");
+  TORCH_CHECK(v_cache.stride(0) > 0 && v_cache.stride(1) >= kHeadDim &&
+                  v_cache.stride(3) == 1,
+              "v_cache must have positive page stride, token stride >= 256, "
+              "and unit head-dimension stride");
+#if QSA_NATIVE_EXACT_PACKED_CACHE
+  TORCH_CHECK(k_cache.stride(0) == kPackedPageStride &&
+                  k_cache.stride(1) == kPackedTokenStride &&
+                  k_cache.stride(2) == kHeadDim &&
+                  v_cache.stride(0) == kPackedPageStride &&
+                  v_cache.stride(1) == kPackedTokenStride &&
+                  v_cache.stride(2) == kHeadDim,
+              "k_cache and v_cache must have exact packed strides "
+              "[262144,512,256,1]");
+#endif
+  TORCH_CHECK(logical_indices.dim() == 2 &&
+                  logical_indices.size(0) == q.size(0) &&
+                  logical_indices.size(1) == kIndexWidth,
+              "logical_indices must have shape [R,2051]");
+  TORCH_CHECK(block_table.dim() == 2 && block_table.size(1) > 0,
+              "block_table must have shape [requests,pages]");
+  TORCH_CHECK(token_to_req.dim() == 1 && token_to_req.size(0) == q.size(0),
+              "token_to_req must have shape [R]");
+  TORCH_CHECK(out.sizes() == q.sizes(), "out must match q");
+  TORCH_CHECK(valid_width_scan_bound >= 0 &&
+                  valid_width_scan_bound <= kIndexWidth,
+              "valid-width scan bound must be in [0,2051]");
+  TORCH_CHECK(q.device() == k_cache.device() && q.device() == v_cache.device() &&
+                  q.device() == logical_indices.device() &&
+                  q.device() == block_table.device() &&
+                  q.device() == token_to_req.device() && q.device() == out.device(),
+              "all tensors must share one XPU device");
+
+  const int64_t rows = q.size(0);
+  if (rows == 0) {
+    return out;
+  }
+  const int64_t physical_pages = k_cache.size(0);
+  const int64_t requests = block_table.size(0);
+  const int64_t pages_per_request = block_table.size(1);
+#if QSA_NATIVE_EXACT_PACKED_CACHE
+  constexpr int64_t k_page_stride = kPackedPageStride;
+  constexpr int64_t k_token_stride = kPackedTokenStride;
+  constexpr int64_t v_page_stride = kPackedPageStride;
+  constexpr int64_t v_token_stride = kPackedTokenStride;
+#else
+  const int64_t k_page_stride = k_cache.stride(0);
+  const int64_t k_token_stride = k_cache.stride(1);
+  const int64_t v_page_stride = v_cache.stride(0);
+  const int64_t v_token_stride = v_cache.stride(1);
+#endif
+  const auto* q_ptr = reinterpret_cast<const activation_t*>(q.data_ptr());
+  const auto* k_ptr = reinterpret_cast<const activation_t*>(k_cache.data_ptr());
+  const auto* v_ptr = reinterpret_cast<const activation_t*>(v_cache.data_ptr());
+  const auto* index_ptr = logical_indices.data_ptr<int32_t>();
+  const auto* table_ptr = block_table.data_ptr<int32_t>();
+  const auto* request_ptr = token_to_req.data_ptr<int32_t>();
+  auto* out_ptr = reinterpret_cast<activation_t*>(out.data_ptr());
+  constexpr float scale = 1.0f / 16.0f;
+
+  auto& queue = c10::xpu::getCurrentXPUStream(q.device().index()).queue();
+  queue.submit([&](sycl::handler& cgh) {
+    sycl::local_accessor<activation_t, 1> staged(
+#if QSA_NATIVE_PIPELINED_LOADER
+        sycl::range<1>(4 * kTileElements), cgh);
+#elif QSA_NATIVE_STAGE_VALIDITY
+        sycl::range<1>(2 * kTileElements + kTile), cgh);
+#else
+        sycl::range<1>(2 * kTileElements), cgh);
+#endif
+    cgh.parallel_for<SparsePagedAttentionKernel>(
+        sycl::nd_range<1>(
+            sycl::range<1>(static_cast<size_t>(rows * kWorkgroup)),
+            sycl::range<1>(static_cast<size_t>(kWorkgroup))),
+        [=](sycl::nd_item<1> item)
+            [[sycl::reqd_sub_group_size(QSA_NATIVE_SUBGROUP)]] {
+          const int64_t row = item.get_group_linear_id();
+          const int64_t local = item.get_local_linear_id();
+          const int64_t subgroup_id = local / kSubgroup;
+          const int64_t lane = local % kSubgroup;
+          const int32_t request = request_ptr[row];
+#if QSA_NATIVE_TRIM_VALID_WIDTH
+          int32_t local_last_valid = -1;
+#if QSA_NATIVE_BOUNDED_SCAN
+          for (int64_t column = local; column < valid_width_scan_bound;
+#else
+          for (int64_t column = local; column < kIndexWidth;
+#endif
+               column += kWorkgroup) {
+            if (index_ptr[row * kIndexWidth + column] >= 0) {
+              local_last_valid = static_cast<int32_t>(column);
+            }
+          }
+          const int32_t last_valid = sycl::reduce_over_group(
+              item.get_group(), local_last_valid, sycl::maximum<int32_t>());
+          const int64_t valid_width = static_cast<int64_t>(last_valid) + 1;
+#endif
+
+          float q_values[kValuesPerLane];
+          float accumulators[kValuesPerLane];
+          if (subgroup_id < kQueryHeads) {
+            for (int64_t fragment = 0; fragment < kValuesPerLane; ++fragment) {
+              const int64_t dim = lane + fragment * kSubgroup;
+              q_values[fragment] = static_cast<float>(
+                  q_ptr[(row * kQueryHeads + subgroup_id) * kHeadDim + dim]);
+              accumulators[fragment] = 0.0f;
+            }
+          }
+          float row_max = -std::numeric_limits<float>::infinity();
+          float denominator = 0.0f;
+
+#if QSA_NATIVE_PIPELINED_LOADER
+          auto staged_ptr = staged.template get_multi_ptr<
+              sycl::access::decorated::no>();
+          auto load_pipeline_tile = [&](int64_t load_tile_start,
+                                        int64_t stage_base) {
+            if (subgroup_id != kPipelineLoaderSubgroup) {
+              return;
+            }
+            const int64_t token_in_tile =
+                lane / kPipelineWorkersPerToken;
+            const int64_t worker_in_token =
+                lane % kPipelineWorkersPerToken;
+            const uint32_t source_lane = static_cast<uint32_t>(
+                token_in_tile * kPipelineWorkersPerToken);
+            const int64_t column = load_tile_start + token_in_tile;
+            int64_t key_cache_base = -1;
+            int64_t value_cache_base = -1;
+            if (static_cast<uint32_t>(lane) == source_lane &&
+#if QSA_NATIVE_TRIM_VALID_WIDTH
+                column < valid_width) {
+#else
+                column < kIndexWidth) {
+#endif
+              const int32_t logical =
+                  index_ptr[row * kIndexWidth + column];
+              if (logical >= 0 && request >= 0 && request < requests) {
+                const int64_t page_column = logical / kPageSize;
+                if (page_column < pages_per_request) {
+                  const int32_t physical =
+                      table_ptr[request * pages_per_request + page_column];
+                  if (physical >= 0 && physical < physical_pages) {
+                    const int64_t offset = logical % kPageSize;
+                    key_cache_base =
+                        static_cast<int64_t>(physical) * k_page_stride +
+                        offset * k_token_stride;
+                    value_cache_base =
+                        static_cast<int64_t>(physical) * v_page_stride +
+                        offset * v_token_stride;
+                  }
+                }
+              }
+            }
+            key_cache_base = sycl::select_from_group(
+                item.get_sub_group(), key_cache_base, source_lane);
+            value_cache_base = sycl::select_from_group(
+                item.get_sub_group(), value_cache_base, source_lane);
+            const int64_t dim_start =
+                worker_in_token * kPipelineDimsPerWorker;
+#pragma unroll
+            for (int64_t dim_offset = 0;
+                 dim_offset < kPipelineDimsPerWorker;
+                 dim_offset += kPackedElements) {
+              const int64_t dim = dim_start + dim_offset;
+              const int64_t linear =
+                  stage_base + token_in_tile * kHeadDim + dim;
+              {
+                sycl::vec<activation_t, kPackedElements> key_values(
+                    static_cast<activation_t>(0.0f));
+                if (key_cache_base >= 0) {
+                  key_values.load(0, k_ptr + key_cache_base + dim);
+                }
+                key_values.store(0, staged_ptr + linear);
+              }
+              {
+                sycl::vec<activation_t, kPackedElements> value_values(
+                    static_cast<activation_t>(0.0f));
+                if (value_cache_base >= 0) {
+                  value_values.load(0, v_ptr + value_cache_base + dim);
+                }
+                value_values.store(
+                    0, staged_ptr + kTileElements + linear);
+              }
+            }
+          };
+#if QSA_NATIVE_TRIM_VALID_WIDTH
+          if (valid_width > 0) {
+            load_pipeline_tile(0, 0);
+            item.barrier(sycl::access::fence_space::local_space);
+          }
+#else
+          load_pipeline_tile(0, 0);
+          item.barrier(sycl::access::fence_space::local_space);
+#endif
+          int64_t stage_slot = 0;
+#endif
+
+#if QSA_NATIVE_TRIM_VALID_WIDTH
+          for (int64_t tile_start = 0; tile_start < valid_width;
+#else
+          for (int64_t tile_start = 0; tile_start < kIndexWidth;
+#endif
+               tile_start += kTile) {
+#if QSA_NATIVE_PIPELINED_LOADER
+              const int64_t next_tile_start = tile_start + kTile;
+#if QSA_NATIVE_TRIM_VALID_WIDTH
+              const bool has_next_tile = next_tile_start < valid_width;
+#else
+              const bool has_next_tile = next_tile_start < kIndexWidth;
+#endif
+              if (has_next_tile) {
+                const int64_t next_stage_base =
+                    (stage_slot ^ 1) * 2 * kTileElements;
+                load_pipeline_tile(next_tile_start, next_stage_base);
+              }
+#else
+#if QSA_NATIVE_TOKEN_LOADER
+              const int64_t token_in_tile = local / kWorkersPerToken;
+              const int64_t worker_in_token = local % kWorkersPerToken;
+              const int64_t token_in_subgroup = lane / kWorkersPerToken;
+              const uint32_t source_lane = static_cast<uint32_t>(
+                  token_in_subgroup * kWorkersPerToken);
+              const int64_t column = tile_start + token_in_tile;
+              int64_t key_cache_base = -1;
+              int64_t value_cache_base = -1;
+              int32_t logical_for_token = -1;
+              if (static_cast<uint32_t>(lane) == source_lane &&
+#if QSA_NATIVE_TRIM_VALID_WIDTH
+                  column < valid_width) {
+#else
+                  column < kIndexWidth) {
+#endif
+                logical_for_token = index_ptr[row * kIndexWidth + column];
+                const int32_t logical = logical_for_token;
+                if (logical >= 0 && request >= 0 && request < requests) {
+                  const int64_t page_column = logical / kPageSize;
+                  if (page_column < pages_per_request) {
+                    const int32_t physical =
+                        table_ptr[request * pages_per_request + page_column];
+                    if (physical >= 0 && physical < physical_pages) {
+                      const int64_t offset = logical % kPageSize;
+                      key_cache_base =
+                          static_cast<int64_t>(physical) * k_page_stride +
+                          offset * k_token_stride;
+                      value_cache_base =
+                          static_cast<int64_t>(physical) * v_page_stride +
+                          offset * v_token_stride;
+                    }
+                  }
+                }
+              }
+#if QSA_NATIVE_STAGE_VALIDITY
+              if (static_cast<uint32_t>(lane) == source_lane) {
+                staged[2 * kTileElements + token_in_tile] =
+                    logical_for_token >= 0
+                    ? static_cast<activation_t>(1.0f)
+                    : static_cast<activation_t>(0.0f);
+              }
+#endif
+              key_cache_base = sycl::select_from_group(
+                  item.get_sub_group(), key_cache_base, source_lane);
+              value_cache_base = sycl::select_from_group(
+                  item.get_sub_group(), value_cache_base, source_lane);
+              const int64_t dim_start = worker_in_token * kDimsPerWorker;
+#if QSA_NATIVE_PACKED_KV
+              auto staged_ptr = staged.template get_multi_ptr<
+                  sycl::access::decorated::no>();
+#pragma unroll
+              for (int64_t dim_offset = 0; dim_offset < kDimsPerWorker;
+                   dim_offset += kPackedElements) {
+                const int64_t dim = dim_start + dim_offset;
+                const int64_t linear = token_in_tile * kHeadDim + dim;
+                {
+                  sycl::vec<activation_t, kPackedElements> key_values(
+                      static_cast<activation_t>(0.0f));
+                  if (key_cache_base >= 0) {
+                    key_values.load(0, k_ptr + key_cache_base + dim);
+                  }
+                  key_values.store(0, staged_ptr + linear);
+                }
+                {
+                  sycl::vec<activation_t, kPackedElements> value_values(
+                      static_cast<activation_t>(0.0f));
+                  if (value_cache_base >= 0) {
+                    value_values.load(0, v_ptr + value_cache_base + dim);
+                  }
+                  value_values.store(
+                      0, staged_ptr + kTileElements + linear);
+                }
+              }
+#else
+#pragma unroll 4
+              for (int64_t dim_offset = 0; dim_offset < kDimsPerWorker;
+                   ++dim_offset) {
+                const int64_t dim = dim_start + dim_offset;
+                const int64_t linear = token_in_tile * kHeadDim + dim;
+                activation_t key_value = static_cast<activation_t>(0.0f);
+                activation_t value_value = static_cast<activation_t>(0.0f);
+                if (key_cache_base >= 0) {
+                  key_value = k_ptr[key_cache_base + dim];
+                  value_value = v_ptr[value_cache_base + dim];
+                }
+                staged[linear] = key_value;
+                staged[kTileElements + linear] = value_value;
+              }
+#endif
+#else
+              for (int64_t linear = local; linear < kTileElements;
+                   linear += kWorkgroup) {
+                const int64_t token_in_tile = linear / kHeadDim;
+                const int64_t dim = linear % kHeadDim;
+                const int64_t column = tile_start + token_in_tile;
+                int32_t logical = -1;
+                if (
+#if QSA_NATIVE_TRIM_VALID_WIDTH
+                    column < valid_width) {
+#else
+                    column < kIndexWidth) {
+#endif
+                  logical = index_ptr[row * kIndexWidth + column];
+                }
+                activation_t key_value = static_cast<activation_t>(0.0f);
+                activation_t value_value = static_cast<activation_t>(0.0f);
+                if (logical >= 0 && request >= 0 && request < requests) {
+                  const int64_t page_column = logical / kPageSize;
+                  if (page_column < pages_per_request) {
+                    const int32_t physical =
+                        table_ptr[request * pages_per_request + page_column];
+                    if (physical >= 0 && physical < physical_pages) {
+                      const int64_t offset = logical % kPageSize;
+                      const int64_t key_cache_offset =
+                          static_cast<int64_t>(physical) * k_page_stride +
+                          offset * k_token_stride + dim;
+                      const int64_t value_cache_offset =
+                          static_cast<int64_t>(physical) * v_page_stride +
+                          offset * v_token_stride + dim;
+                      key_value = k_ptr[key_cache_offset];
+                      value_value = v_ptr[value_cache_offset];
+                    }
+                  }
+                }
+                staged[linear] = key_value;
+                staged[kTileElements + linear] = value_value;
+              }
+#endif
+              item.barrier(sycl::access::fence_space::local_space);
+#endif
+
+              if (subgroup_id < kQueryHeads) {
+#if QSA_NATIVE_PIPELINED_LOADER
+                const int64_t stage_base =
+                    stage_slot * 2 * kTileElements;
+#else
+                constexpr int64_t stage_base = 0;
+#endif
+#if QSA_NATIVE_TRIM_VALID_WIDTH
+                const int64_t remaining = valid_width - tile_start;
+#else
+                const int64_t remaining = kIndexWidth - tile_start;
+#endif
+                const int64_t tile_tokens =
+                    sycl::min<int64_t>(kTile, remaining);
+#if QSA_NATIVE_BLOCK_SOFTMAX
+                float tile_scores[kTile];
+                float tile_max = -std::numeric_limits<float>::infinity();
+                for (int64_t token = 0; token < tile_tokens; ++token) {
+#if QSA_NATIVE_STAGE_VALIDITY
+                  if (static_cast<float>(
+                          staged[2 * kTileElements + token]) == 0.0f) {
+                    tile_scores[token] =
+                        -std::numeric_limits<float>::infinity();
+                    continue;
+                  }
+#else
+                  const int32_t logical =
+                      index_ptr[row * kIndexWidth + tile_start + token];
+                  if (logical < 0) {
+                    tile_scores[token] =
+                        -std::numeric_limits<float>::infinity();
+                    continue;
+                  }
+#endif
+                  float partial = 0.0f;
+                  for (int64_t fragment = 0; fragment < kValuesPerLane;
+                       ++fragment) {
+                    const int64_t dim = lane + fragment * kSubgroup;
+                    partial += q_values[fragment] * static_cast<float>(
+                        staged[stage_base + token * kHeadDim + dim]);
+                  }
+                  const float score = sycl::reduce_over_group(
+                      item.get_sub_group(), partial, sycl::plus<float>()) *
+                      scale;
+                  tile_scores[token] = score;
+                  tile_max = sycl::fmax(tile_max, score);
+                }
+                float tile_denominator = 0.0f;
+                float tile_accumulators[kValuesPerLane];
+                for (int64_t fragment = 0; fragment < kValuesPerLane;
+                     ++fragment) {
+                  tile_accumulators[fragment] = 0.0f;
+                }
+                for (int64_t token = 0; token < tile_tokens; ++token) {
+#if QSA_NATIVE_STAGE_VALIDITY
+                  if (static_cast<float>(
+                          staged[2 * kTileElements + token]) == 0.0f) {
+                    continue;
+                  }
+#else
+                  const int32_t logical =
+                      index_ptr[row * kIndexWidth + tile_start + token];
+                  if (logical < 0) {
+                    continue;
+                  }
+#endif
+                  const float probability =
+                      qsa_exp(tile_scores[token] - tile_max);
+                  for (int64_t fragment = 0; fragment < kValuesPerLane;
+                       ++fragment) {
+                    const int64_t dim = lane + fragment * kSubgroup;
+                    const float value = static_cast<float>(
+                        staged[stage_base + kTileElements +
+                               token * kHeadDim + dim]);
+                    tile_accumulators[fragment] += probability * value;
+                  }
+                  tile_denominator += probability;
+                }
+                if (tile_denominator > 0.0f) {
+                  const float next_max = sycl::fmax(row_max, tile_max);
+                  const float rescale = qsa_exp(
+                      sycl::fmin(row_max, tile_max) - next_max);
+                  const bool replace_max = tile_max > row_max;
+                  const float alpha = replace_max ? rescale : 1.0f;
+                  const float beta = replace_max ? 1.0f : rescale;
+                  for (int64_t fragment = 0; fragment < kValuesPerLane;
+                       ++fragment) {
+                    accumulators[fragment] =
+                        accumulators[fragment] * alpha +
+                        tile_accumulators[fragment] * beta;
+                  }
+                  denominator =
+                      denominator * alpha + tile_denominator * beta;
+                  row_max = next_max;
+                }
+#else
+                for (int64_t token = 0; token < tile_tokens; ++token) {
+#if QSA_NATIVE_STAGE_VALIDITY
+                  if (static_cast<float>(
+                          staged[2 * kTileElements + token]) == 0.0f) {
+                    continue;
+                  }
+#else
+                  const int32_t logical =
+                      index_ptr[row * kIndexWidth + tile_start + token];
+                  if (logical < 0) {
+                    continue;
+                  }
+#endif
+                  float partial = 0.0f;
+                  for (int64_t fragment = 0; fragment < kValuesPerLane;
+                       ++fragment) {
+                    const int64_t dim = lane + fragment * kSubgroup;
+                    partial += q_values[fragment] * static_cast<float>(
+                        staged[stage_base + token * kHeadDim + dim]);
+                  }
+                  const float score = sycl::reduce_over_group(
+                      item.get_sub_group(), partial, sycl::plus<float>()) *
+                      scale;
+                  const float next_max = sycl::fmax(row_max, score);
+#if QSA_NATIVE_SINGLE_EXP
+                  float alpha = 1.0f;
+                  float probability = 1.0f;
+                  if (score > row_max) {
+                    alpha = qsa_exp(row_max - score);
+                  } else {
+                    probability = qsa_exp(score - row_max);
+                  }
+#else
+                  const float alpha = qsa_exp(row_max - next_max);
+                  const float probability = qsa_exp(score - next_max);
+#endif
+                  for (int64_t fragment = 0; fragment < kValuesPerLane;
+                       ++fragment) {
+                    const int64_t dim = lane + fragment * kSubgroup;
+                    const float value = static_cast<float>(
+                        staged[stage_base + kTileElements +
+                               token * kHeadDim + dim]);
+                    accumulators[fragment] =
+                        accumulators[fragment] * alpha + probability * value;
+                  }
+                  denominator = denominator * alpha + probability;
+                  row_max = next_max;
+                }
+#endif
+              }
+#if QSA_NATIVE_PIPELINED_LOADER
+              if (has_next_tile) {
+                item.barrier(sycl::access::fence_space::local_space);
+                stage_slot ^= 1;
+              }
+#else
+              item.barrier(sycl::access::fence_space::local_space);
+#endif
+          }
+
+          if (subgroup_id < kQueryHeads) {
+            for (int64_t fragment = 0; fragment < kValuesPerLane; ++fragment) {
+              const int64_t dim = lane + fragment * kSubgroup;
+              const float value = denominator > 0.0f
+                  ? accumulators[fragment] / denominator
+                  : 0.0f;
+              out_ptr[(row * kQueryHeads + subgroup_id) * kHeadDim + dim] =
+                  static_cast<activation_t>(value);
+            }
+          }
+        });
+  });
+  return out;
+}
+
+at::Tensor sparse_paged_attention(
+    const at::Tensor& q,
+    const at::Tensor& k_cache,
+    const at::Tensor& v_cache,
+    const at::Tensor& logical_indices,
+    const at::Tensor& block_table,
+    const at::Tensor& token_to_req,
+    at::Tensor out) {
+  return sparse_paged_attention_impl(
+      q, k_cache, v_cache, logical_indices, block_table, token_to_req,
+      kIndexWidth, out);
+}
+
+at::Tensor sparse_paged_attention_bounded(
+    const at::Tensor& q,
+    const at::Tensor& k_cache,
+    const at::Tensor& v_cache,
+    const at::Tensor& logical_indices,
+    const at::Tensor& block_table,
+    const at::Tensor& token_to_req,
+    int64_t max_valid_width,
+    at::Tensor out) {
+  return sparse_paged_attention_impl(
+      q, k_cache, v_cache, logical_indices, block_table, token_to_req,
+      max_valid_width, out);
+}
+
+}  // namespace
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, module) {
+  module.def(
+      "sparse_paged_attention",
+      &sparse_paged_attention,
+      "Qwen3.8 TP8-rank sparse paged attention (XPU)");
+  module.def(
+      "sparse_paged_attention_bounded",
+      &sparse_paged_attention_bounded,
+      "Qwen3.8 TP8-rank sparse paged attention with trusted scan bound (XPU)");
+  module.attr("kv_tile") = QSA_NATIVE_KV_TILE;
+  module.attr("subgroup") = QSA_NATIVE_SUBGROUP;
+  module.attr("token_loader") = QSA_NATIVE_TOKEN_LOADER;
+  module.attr("trim_valid_width") = QSA_NATIVE_TRIM_VALID_WIDTH;
+  module.attr("packed_kv") = QSA_NATIVE_PACKED_KV;
+  module.attr("pipelined_loader") = QSA_NATIVE_PIPELINED_LOADER;
+  module.attr("stage_validity") = QSA_NATIVE_STAGE_VALIDITY;
+  module.attr("bounded_scan") = QSA_NATIVE_BOUNDED_SCAN;
+  module.attr("single_exp") = QSA_NATIVE_SINGLE_EXP;
+  module.attr("block_softmax") = QSA_NATIVE_BLOCK_SOFTMAX;
+  module.attr("fast_exp") = QSA_NATIVE_FAST_EXP;
+  module.attr("activation_dtype") = kActivationName;
+  module.attr("strided_kv") = 1;
+  module.attr("exact_packed_cache") = QSA_NATIVE_EXACT_PACKED_CACHE;
+}

--- a/vllm/custom-esimd-kernels-vllm/csrc/qsa/qsa_sparse_attention.sycl
+++ b/vllm/custom-esimd-kernels-vllm/csrc/qsa/qsa_sparse_attention.sycl
@@ -13,6 +13,8 @@
 #include <cstdint>
 #include <limits>
 
+#include "qsa_ops.h"
+
 namespace {
 
 #ifndef QSA_NATIVE_ACTIVATION_FP16
@@ -737,6 +739,10 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, module) {
       "sparse_paged_attention_bounded",
       &sparse_paged_attention_bounded,
       "Qwen3.8 TP8-rank sparse paged attention with trusted scan bound (XPU)");
+  module.def(
+      "qsa_select_paged_tokens",
+      &qsa::select_paged_tokens,
+      "Qwen3.8 TP8-rank fused paged index selection and expansion (XPU)");
   module.attr("kv_tile") = QSA_NATIVE_KV_TILE;
   module.attr("subgroup") = QSA_NATIVE_SUBGROUP;
   module.attr("token_loader") = QSA_NATIVE_TOKEN_LOADER;
@@ -751,4 +757,5 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, module) {
   module.attr("activation_dtype") = kActivationName;
   module.attr("strided_kv") = 1;
   module.attr("exact_packed_cache") = QSA_NATIVE_EXACT_PACKED_CACHE;
+  module.attr("selection_output_width") = 2051;
 }

--- a/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/__init__.py
+++ b/vllm/custom-esimd-kernels-vllm/python/custom_esimd_kernels_vllm/__init__.py
@@ -15,6 +15,9 @@ from custom_esimd_kernels_vllm import moe_ops
 # MoE INT4 Batch kernels — registers torch.ops.moe_int4_ops.*
 from custom_esimd_kernels_vllm import moe_int4_ops
 
+# Qwen3.8 QSA — direct pybind API: qsa_ops.sparse_paged_attention(...)
+from custom_esimd_kernels_vllm import qsa_ops
+
 from custom_esimd_kernels_vllm.ops import (
     # Core ESIMD ops
     esimd_gemv_fp8_pern,

--- a/vllm/custom-esimd-kernels-vllm/qsa_build.py
+++ b/vllm/custom-esimd-kernels-vllm/qsa_build.py
@@ -1,0 +1,44 @@
+"""Shared build definition for the fixed-contract Qwen3.8 QSA extension."""
+
+from pathlib import Path
+
+from torch.utils.cpp_extension import SyclExtension
+
+
+QSA_EXTENSION_NAME = "custom_esimd_kernels_vllm.qsa_ops"
+QSA_DEFINES = (
+    "QSA_NATIVE_ACTIVATION_FP16=1",
+    "QSA_NATIVE_EXACT_PACKED_CACHE=1",
+    "QSA_NATIVE_KV_TILE=4",
+    "QSA_NATIVE_SUBGROUP=32",
+    "QSA_NATIVE_TOKEN_LOADER=1",
+    "QSA_NATIVE_TRIM_VALID_WIDTH=1",
+    "QSA_NATIVE_PACKED_KV=1",
+    "QSA_NATIVE_PIPELINED_LOADER=0",
+    "QSA_NATIVE_STAGE_VALIDITY=0",
+    "QSA_NATIVE_BOUNDED_SCAN=0",
+    "QSA_NATIVE_SINGLE_EXP=0",
+    "QSA_NATIVE_BLOCK_SOFTMAX=0",
+    "QSA_NATIVE_FAST_EXP=1",
+)
+
+
+def make_qsa_extension(root: Path, torch_include: str) -> SyclExtension:
+    """Return the production FP16 packed-cache QSA extension definition."""
+
+    return SyclExtension(
+        name=QSA_EXTENSION_NAME,
+        sources=["csrc/qsa/qsa_sparse_attention.sycl"],
+        include_dirs=[root / "csrc" / "qsa"],
+        extra_compile_args={
+            "cxx": ["-O3", "-std=c++17"],
+            "sycl": [
+                "-O3",
+                "-fsycl-device-code-split=per_kernel",
+                f"-I{torch_include}",
+                *(f"-D{definition}" for definition in QSA_DEFINES),
+            ],
+        },
+        extra_link_args=["-Wl,-rpath,$ORIGIN/../../torch/lib"],
+        py_limited_api=False,
+    )

--- a/vllm/custom-esimd-kernels-vllm/qsa_build.py
+++ b/vllm/custom-esimd-kernels-vllm/qsa_build.py
@@ -28,7 +28,10 @@ def make_qsa_extension(root: Path, torch_include: str) -> SyclExtension:
 
     return SyclExtension(
         name=QSA_EXTENSION_NAME,
-        sources=["csrc/qsa/qsa_sparse_attention.sycl"],
+        sources=[
+            "csrc/qsa/qsa_sparse_attention.sycl",
+            "csrc/qsa/qsa_select_paged_tokens.sycl",
+        ],
         include_dirs=[root / "csrc" / "qsa"],
         extra_compile_args={
             "cxx": ["-O3", "-std=c++17"],

--- a/vllm/custom-esimd-kernels-vllm/setup.py
+++ b/vllm/custom-esimd-kernels-vllm/setup.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from setuptools import find_packages, setup
 from torch.utils.cpp_extension import SyclExtension
 from esimd_build_extention import BuildExtension
+from qsa_build import make_qsa_extension
 
 root = Path(__file__).parent.resolve()
 
@@ -237,6 +238,10 @@ ext_modules.append(
     )
 )
 ### Q4_0 quantize kernel
+
+### Qwen3.8 TP8-rank sparse paged attention — FP16 packed-cache ABI
+ext_modules.append(make_qsa_extension(root, torch_include))
+### Qwen3.8 QSA kernel
 
 setup(
     name="custom-esimd-kernels-vllm",

--- a/vllm/custom-esimd-kernels-vllm/setup_qsa_only.py
+++ b/vllm/custom-esimd-kernels-vllm/setup_qsa_only.py
@@ -1,0 +1,31 @@
+"""Standalone setup script that only builds the Qwen3.8 QSA extension.
+
+The target architecture intentionally comes from ``TORCH_XPU_ARCH_LIST`` so
+the focused build uses the same architecture selection as the full wheel:
+
+    TORCH_XPU_ARCH_LIST=bmg-g31 python setup_qsa_only.py build_ext --inplace
+"""
+from pathlib import Path
+
+from setuptools import find_packages, setup
+
+from esimd_build_extention import BuildExtension
+from qsa_build import make_qsa_extension
+
+
+root = Path(__file__).parent.resolve()
+
+import torch
+
+
+torch_include = str(Path(torch.__file__).parent / "include")
+
+
+setup(
+    name="custom-esimd-kernels-vllm-qsa-only",
+    version="0.1.0",
+    packages=find_packages(where="python"),
+    package_dir={"": "python"},
+    ext_modules=[make_qsa_extension(root, torch_include)],
+    cmdclass={"build_ext": BuildExtension.with_options(use_ninja=True)},
+)

--- a/vllm/custom-esimd-kernels-vllm/setup_sycl.py
+++ b/vllm/custom-esimd-kernels-vllm/setup_sycl.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from setuptools import find_packages, setup
 from torch.utils.cpp_extension import SyclExtension
 from esimd_build_extention import BuildExtension
+from qsa_build import make_qsa_extension
 
 root = Path(__file__).parent.resolve()
 
@@ -164,6 +165,10 @@ ext_modules.append(
     )
 )
 ### MoE Batch kernels
+
+### Qwen3.8 TP8-rank sparse paged attention — FP16 packed-cache ABI
+ext_modules.append(make_qsa_extension(root, torch_include))
+### Qwen3.8 QSA kernel
 
 setup(
     name="custom-esimd-kernels-vllm",

--- a/vllm/custom-esimd-kernels-vllm/tests/bench_qsa_select_paged_tokens.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/bench_qsa_select_paged_tokens.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""B/C/B latency for the fused FP16 QSA token-selection kernel."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import importlib.util
+import json
+import math
+import statistics
+import time
+from pathlib import Path
+
+import torch
+
+
+INDEX_HEADS = 4
+HEAD_DIM = 128
+PAGE_SIZE = 128
+TOKEN_TOPK = 2048
+COMPRESS_RATIO = 4
+OUTPUT_WIDTH = TOKEN_TOPK + COMPRESS_RATIO - 1
+CASES = {
+    "cross_page_tail": (518, 520),
+    "p8192_saturated_2051": (9214, 9216),
+}
+
+
+def _load_qsa_extension():
+    try:
+        return importlib.import_module("custom_esimd_kernels_vllm.qsa_ops")
+    except ImportError:
+        package_dir = (
+            Path(__file__).resolve().parents[1]
+            / "python"
+            / "custom_esimd_kernels_vllm"
+        )
+        candidates = sorted(package_dir.glob("qsa_ops*.so"))
+        if len(candidates) != 1:
+            raise
+        spec = importlib.util.spec_from_file_location("qsa_ops", candidates[0])
+        if spec is None or spec.loader is None:
+            raise ImportError(f"cannot load QSA extension: {candidates[0]}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+
+def _expand_reference(
+    blocks: torch.Tensor,
+    query_positions: torch.Tensor,
+    row_lengths: torch.Tensor,
+) -> torch.Tensor:
+    rows = blocks.shape[0]
+    offsets = torch.arange(COMPRESS_RATIO, device=blocks.device)
+    expanded = blocks.long().unsqueeze(-1) * COMPRESS_RATIO + offsets
+    expanded = torch.where(
+        blocks.unsqueeze(-1) >= 0,
+        expanded,
+        torch.full_like(expanded, -1),
+    ).reshape(rows, TOKEN_TOPK)
+    expanded = torch.where(
+        (expanded >= 0) & (expanded < row_lengths.unsqueeze(1)),
+        expanded,
+        torch.full_like(expanded, -1),
+    )
+    tail_offsets = torch.arange(COMPRESS_RATIO - 1, device=blocks.device)
+    visible_tokens = query_positions + 1
+    tail_start = visible_tokens // COMPRESS_RATIO * COMPRESS_RATIO
+    tail = tail_start.unsqueeze(1) + tail_offsets.unsqueeze(0)
+    tail_valid = (
+        tail_offsets.unsqueeze(0)
+        < (visible_tokens - tail_start).unsqueeze(1)
+    ) & (tail < row_lengths.unsqueeze(1))
+    tail = torch.where(tail_valid, tail, torch.full_like(tail, -1))
+    result = torch.cat((expanded, tail), dim=1)
+    order = torch.arange(OUTPUT_WIDTH, device=result.device).expand(rows, -1)
+    sort_key = torch.where(result >= 0, order, order + OUTPUT_WIDTH)
+    return result.gather(
+        1, torch.argsort(sort_key, dim=1, stable=True)
+    ).to(torch.int32)
+
+
+def _select_reference(
+    q: torch.Tensor,
+    cache: torch.Tensor,
+    page_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    query_positions: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+) -> torch.Tensor:
+    rows = q.shape[0]
+    selected = torch.full(
+        (rows, TOKEN_TOPK // COMPRESS_RATIO),
+        -1,
+        dtype=torch.int32,
+        device=q.device,
+    )
+    row_lengths = sequence_lengths.index_select(0, token_to_req.long())
+    visible_blocks = torch.minimum(
+        (query_positions + 1) // COMPRESS_RATIO,
+        row_lengths.long() // COMPRESS_RATIO,
+    )
+    for row in range(rows):
+        visible = int(visible_blocks[row].item())
+        width = min(visible, TOKEN_TOPK // COMPRESS_RATIO)
+        if not width:
+            continue
+        logical = torch.arange(visible, device=q.device)
+        request = int(token_to_req[row].item())
+        pages = page_table[request, logical // PAGE_SIZE].long()
+        keys = cache[pages, logical % PAGE_SIZE, 0]
+        scores = torch.relu(
+            torch.einsum("hd,nd->nh", q[row].float(), keys.float())
+        ).sum(dim=-1) * (HEAD_DIM**-0.5)
+        selected[row, :width] = torch.topk(scores, width).indices.to(
+            torch.int32
+        )
+    return _expand_reference(selected, query_positions, row_lengths.long())
+
+
+def _make_inputs(query_position: int, sequence_length: int):
+    visible_blocks = min(
+        (query_position + 1) // COMPRESS_RATIO,
+        sequence_length // COMPRESS_RATIO,
+    )
+    page_columns = max(1, math.ceil(visible_blocks / PAGE_SIZE))
+    cache = torch.randn(
+        page_columns,
+        PAGE_SIZE,
+        1,
+        HEAD_DIM,
+        dtype=torch.float16,
+        device="xpu",
+    )
+    q = torch.randn(
+        1, INDEX_HEADS, HEAD_DIM, dtype=torch.float16, device="xpu"
+    )
+    page_table = torch.arange(
+        page_columns, dtype=torch.int32, device="xpu"
+    ).view(1, page_columns)
+    token_to_req = torch.zeros(1, dtype=torch.int32, device="xpu")
+    query_positions = torch.tensor(
+        [query_position], dtype=torch.int64, device="xpu"
+    )
+    sequence_lengths = torch.tensor(
+        [sequence_length], dtype=torch.int32, device="xpu"
+    )
+    out = torch.empty(1, OUTPUT_WIDTH, dtype=torch.int32, device="xpu")
+    return (
+        q,
+        cache,
+        page_table,
+        token_to_req,
+        query_positions,
+        sequence_lengths,
+        out,
+    )
+
+
+def _measure(operation, inner: int) -> float:
+    torch.xpu.synchronize()
+    start = time.perf_counter_ns()
+    for _ in range(inner):
+        operation()
+    torch.xpu.synchronize()
+    return (time.perf_counter_ns() - start) / 1_000_000 / inner
+
+
+def _benchmark_case(module, values, warmup_units, samples, inner):
+    q, cache, page_table, token_to_req, positions, lengths, out = values
+
+    def baseline():
+        return _select_reference(
+            q, cache, page_table, token_to_req, positions, lengths
+        )
+
+    def candidate():
+        return module.qsa_select_paged_tokens(
+            q,
+            cache,
+            page_table,
+            token_to_req,
+            positions,
+            lengths,
+            TOKEN_TOPK,
+            COMPRESS_RATIO,
+            out,
+        )
+
+    with torch.inference_mode():
+        for _ in range(warmup_units):
+            _measure(baseline, inner)
+            _measure(candidate, inner)
+        before = []
+        fused = []
+        after = []
+        for _ in range(samples):
+            before.append(_measure(baseline, inner))
+            fused.append(_measure(candidate, inner))
+            after.append(_measure(baseline, inner))
+    paired_baseline = [(a + b) / 2 for a, b in zip(before, after)]
+    deltas = [
+        (candidate_ms / baseline_ms - 1) * 100
+        for candidate_ms, baseline_ms in zip(fused, paired_baseline)
+    ]
+    return {
+        "baseline_before_ms": before,
+        "candidate_ms": fused,
+        "baseline_after_ms": after,
+        "paired_baseline_mean_ms": statistics.mean(paired_baseline),
+        "candidate_mean_ms": statistics.mean(fused),
+        "paired_mean_change_percent": statistics.mean(deltas),
+        "paired_deltas_percent": deltas,
+        "candidate_wins": sum(value < 0 for value in deltas),
+        "baseline_drift_percent": (
+            statistics.mean(after) / statistics.mean(before) - 1
+        )
+        * 100,
+        "speedup": statistics.mean(paired_baseline) / statistics.mean(fused),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cases", default=",".join(CASES))
+    parser.add_argument("--warmup-units", type=int, default=5)
+    parser.add_argument("--samples", type=int, default=10)
+    parser.add_argument("--inner-iterations", type=int, default=64)
+    args = parser.parse_args()
+    if min(args.warmup_units, args.samples, args.inner_iterations) <= 0:
+        parser.error("warm-up, samples, and inner iterations must be positive")
+    selected_cases = tuple(args.cases.split(","))
+    if not selected_cases or any(case not in CASES for case in selected_cases):
+        parser.error(f"cases must be selected from {tuple(CASES)}")
+    if torch.xpu.device_count() != 1:
+        raise RuntimeError("benchmark requires exactly one visible XPU")
+    torch.manual_seed(20260828)
+    module = _load_qsa_extension()
+    results = {}
+    for case in selected_cases:
+        position, length = CASES[case]
+        inputs = _make_inputs(position, length)
+        expected = _select_reference(*inputs[:6])
+        actual = module.qsa_select_paged_tokens(
+            *inputs[:6], TOKEN_TOPK, COMPRESS_RATIO, inputs[-1]
+        )
+        torch.xpu.synchronize()
+        if not torch.equal(actual, expected):
+            raise RuntimeError(f"correctness precheck failed for {case}")
+        result = _benchmark_case(
+            module,
+            inputs,
+            args.warmup_units,
+            args.samples,
+            args.inner_iterations,
+        )
+        result.update(
+            {
+                "query_position": position,
+                "sequence_length": length,
+                "visible_blocks": min((position + 1) // 4, length // 4),
+                "valid_output_width": int((actual >= 0).sum().item()),
+            }
+        )
+        results[case] = result
+    report = {
+        "schema_version": 1,
+        "kind": "qwen38_qsa_fp16_select_bcb_microbenchmark",
+        "rows": 1,
+        "warmup_units": args.warmup_units,
+        "samples": args.samples,
+        "inner_iterations": args.inner_iterations,
+        "device": torch.xpu.get_device_name(0),
+        "torch": torch.__version__,
+        "results": results,
+        "claim_boundary": (
+            "rank-local Torch reference versus fused kernel; not TP8 E2E"
+        ),
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/custom-esimd-kernels-vllm/tests/bench_qsa_sparse_attention.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/bench_qsa_sparse_attention.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Steady single-row latency for the FP16 exact-packed QSA kernel."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import importlib.util
+import json
+import statistics
+import time
+from pathlib import Path
+
+import torch
+
+
+HEADS = 3
+HEAD_DIM = 256
+PAGE_SIZE = 512
+INDEX_WIDTH = 2051
+
+
+def _load_qsa_extension():
+    try:
+        return importlib.import_module("custom_esimd_kernels_vllm.qsa_ops")
+    except ImportError:
+        package_dir = (
+            Path(__file__).resolve().parents[1]
+            / "python"
+            / "custom_esimd_kernels_vllm"
+        )
+        candidates = sorted(package_dir.glob("qsa_ops*.so"))
+        if len(candidates) != 1:
+            raise
+        spec = importlib.util.spec_from_file_location("qsa_ops", candidates[0])
+        if spec is None or spec.loader is None:
+            raise ImportError(f"cannot load QSA extension: {candidates[0]}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+
+def _canonicalize_singleton_dim_strides(tensor: torch.Tensor) -> torch.Tensor:
+    strides = list(tensor.stride())
+    previous_stride = 1
+    changed = False
+    for dim in range(tensor.dim() - 1, -1, -1):
+        if tensor.shape[dim] == 1 and strides[dim] != previous_stride:
+            strides[dim] = previous_stride
+            changed = True
+        previous_stride = strides[dim] * tensor.shape[dim]
+    return tensor.as_strided(tensor.shape, strides) if changed else tensor
+
+
+def _make_inputs(valid_width: int):
+    if not 0 <= valid_width <= INDEX_WIDTH:
+        raise ValueError(f"valid width must be in [0,{INDEX_WIDTH}]")
+    pages = 5
+    packed_kv = torch.randn(
+        pages,
+        1,
+        PAGE_SIZE,
+        2 * HEAD_DIM,
+        dtype=torch.float16,
+        device="xpu",
+    )
+    k_cache, v_cache = packed_kv.transpose(1, 2).split(HEAD_DIM, dim=-1)
+    k_cache = _canonicalize_singleton_dim_strides(k_cache)
+    v_cache = _canonicalize_singleton_dim_strides(v_cache)
+    q = 0.1 * torch.randn(
+        1, HEADS, HEAD_DIM, dtype=torch.float16, device="xpu"
+    )
+    logical = torch.full(
+        (1, INDEX_WIDTH), -1, dtype=torch.int32, device="xpu"
+    )
+    logical[:, :valid_width] = torch.arange(
+        valid_width, dtype=torch.int32, device="xpu"
+    )
+    block_table = torch.arange(
+        pages, dtype=torch.int32, device="xpu"
+    ).view(1, pages)
+    token_to_req = torch.zeros(1, dtype=torch.int32, device="xpu")
+    out = torch.empty_like(q)
+    return q, k_cache, v_cache, logical, block_table, token_to_req, out
+
+
+def _measure(module, args, warmup_units: int, samples: int, inner: int):
+    def operation():
+        return module.sparse_paged_attention(*args)
+
+    with torch.inference_mode():
+        for _ in range(warmup_units):
+            for _ in range(inner):
+                operation()
+            torch.xpu.synchronize()
+        samples_ms = []
+        for _ in range(samples):
+            torch.xpu.synchronize()
+            start = time.perf_counter_ns()
+            for _ in range(inner):
+                operation()
+            torch.xpu.synchronize()
+            samples_ms.append(
+                (time.perf_counter_ns() - start) / 1_000_000 / inner
+            )
+    return samples_ms
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--valid-widths", default="32,1024,2051")
+    parser.add_argument("--warmup-units", type=int, default=5)
+    parser.add_argument("--samples", type=int, default=10)
+    parser.add_argument("--inner-iterations", type=int, default=128)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    if min(args.warmup_units, args.samples, args.inner_iterations) <= 0:
+        parser.error("warm-up, samples, and inner iterations must be positive")
+    widths = tuple(int(value) for value in args.valid_widths.split(","))
+    if torch.xpu.device_count() != 1:
+        raise RuntimeError("benchmark requires exactly one visible XPU")
+
+    torch.manual_seed(20260828)
+    module = _load_qsa_extension()
+    results = []
+    for width in widths:
+        inputs = _make_inputs(width)
+        samples_ms = _measure(
+            module,
+            inputs,
+            args.warmup_units,
+            args.samples,
+            args.inner_iterations,
+        )
+        results.append(
+            {
+                "valid_width": width,
+                "mean_ms": statistics.mean(samples_ms),
+                "samples_ms": samples_ms,
+            }
+        )
+    report = {
+        "schema_version": 1,
+        "kind": "qwen38_qsa_fp16_exact_packed_r1_microbenchmark",
+        "rows": 1,
+        "warmup_units": args.warmup_units,
+        "samples": args.samples,
+        "inner_iterations": args.inner_iterations,
+        "device": torch.xpu.get_device_name(0),
+        "torch": torch.__version__,
+        "results": results,
+        "claim_boundary": "single-kernel rank-local latency; not TP8 E2E",
+    }
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/custom-esimd-kernels-vllm/tests/test_qsa_build_config.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/test_qsa_build_config.py
@@ -4,7 +4,11 @@ import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from qsa_build import QSA_DEFINES, QSA_EXTENSION_NAME  # noqa: E402
+from qsa_build import (  # noqa: E402
+    QSA_DEFINES,
+    QSA_EXTENSION_NAME,
+    make_qsa_extension,
+)
 
 
 def test_qsa_extension_name_is_stable():
@@ -27,3 +31,13 @@ def test_qsa_build_matches_validated_fp16_packed_contract():
         "QSA_NATIVE_BLOCK_SOFTMAX=0",
         "QSA_NATIVE_FAST_EXP=1",
     }
+
+
+def test_qsa_build_contains_attention_and_selection_sources():
+    root = Path(__file__).resolve().parents[1]
+    extension = make_qsa_extension(root, "/torch/include")
+
+    assert extension.sources == [
+        "csrc/qsa/qsa_sparse_attention.sycl",
+        "csrc/qsa/qsa_select_paged_tokens.sycl",
+    ]

--- a/vllm/custom-esimd-kernels-vllm/tests/test_qsa_build_config.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/test_qsa_build_config.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+import sys
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from qsa_build import QSA_DEFINES, QSA_EXTENSION_NAME  # noqa: E402
+
+
+def test_qsa_extension_name_is_stable():
+    assert QSA_EXTENSION_NAME == "custom_esimd_kernels_vllm.qsa_ops"
+
+
+def test_qsa_build_matches_validated_fp16_packed_contract():
+    assert set(QSA_DEFINES) == {
+        "QSA_NATIVE_ACTIVATION_FP16=1",
+        "QSA_NATIVE_EXACT_PACKED_CACHE=1",
+        "QSA_NATIVE_KV_TILE=4",
+        "QSA_NATIVE_SUBGROUP=32",
+        "QSA_NATIVE_TOKEN_LOADER=1",
+        "QSA_NATIVE_TRIM_VALID_WIDTH=1",
+        "QSA_NATIVE_PACKED_KV=1",
+        "QSA_NATIVE_PIPELINED_LOADER=0",
+        "QSA_NATIVE_STAGE_VALIDITY=0",
+        "QSA_NATIVE_BOUNDED_SCAN=0",
+        "QSA_NATIVE_SINGLE_EXP=0",
+        "QSA_NATIVE_BLOCK_SOFTMAX=0",
+        "QSA_NATIVE_FAST_EXP=1",
+    }

--- a/vllm/custom-esimd-kernels-vllm/tests/test_qsa_select_paged_tokens_xpu.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/test_qsa_select_paged_tokens_xpu.py
@@ -1,0 +1,258 @@
+"""Correctness checks for fused Qwen3.8 QSA index selection on XPU."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+from pathlib import Path
+
+import pytest
+import torch
+
+
+INDEX_HEADS = 4
+HEAD_DIM = 128
+PAGE_SIZE = 128
+TOKEN_TOPK = 2048
+COMPRESS_RATIO = 4
+OUTPUT_WIDTH = TOKEN_TOPK + COMPRESS_RATIO - 1
+
+
+def _xpu_available() -> bool:
+    try:
+        return torch.xpu.is_available() and torch.xpu.device_count() > 0
+    except RuntimeError:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _xpu_available(), reason="QSA selection validation requires an XPU"
+)
+
+
+def _load_qsa_extension():
+    try:
+        return importlib.import_module("custom_esimd_kernels_vllm.qsa_ops")
+    except ImportError:
+        package_dir = (
+            Path(__file__).resolve().parents[1]
+            / "python"
+            / "custom_esimd_kernels_vllm"
+        )
+        candidates = sorted(package_dir.glob("qsa_ops*.so"))
+        if len(candidates) != 1:
+            raise
+        spec = importlib.util.spec_from_file_location("qsa_ops", candidates[0])
+        if spec is None or spec.loader is None:
+            raise ImportError(f"cannot load QSA extension: {candidates[0]}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+
+@pytest.fixture(scope="module")
+def qsa_ops():
+    return _load_qsa_extension()
+
+
+def _expand_reference(
+    blocks: torch.Tensor,
+    query_positions: torch.Tensor,
+    row_lengths: torch.Tensor,
+) -> torch.Tensor:
+    rows = blocks.shape[0]
+    offsets = torch.arange(COMPRESS_RATIO, device=blocks.device)
+    expanded = blocks.long().unsqueeze(-1) * COMPRESS_RATIO + offsets
+    expanded = torch.where(
+        blocks.unsqueeze(-1) >= 0,
+        expanded,
+        torch.full_like(expanded, -1),
+    ).reshape(rows, TOKEN_TOPK)
+    expanded = torch.where(
+        (expanded >= 0) & (expanded < row_lengths.unsqueeze(1)),
+        expanded,
+        torch.full_like(expanded, -1),
+    )
+
+    tail_offsets = torch.arange(COMPRESS_RATIO - 1, device=blocks.device)
+    visible_tokens = query_positions + 1
+    tail_start = visible_tokens // COMPRESS_RATIO * COMPRESS_RATIO
+    tail = tail_start.unsqueeze(1) + tail_offsets.unsqueeze(0)
+    tail_valid = (
+        tail_offsets.unsqueeze(0)
+        < (visible_tokens - tail_start).unsqueeze(1)
+    ) & (tail < row_lengths.unsqueeze(1))
+    tail = torch.where(tail_valid, tail, torch.full_like(tail, -1))
+
+    result = torch.cat((expanded, tail), dim=1)
+    order = torch.arange(OUTPUT_WIDTH, device=result.device).expand(rows, -1)
+    sort_key = torch.where(result >= 0, order, order + OUTPUT_WIDTH)
+    return result.gather(
+        1, torch.argsort(sort_key, dim=1, stable=True)
+    ).to(torch.int32)
+
+
+def _select_reference(
+    q: torch.Tensor,
+    cache: torch.Tensor,
+    page_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    query_positions: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+) -> torch.Tensor:
+    rows = q.shape[0]
+    selected = torch.full(
+        (rows, TOKEN_TOPK // COMPRESS_RATIO),
+        -1,
+        dtype=torch.int32,
+        device=q.device,
+    )
+    row_lengths = sequence_lengths.index_select(0, token_to_req.long())
+    visible_blocks = torch.minimum(
+        (query_positions + 1) // COMPRESS_RATIO,
+        row_lengths.long() // COMPRESS_RATIO,
+    )
+    for row in range(rows):
+        visible = int(visible_blocks[row].item())
+        width = min(visible, TOKEN_TOPK // COMPRESS_RATIO)
+        if not width:
+            continue
+        logical = torch.arange(visible, device=q.device)
+        request = int(token_to_req[row].item())
+        pages = page_table[request, logical // PAGE_SIZE].long()
+        keys = cache[pages, logical % PAGE_SIZE, 0]
+        scores = torch.relu(
+            torch.einsum("hd,nd->nh", q[row].float(), keys.float())
+        ).sum(dim=-1) * (HEAD_DIM**-0.5)
+        selected[row, :width] = torch.topk(scores, width).indices.to(
+            torch.int32
+        )
+    return _expand_reference(selected, query_positions, row_lengths.long())
+
+
+def _case_metadata(case: str):
+    if case == "empty_sequence":
+        return [-1], [0], [0], False
+    if case == "short_tail":
+        return [2], [3], [0], False
+    if case == "full_page":
+        return [511], [512], [0], False
+    if case == "cross_page_tail":
+        return [518], [520], [0], False
+    if case == "p8192_saturated_2051":
+        return [9214], [9216], [0], False
+    if case == "exact_score_ties":
+        return [2079], [2080], [0], True
+    if case == "duplicate_physical_pages":
+        return [1027], [1028], [0], False
+    if case == "multi_request":
+        return [2, 518, 8192, 9214], [520, 9216], [0, 0, 1, 1], False
+    raise ValueError(case)
+
+
+def _make_inputs(case: str):
+    positions, sequence_lengths, requests, zero_query = _case_metadata(case)
+    rows = len(positions)
+    num_requests = len(sequence_lengths)
+    page_columns = max(
+        1,
+        max(length // COMPRESS_RATIO for length in sequence_lengths)
+        // PAGE_SIZE
+        + 1,
+    )
+    physical_pages = num_requests * page_columns
+    page_table = torch.arange(
+        physical_pages, dtype=torch.int32, device="xpu"
+    ).view(num_requests, page_columns)
+    if num_requests > 1:
+        page_table[1] = page_table[1].flip(0)
+    if case == "duplicate_physical_pages":
+        page_table[:, 1::2] = page_table[:, :1]
+    cache = torch.randn(
+        physical_pages,
+        PAGE_SIZE,
+        1,
+        HEAD_DIM,
+        dtype=torch.float16,
+        device="xpu",
+    )
+    q = torch.randn(
+        rows,
+        INDEX_HEADS,
+        HEAD_DIM,
+        dtype=torch.float16,
+        device="xpu",
+    )
+    if zero_query:
+        q.zero_()
+    token_to_req = torch.tensor(requests, dtype=torch.int32, device="xpu")
+    query_positions = torch.tensor(
+        positions, dtype=torch.int64, device="xpu"
+    )
+    seq_lens = torch.tensor(
+        sequence_lengths, dtype=torch.int32, device="xpu"
+    )
+    out = torch.empty(
+        rows, OUTPUT_WIDTH, dtype=torch.int32, device="xpu"
+    )
+    return (
+        q,
+        cache,
+        page_table,
+        token_to_req,
+        query_positions,
+        seq_lens,
+        TOKEN_TOPK,
+        COMPRESS_RATIO,
+        out,
+    )
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "empty_sequence",
+        "short_tail",
+        "full_page",
+        "cross_page_tail",
+        "p8192_saturated_2051",
+        "exact_score_ties",
+        "duplicate_physical_pages",
+        "multi_request",
+    ],
+)
+def test_qsa_select_matches_reference(qsa_ops, case):
+    torch.manual_seed(20260828)
+    args = _make_inputs(case)
+    tensor_inputs = [value for value in args if isinstance(value, torch.Tensor)]
+    snapshots = [value.clone() for value in tensor_inputs[:-1]]
+    expected = _select_reference(*args[:6])
+
+    returned = qsa_ops.qsa_select_paged_tokens(*args)
+    torch.xpu.synchronize()
+
+    assert returned.data_ptr() == args[-1].data_ptr()
+    assert returned.dtype == torch.int32
+    assert returned.shape == (args[0].shape[0], OUTPUT_WIDTH)
+    assert torch.equal(returned, expected)
+    for actual, snapshot in zip(tensor_inputs[:-1], snapshots):
+        assert torch.equal(actual, snapshot)
+    for row in returned:
+        valid = row >= 0
+        valid_count = int(valid.sum().item())
+        assert torch.all(valid[:valid_count])
+        assert not torch.any(valid[valid_count:])
+
+
+def test_qsa_select_rejects_bf16(qsa_ops):
+    args = list(_make_inputs("short_tail"))
+    args[0] = args[0].to(torch.bfloat16)
+    with pytest.raises(RuntimeError, match="q must be float16"):
+        qsa_ops.qsa_select_paged_tokens(*args)
+
+
+def test_qsa_select_rejects_wrong_output_width(qsa_ops):
+    args = list(_make_inputs("short_tail"))
+    args[-1] = torch.empty(1, 2048, dtype=torch.int32, device="xpu")
+    with pytest.raises(RuntimeError, match="out must have shape"):
+        qsa_ops.qsa_select_paged_tokens(*args)

--- a/vllm/custom-esimd-kernels-vllm/tests/test_qsa_sparse_attention_xpu.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/test_qsa_sparse_attention_xpu.py
@@ -10,7 +10,6 @@ import pytest
 import torch
 
 
-ROWS = 2
 HEADS = 3
 HEAD_DIM = 256
 PAGE_SIZE = 512
@@ -68,9 +67,9 @@ def _canonicalize_singleton_dim_strides(tensor: torch.Tensor) -> torch.Tensor:
     return tensor.as_strided(tensor.shape, strides) if changed else tensor
 
 
-def _make_inputs(case: str):
+def _make_inputs(case: str, rows: int):
     pages_per_request = 5
-    pages = ROWS * pages_per_request
+    pages = rows * pages_per_request
     packed_kv = torch.randn(
         pages,
         1,
@@ -83,15 +82,15 @@ def _make_inputs(case: str):
     k_cache = _canonicalize_singleton_dim_strides(k_cache)
     v_cache = _canonicalize_singleton_dim_strides(v_cache)
     q = 0.1 * torch.randn(
-        ROWS, HEADS, HEAD_DIM, dtype=torch.float16, device="xpu"
+        rows, HEADS, HEAD_DIM, dtype=torch.float16, device="xpu"
     )
     logical_indices = torch.full(
-        (ROWS, INDEX_WIDTH), -1, dtype=torch.int32, device="xpu"
+        (rows, INDEX_WIDTH), -1, dtype=torch.int32, device="xpu"
     )
     block_table = torch.arange(
         pages, dtype=torch.int32, device="xpu"
-    ).view(ROWS, pages_per_request)
-    token_to_req = torch.arange(ROWS, dtype=torch.int32, device="xpu")
+    ).view(rows, pages_per_request)
+    token_to_req = torch.arange(rows, dtype=torch.int32, device="xpu")
 
     if case == "empty":
         pass
@@ -101,7 +100,7 @@ def _make_inputs(case: str):
             dtype=torch.int32,
             device="xpu",
         )
-        for row in range(ROWS):
+        for row in range(rows):
             logical_indices[row, : values.numel()] = torch.roll(values, row)
     elif case == "valid_width_32":
         logical_indices[:, :32] = torch.arange(
@@ -158,15 +157,17 @@ def test_qsa_module_contract(qsa_ops):
     assert qsa_ops.trim_valid_width == 1
     assert qsa_ops.packed_kv == 1
     assert qsa_ops.fast_exp == 1
+    assert qsa_ops.selection_output_width == INDEX_WIDTH
 
 
 @pytest.mark.parametrize(
     "case",
     ["empty", "holes_duplicates_pages", "valid_width_32", "full_width_2051"],
 )
-def test_qsa_matches_reference_and_preserves_inputs(qsa_ops, case):
+@pytest.mark.parametrize("rows", [1, 2])
+def test_qsa_matches_reference_and_preserves_inputs(qsa_ops, case, rows):
     torch.manual_seed(20260828)
-    args = list(_make_inputs(case))
+    args = list(_make_inputs(case, rows))
     packed_kv = args.pop()
     q, _, _, logical_indices, block_table, token_to_req, out = args
     snapshots = [
@@ -181,6 +182,13 @@ def test_qsa_matches_reference_and_preserves_inputs(qsa_ops, case):
     returned = qsa_ops.sparse_paged_attention(*args)
     torch.xpu.synchronize()
 
+    assert q.dtype == torch.float16
+    assert args[1].dtype == torch.float16
+    assert args[2].dtype == torch.float16
+    assert out.dtype == torch.float16
+    assert tuple(args[1].stride()) == PACKED_STRIDE
+    assert tuple(args[2].stride()) == PACKED_STRIDE
+    assert args[2].storage_offset() == HEAD_DIM
     assert returned.data_ptr() == out.data_ptr()
     assert torch.isfinite(returned).all()
     assert torch.allclose(
@@ -193,14 +201,14 @@ def test_qsa_matches_reference_and_preserves_inputs(qsa_ops, case):
 
 
 def test_qsa_rejects_bf16_query(qsa_ops):
-    args = list(_make_inputs("valid_width_32")[:-1])
+    args = list(_make_inputs("valid_width_32", 1)[:-1])
     args[0] = args[0].to(torch.bfloat16)
     with pytest.raises(RuntimeError, match="q must be float16"):
         qsa_ops.sparse_paged_attention(*args)
 
 
 def test_qsa_rejects_nonpacked_cache(qsa_ops):
-    args = list(_make_inputs("valid_width_32")[:-1])
+    args = list(_make_inputs("valid_width_32", 1)[:-1])
     args[1] = args[1].contiguous()
     args[2] = args[2].contiguous()
     with pytest.raises(RuntimeError, match="must have exact packed strides"):

--- a/vllm/custom-esimd-kernels-vllm/tests/test_qsa_sparse_attention_xpu.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/test_qsa_sparse_attention_xpu.py
@@ -1,0 +1,207 @@
+"""Correctness checks for the fixed-contract Qwen3.8 QSA XPU extension."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+from pathlib import Path
+
+import pytest
+import torch
+
+
+ROWS = 2
+HEADS = 3
+HEAD_DIM = 256
+PAGE_SIZE = 512
+INDEX_WIDTH = 2051
+PACKED_STRIDE = (262144, 512, 256, 1)
+
+
+def _xpu_available() -> bool:
+    try:
+        return torch.xpu.is_available() and torch.xpu.device_count() > 0
+    except RuntimeError:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _xpu_available(), reason="QSA validation requires an XPU"
+)
+
+
+def _load_qsa_extension():
+    try:
+        return importlib.import_module("custom_esimd_kernels_vllm.qsa_ops")
+    except ImportError:
+        # Focused in-place builds may not contain the package's other modules.
+        package_dir = (
+            Path(__file__).resolve().parents[1]
+            / "python"
+            / "custom_esimd_kernels_vllm"
+        )
+        candidates = sorted(package_dir.glob("qsa_ops*.so"))
+        if len(candidates) != 1:
+            raise
+        spec = importlib.util.spec_from_file_location("qsa_ops", candidates[0])
+        if spec is None or spec.loader is None:
+            raise ImportError(f"cannot load QSA extension: {candidates[0]}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+
+@pytest.fixture(scope="module")
+def qsa_ops():
+    return _load_qsa_extension()
+
+
+def _canonicalize_singleton_dim_strides(tensor: torch.Tensor) -> torch.Tensor:
+    strides = list(tensor.stride())
+    previous_stride = 1
+    changed = False
+    for dim in range(tensor.dim() - 1, -1, -1):
+        if tensor.shape[dim] == 1 and strides[dim] != previous_stride:
+            strides[dim] = previous_stride
+            changed = True
+        previous_stride = strides[dim] * tensor.shape[dim]
+    return tensor.as_strided(tensor.shape, strides) if changed else tensor
+
+
+def _make_inputs(case: str):
+    pages_per_request = 5
+    pages = ROWS * pages_per_request
+    packed_kv = torch.randn(
+        pages,
+        1,
+        PAGE_SIZE,
+        2 * HEAD_DIM,
+        dtype=torch.float16,
+        device="xpu",
+    )
+    k_cache, v_cache = packed_kv.transpose(1, 2).split(HEAD_DIM, dim=-1)
+    k_cache = _canonicalize_singleton_dim_strides(k_cache)
+    v_cache = _canonicalize_singleton_dim_strides(v_cache)
+    q = 0.1 * torch.randn(
+        ROWS, HEADS, HEAD_DIM, dtype=torch.float16, device="xpu"
+    )
+    logical_indices = torch.full(
+        (ROWS, INDEX_WIDTH), -1, dtype=torch.int32, device="xpu"
+    )
+    block_table = torch.arange(
+        pages, dtype=torch.int32, device="xpu"
+    ).view(ROWS, pages_per_request)
+    token_to_req = torch.arange(ROWS, dtype=torch.int32, device="xpu")
+
+    if case == "empty":
+        pass
+    elif case == "holes_duplicates_pages":
+        values = torch.tensor(
+            [0, 511, -1, 512, 513, 512, -1, 1023, 1024, 1535],
+            dtype=torch.int32,
+            device="xpu",
+        )
+        for row in range(ROWS):
+            logical_indices[row, : values.numel()] = torch.roll(values, row)
+    elif case == "valid_width_32":
+        logical_indices[:, :32] = torch.arange(
+            32, dtype=torch.int32, device="xpu"
+        )
+    elif case == "full_width_2051":
+        logical_indices[:] = torch.arange(
+            INDEX_WIDTH, dtype=torch.int32, device="xpu"
+        )
+    else:
+        raise ValueError(case)
+
+    assert tuple(k_cache.stride()) == PACKED_STRIDE
+    assert tuple(v_cache.stride()) == PACKED_STRIDE
+    assert v_cache.storage_offset() == HEAD_DIM
+    return (
+        q,
+        k_cache,
+        v_cache,
+        logical_indices,
+        block_table,
+        token_to_req,
+        torch.empty_like(q),
+        packed_kv,
+    )
+
+
+def _reference(q, k_cache, v_cache, logical_indices, block_table, token_to_req):
+    output = torch.zeros_like(q)
+    for row in range(q.shape[0]):
+        logical = logical_indices[row]
+        logical = logical[logical >= 0].long()
+        if logical.numel() == 0:
+            continue
+        request = int(token_to_req[row].item())
+        pages = block_table[request, logical // PAGE_SIZE].long()
+        offsets = logical % PAGE_SIZE
+        keys = k_cache[pages, offsets, 0]
+        values = v_cache[pages, offsets, 0]
+        scores = torch.einsum("hd,kd->hk", q[row].float(), keys.float())
+        probabilities = torch.softmax(scores * (HEAD_DIM**-0.5), dim=-1)
+        output[row] = torch.einsum(
+            "hk,kd->hd", probabilities, values.float()
+        ).to(q.dtype)
+    return output
+
+
+def test_qsa_module_contract(qsa_ops):
+    assert qsa_ops.activation_dtype == "float16"
+    assert qsa_ops.exact_packed_cache == 1
+    assert qsa_ops.kv_tile == 4
+    assert qsa_ops.subgroup == 32
+    assert qsa_ops.token_loader == 1
+    assert qsa_ops.trim_valid_width == 1
+    assert qsa_ops.packed_kv == 1
+    assert qsa_ops.fast_exp == 1
+
+
+@pytest.mark.parametrize(
+    "case",
+    ["empty", "holes_duplicates_pages", "valid_width_32", "full_width_2051"],
+)
+def test_qsa_matches_reference_and_preserves_inputs(qsa_ops, case):
+    torch.manual_seed(20260828)
+    args = list(_make_inputs(case))
+    packed_kv = args.pop()
+    q, _, _, logical_indices, block_table, token_to_req, out = args
+    snapshots = [
+        q.clone(),
+        packed_kv.clone(),
+        logical_indices.clone(),
+        block_table.clone(),
+        token_to_req.clone(),
+    ]
+    expected = _reference(*args[:6])
+
+    returned = qsa_ops.sparse_paged_attention(*args)
+    torch.xpu.synchronize()
+
+    assert returned.data_ptr() == out.data_ptr()
+    assert torch.isfinite(returned).all()
+    assert torch.allclose(
+        returned.float(), expected.float(), atol=2e-2, rtol=2e-2
+    )
+    for actual, snapshot in zip(
+        [q, packed_kv, logical_indices, block_table, token_to_req], snapshots
+    ):
+        assert torch.equal(actual, snapshot)
+
+
+def test_qsa_rejects_bf16_query(qsa_ops):
+    args = list(_make_inputs("valid_width_32")[:-1])
+    args[0] = args[0].to(torch.bfloat16)
+    with pytest.raises(RuntimeError, match="q must be float16"):
+        qsa_ops.sparse_paged_attention(*args)
+
+
+def test_qsa_rejects_nonpacked_cache(qsa_ops):
+    args = list(_make_inputs("valid_width_32")[:-1])
+    args[1] = args[1].contiguous()
+    args[2] = args[2].contiguous()
+    with pytest.raises(RuntimeError, match="must have exact packed strides"):
+        qsa_ops.sparse_paged_attention(*args)


### PR DESCRIPTION
## Summary

- add `custom_esimd_kernels_vllm.qsa_ops` as a standalone SYCL extension for the fixed Qwen3.8 TP8-rank sparse paged-attention contract
- retain the validated FP16 exact-packed T4/SG32 attention kernel and add explicit `R=1` coverage
- add a fused FP16 `qsa_select_paged_tokens(...)` XPU kernel that reads paged compressed keys, computes four-head `ReLU(Q*K)` scores, performs streaming top-512 selection, expands blocks to 2,048 tokens, appends the three-token tail, and writes caller-owned `[R,2051]` int32 output without per-row `.item()`/CPU synchronization
- build attention and selection into the same `qsa_ops` extension from the regular `setup.py`/`setup_sycl.py` paths and the focused `setup_qsa_only.py` iteration path
- add focused build, correctness, latency, B/C/B, and targeted-profiler coverage

The initial imported attention source SHA256 is `f1e3ad106cff2c01232e9ac90565f1decbe4804af97fbbf8967de065e145d1ad`. The current PR head is `87a31a5e340d3b73c89a7ec80a850536f6659b61`.

## Exact contracts

Attention:

- FP16 Q/output `[R,3,256]`
- FP16 K/V exact-packed stride `[262144,512,256,1]`
- V `storage_offset=256`
- logical indices `[R,2051]` int32, including holes and duplicates
- caller-owned output; inputs remain unchanged

Selection:

- FP16 Q `[R,4,128]`
- FP16 compressed-key cache `[P,128,1,128]`
- int32 page table/token-to-request/sequence lengths; int64 query positions
- fixed `token_topk=2048`, `compress_ratio=4`, caller-owned `[R,2051]` int32 output padded with `-1`
- descending score order with ascending logical-index order for exact ties

## Validation

- `python -m pytest -q tests/test_qsa_build_config.py`: 3 passed
- `TORCH_XPU_ARCH_LIST=bmg-g31 MAX_JOBS=1 python setup_qsa_only.py build_ext --inplace`: passed; built DSO SHA256 `6a4c25705f4ebc19dc22c6e5b89f8016b89f2d099cecc547639feea95ed71cc3`
- XPU1-only attention + selection suite: 21 passed
  - attention: `R=[1,2]` across empty, holes/duplicates/cross-page, valid width 32, and full width 2051, plus fail-closed dtype/layout checks
  - selection: empty, short tail, full page, cross-page tail, duplicate physical-page mapping, exact-score ties, P8192 saturated width 2051, and multi-request, plus fail-closed dtype/output checks
- `git diff --check`: passed

R=1 attention latency uses five excluded warm-up units, 10 samples, and 128 calls per measurement unit:

| valid width | mean latency |
| ---: | ---: |
| 32 | 0.014193 ms |
| 1024 | 0.355889 ms |
| 2051 | 0.710274 ms |

R=1 selection B/C/B uses five excluded warm-up units, 10 pairs, and 64 calls per measurement unit:

| case | Torch reference | fused | speedup | wins | baseline drift |
| --- | ---: | ---: | ---: | ---: | ---: |
| cross-page tail, 129 visible blocks / 519 valid tokens | 0.834475 ms | 0.053155 ms | 15.70x | 10/10 | -0.064% |
| P8192 saturated, 2303 visible blocks / 2051 valid tokens | 0.862417 ms | 0.319464 ms | 2.70x | 10/10 | +0.271% |

A one-call targeted profiler capture for the P8192 `R=1` case observed 109 XPU events and 1,221 CPU events for the Torch reference, including two device-to-host copies. The fused path observed one XPU event, `QsaSelectPagedTokensKernel`, and 209 CPU profiler events. This is a rank-local targeted trace, not a vLLM E2E trace.

## Scope and remaining gates

The current public `vllm_for_multi_arc.patch` does not yet contain the Qwen3.8 QSA caller, so this PR exposes the formal extension ABI for subsequent integration. It does not claim TP8 serving/E2E performance.

A full bdist wheel, BMG-g21 build, vLLM source-overlay E2E, TP8 GSM8K strict gate, public package validation, and focused image validation were intentionally not run on this host because the required E2E environment is unavailable. The package version remains `0.1.0`.

## Follow-up TODO

- consider removing the single-purpose `qsa_build.py` helper and inlining the QSA `SyclExtension` definition into the existing setup scripts to match the current repository style
- keep the compiled `qsa_ops` extension standalone unless a later change deliberately splits the kernel from its pybind module and integrates the binding into the core extension
- preserve one authoritative set of validated FP16 exact-packed build macros when performing that refactor
