### PR TITLE
docker: upgrade production vLLM image to 0.26.0

### DIFF
--- a/vllm/docker/Dockerfile
+++ b/vllm/docker/Dockerfile
@@ -13,7 +13,7 @@
 # Why: vLLM v0.26.0 requires separately built Rust extensions, while an Intel
 # PyTorch 2.12 runtime image is not available.  OMIX provides the required GPU
 # runtime, and the final stage installs torch 2.12.0+xpu into an isolated venv.
-# Build outputs still cross stage boundaries only as source trees and wheels.
+# Build outputs cross stage boundaries only as Rust artifacts, source trees, and wheels.
 #
 # Scope ("lean core"): vLLM + custom ESIMD kernels + vllm-xpu-kernels + core serving
 # deps + bigdl-core (ships vllm_int4_for_multi_arc.so used by the sym_int4 path).

--- a/vllm/docker/Dockerfile
+++ b/vllm/docker/Dockerfile
@@ -30,12 +30,17 @@ FROM ubuntu:24.04 AS rust-build
 ARG VLLM_VERSION=v0.26.0
 
 ENV DEBIAN_FRONTEND=noninteractive \
-    CARGO_BUILD_JOBS=4
+    CARGO_BUILD_JOBS=4 \
+    VIRTUAL_ENV=/opt/rust-venv \
+    PATH="/opt/rust-venv/bin:${PATH}"
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
-        ca-certificates curl git build-essential unzip python3 python3-pip && \
+        ca-certificates curl git build-essential unzip \
+        python3 python3-pip python3-venv && \
     rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m venv ${VIRTUAL_ENV}
 
 RUN git clone --depth 1 --branch "${VLLM_VERSION}" \
         https://github.com/vllm-project/vllm.git /workspace/vllm

--- a/vllm/docker/Dockerfile
+++ b/vllm/docker/Dockerfile
@@ -3,7 +3,7 @@
 #
 # Three-stage OMIX build of llm-scaler-vllm (Intel XPU).
 #
-#   rust-build : ubuntu:22.04                         -- builds vLLM Rust extensions.
+#   rust-build : ubuntu:24.04                         -- builds vLLM Rust extensions.
 #   builder    : intel/omix:0.1.0-devel-ubuntu24.04  -- oneAPI 2025.3 DPC++ compiler
 #                                                         + oneCCL/oneDNN/oneMKL.  Compiles
 #                                                         all native wheels.  NOT shipped.
@@ -25,7 +25,7 @@
 # =========================================================================
 # Stage 1: rust-build -- compile vLLM Rust extensions
 # =========================================================================
-FROM ubuntu:22.04 AS rust-build
+FROM ubuntu:24.04 AS rust-build
 
 ARG VLLM_VERSION=v0.26.0
 

--- a/vllm/docker/Dockerfile
+++ b/vllm/docker/Dockerfile
@@ -58,7 +58,7 @@ ARG http_proxy
 ARG https_proxy
 ARG no_proxy
 ARG VLLM_VERSION=v0.26.0
-# vllm-xpu-kernels pinned base commit (identical to legacy build).
+# vllm-xpu-kernels pinned base commit (aligned with Dockerfile.dev).
 ARG VLLM_XPU_KERNELS_COMMIT=a6929869587fa6c40dbe393eedc96eeab076bfbb
 
 ENV VIRTUAL_ENV=/opt/buildenv \

--- a/vllm/docker/Dockerfile
+++ b/vllm/docker/Dockerfile
@@ -1,36 +1,65 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
-# Multi-stage OMIX build of llm-scaler-vllm (Intel XPU).
+# Three-stage OMIX build of llm-scaler-vllm (Intel XPU).
 #
-#   builder : intel/omix:0.1.0-devel-ubuntu24.04    -- oneAPI 2025.3 DPC++ compiler
-#                                                       + oneCCL/oneDNN/oneMKL.  Compiles
-#                                                       all native wheels.  NOT shipped.
-#   runtime : intel/pytorch:xpu-2.11.0-ubuntu24.04  -- torch 2.11.0+xpu + GPU UMD driver
-#                                                       in /opt/venv.  No compiler.  Shipped.
+#   rust-build : ubuntu:22.04                         -- builds vLLM Rust extensions.
+#   builder    : intel/omix:0.1.0-devel-ubuntu24.04  -- oneAPI 2025.3 DPC++ compiler
+#                                                         + oneCCL/oneDNN/oneMKL.  Compiles
+#                                                         all native wheels.  NOT shipped.
+#   runtime    : intel/omix:0.1.0-devel-ubuntu24.04  -- torch 2.12.0+xpu + GPU UMD driver
+#                                                         in /opt/venv.  Shipped.
 #
-# Why: the legacy single-base build (llm-scaler-platform) carried the whole oneAPI
-# toolchain into the final image (~25-34GB).  Here the compiler lives only in the
-# builder stage; the runtime stage receives pre-built wheels, so the shipped image
-# is much smaller.
+# Why: vLLM v0.26.0 requires separately built Rust extensions, while an Intel
+# PyTorch 2.12 runtime image is not available.  OMIX provides the required GPU
+# runtime, and the final stage installs torch 2.12.0+xpu into an isolated venv.
+# Build outputs still cross stage boundaries only as source trees and wheels.
 #
 # Scope ("lean core"): vLLM + custom ESIMD kernels + vllm-xpu-kernels + core serving
 # deps + bigdl-core (ships vllm_int4_for_multi_arc.so used by the sym_int4 path).
-# Dropped vs legacy: MinerU, UCX/NIXL (PD disaggregation), triton reinstall.
+# Dropped vs legacy: MinerU and UCX/NIXL (PD disaggregation).
 #
 # Build context root MUST be the `vllm/` dir (so ./patches, ./custom-esimd-kernels-vllm
 # and ./examples resolve).
 
 # =========================================================================
-# Stage 1: builder -- compile every native wheel with the oneAPI toolchain
+# Stage 1: rust-build -- compile vLLM Rust extensions
+# =========================================================================
+FROM ubuntu:22.04 AS rust-build
+
+ARG VLLM_VERSION=v0.26.0
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    CARGO_BUILD_JOBS=4
+
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates curl git build-essential unzip python3 python3-pip && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth 1 --branch "${VLLM_VERSION}" \
+        https://github.com/vllm-project/vllm.git /workspace/vllm
+
+WORKDIR /workspace/vllm
+
+RUN ./tools/install_protoc.sh && \
+    python3 -m pip install --no-cache-dir -r requirements/build/rust.txt
+
+RUN --mount=type=cache,target=/root/.cargo/registry,sharing=locked \
+    --mount=type=cache,target=/root/.cargo/git,sharing=locked \
+    bash build_rust.sh
+
+# =========================================================================
+# Stage 2: builder -- compile every native wheel with the oneAPI toolchain
 # =========================================================================
 FROM intel/omix:0.1.0-devel-ubuntu24.04 AS builder
 
 ARG http_proxy
 ARG https_proxy
 ARG no_proxy
+ARG VLLM_VERSION=v0.26.0
 # vllm-xpu-kernels pinned base commit (identical to legacy build).
-ARG VLLM_XPU_KERNELS_COMMIT=3cab97a
+ARG VLLM_XPU_KERNELS_COMMIT=a6929869587fa6c40dbe393eedc96eeab076bfbb
 
 ENV VIRTUAL_ENV=/opt/buildenv \
     PATH="/root/.local/bin:/opt/buildenv/bin:${PATH}" \
@@ -64,32 +93,40 @@ RUN python3 -m venv ${VIRTUAL_ENV}
 # --- uv for fast, deterministic installs (matches legacy build) ---
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 
-# --- torch MUST match the runtime base (2.11.0+xpu) so SyclExtension .so files link
-#     against the same libtorch ABI the runtime ships (rpath $ORIGIN/../../torch/lib) ---
+# --- torch MUST match the runtime venv (2.12.0+xpu) so SyclExtension .so files
+#     link against the same libtorch ABI (rpath $ORIGIN/../../torch/lib) ---
 RUN --mount=type=cache,target=/root/.cache/uv \
     pip install --upgrade pip wheel setuptools && \
-    uv pip install torch==2.11.0+xpu torchaudio torchvision \
+    uv pip install torch==2.12.0+xpu torchaudio torchvision \
         --index-url https://download.pytorch.org/whl/xpu
 
 RUN mkdir -p ${WHEELS}
 
 # ---------------------------------------------------------------------------
-# 1a. vLLM v0.21.0 + multi-arc patch  ->  wheel
+# 2a. vLLM v0.26.0 + multi-arc patch  ->  wheel
 # ---------------------------------------------------------------------------
 RUN --mount=type=cache,target=/root/.cache/uv \
     set -eo pipefail && \
     source /opt/intel/oneapi/setvars.sh --force && \
-    git clone --depth 1 -b v0.21.0 https://github.com/vllm-project/vllm.git /src/vllm && \
+    git clone --depth 1 -b "${VLLM_VERSION}" https://github.com/vllm-project/vllm.git /src/vllm && \
     cd /src/vllm && \
     git apply /tmp/vllm_for_multi_arc.patch && \
     uv pip install -r requirements/xpu.txt && \
-    uv pip install grpcio-tools protobuf nanobind && \
+    uv pip install grpcio-tools protobuf nanobind
+
+COPY --from=rust-build /workspace/vllm/vllm/vllm-rs /src/vllm/vllm/vllm-rs
+COPY --from=rust-build /workspace/vllm/vllm/_rust_*.so /src/vllm/vllm/
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    set -eo pipefail && \
+    source /opt/intel/oneapi/setvars.sh --force && \
+    cd /src/vllm && \
     export CMAKE_PREFIX_PATH="$(python3 -c 'import site; print(site.getsitepackages()[0])'):${CMAKE_PREFIX_PATH:-}" && \
     pip wheel --no-build-isolation --no-deps . -w ${WHEELS} && \
     rm -rf build
 
 # ---------------------------------------------------------------------------
-# 1b. custom ESIMD kernels  ->  wheel  (TORCH_XPU_ARCH_LIST=bmg-g21)
+# 2b. custom ESIMD kernels  ->  wheel  (TORCH_XPU_ARCH_LIST=bmg-g21)
 # ---------------------------------------------------------------------------
 RUN --mount=type=cache,target=/root/.cache/uv \
     set -eo pipefail && \
@@ -100,7 +137,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     rm -rf build dist
 
 # ---------------------------------------------------------------------------
-# 1c. vllm-xpu-kernels (patch + pinned commit)  ->  wheel
+# 2c. vllm-xpu-kernels (patch + pinned commit)  ->  wheel
 # ---------------------------------------------------------------------------
 RUN --mount=type=cache,target=/root/.cache/uv \
     set -eo pipefail && \
@@ -122,9 +159,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN ls -la ${WHEELS}/
 
 # =========================================================================
-# Stage 2: runtime -- lightweight serving image (no compiler, no /opt/intel/oneapi)
+# Stage 3: runtime -- production wheel install on OMIX with torch 2.12
 # =========================================================================
-FROM intel/pytorch:xpu-2.11.0-ubuntu24.04
+FROM intel/omix:0.1.0-devel-ubuntu24.04 AS runtime
 
 ARG http_proxy
 ARG https_proxy
@@ -132,8 +169,9 @@ ARG no_proxy
 ARG ONECCL_INSTALLER="intel-oneccl-2021.15.9.14_offline.sh"
 ARG ONECCL_INSTALLER_SHA256="f7ab81b6ed1b10dd35fadec366a78046d8af214888dfd625047ce8953d5aa4ef"
 
-# The base already exports PATH=/opt/venv/bin:... and DEVICE=xpu.
-ENV PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/xpu" \
+ENV VIRTUAL_ENV=/opt/venv \
+    PATH="/opt/venv/bin:${PATH}" \
+    PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/xpu" \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_NO_CACHE_DIR=1 \
     VLLM_QUANTIZE_Q40_LIB="/opt/venv/lib/python3.12/site-packages/vllm_int4_for_multi_arc.so" \
@@ -142,6 +180,18 @@ ENV PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/xpu" \
     VLLM_WORKER_MULTIPROC_METHOD=spawn
 
 WORKDIR /llm-scaler/vllm
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends --fix-missing \
+        ffmpeg libsndfile1 libsm6 libxext6 libgl1 numactl curl \
+        python3-venv python3-pip && \
+    rm -rf /var/lib/apt/lists/* && \
+    python3 -m venv ${VIRTUAL_ENV} && \
+    pip install --upgrade pip wheel setuptools && \
+    pip install torch==2.12.0+xpu torchaudio torchvision \
+        --index-url https://download.pytorch.org/whl/xpu
 
 # --- patched source trees (post-patch vLLM, vllm-xpu-kernels, and the ESIMD
 #     kernels) kept in the shipped image for reference / editable-install dev
@@ -158,15 +208,8 @@ COPY --from=builder /src/custom-esimd-kernels-vllm ./custom-esimd-kernels-vllm
 #     bake them into their own image layer that a later `rm` could never reclaim
 #     (union FS layers are immutable); the bind mount makes them visible only for
 #     this RUN's lifetime, so nothing from /wheels ever lands in the final image. ---
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-    --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=bind,from=builder,source=/wheels,target=/wheels \
+RUN --mount=type=bind,from=builder,source=/wheels,target=/wheels \
     set -e && \
-    apt-get update -y && \
-    apt-get install -y --no-install-recommends --fix-missing \
-        ffmpeg libsndfile1 libsm6 libxext6 libgl1 numactl curl && \
-    rm -rf /var/lib/apt/lists/* && \
     curl -fL --retry 3 -o "${ONECCL_INSTALLER}" "https://github.com/uxlfoundation/oneCCL/releases/download/2021.15.9/${ONECCL_INSTALLER}" && \
     printf "%s  %s\n" "${ONECCL_INSTALLER_SHA256}" "${ONECCL_INSTALLER}" > /tmp/oneccl.sha256 && \
     sha256sum -c /tmp/oneccl.sha256 && \
@@ -204,7 +247,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     pip install librosa soundfile decord ijson && \
     pip install bigdl-core==2.4.0b2 && \
     (pip uninstall -y triton triton-xpu || true) && \
-    pip install --no-deps triton-xpu==3.7.0 \
+    pip install --no-deps triton-xpu==3.7.1 \
         --extra-index-url https://download.pytorch.org/whl/xpu && \
     (pip uninstall -y oneccl oneccl-devel || true) && \
     rm -f /opt/venv/lib/libccl.so /opt/venv/lib/libccl.so.1 /opt/venv/lib/libccl.so.1.0 \
@@ -218,4 +261,4 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     rm -f ${TRITON}/plugins/libMLIRDialectPlugin.so.22.0git && \
     ln -s libMLIRDialectPlugin.so ${TRITON}/plugins/libMLIRDialectPlugin.so.22.0git
 
-ENTRYPOINT ["bash", "-c", "exec vllm serve \"$@\"", "--"]
+ENTRYPOINT ["bash", "-c", "source /opt/intel/oneapi/setvars.sh --force && source /opt/intel/oneapi/ccl/2021.15/env/vars.sh --force && exec vllm serve \"$@\"", "--"]

--- a/vllm/docker/Dockerfile
+++ b/vllm/docker/Dockerfile
@@ -186,7 +186,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update -y && \
     apt-get install -y --no-install-recommends --fix-missing \
         ffmpeg libsndfile1 libsm6 libxext6 libgl1 numactl curl \
-        python3-venv python3-pip && \
+        python3-dev python3-venv python3-pip && \
     rm -rf /var/lib/apt/lists/* && \
     python3 -m venv ${VIRTUAL_ENV} && \
     pip install --upgrade pip wheel setuptools && \

--- a/vllm/docker/Dockerfile
+++ b/vllm/docker/Dockerfile
@@ -3,7 +3,7 @@
 #
 # Three-stage OMIX build of llm-scaler-vllm (Intel XPU).
 #
-#   rust-build : ubuntu:24.04                         -- builds vLLM Rust extensions.
+#   rust-build : ubuntu:22.04                         -- builds vLLM Rust extensions.
 #   builder    : intel/omix:0.1.0-devel-ubuntu24.04  -- oneAPI 2025.3 DPC++ compiler
 #                                                         + oneCCL/oneDNN/oneMKL.  Compiles
 #                                                         all native wheels.  NOT shipped.
@@ -25,22 +25,17 @@
 # =========================================================================
 # Stage 1: rust-build -- compile vLLM Rust extensions
 # =========================================================================
-FROM ubuntu:24.04 AS rust-build
+FROM ubuntu:22.04 AS rust-build
 
 ARG VLLM_VERSION=v0.26.0
 
 ENV DEBIAN_FRONTEND=noninteractive \
-    CARGO_BUILD_JOBS=4 \
-    VIRTUAL_ENV=/opt/rust-venv \
-    PATH="/opt/rust-venv/bin:${PATH}"
+    CARGO_BUILD_JOBS=4
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
-        ca-certificates curl git build-essential unzip \
-        python3 python3-pip python3-venv && \
+        ca-certificates curl git build-essential unzip python3 python3-pip && \
     rm -rf /var/lib/apt/lists/*
-
-RUN python3 -m venv ${VIRTUAL_ENV}
 
 RUN git clone --depth 1 --branch "${VLLM_VERSION}" \
         https://github.com/vllm-project/vllm.git /workspace/vllm


### PR DESCRIPTION
## Summary

- upgrade the production image from vLLM v0.21.0 / PyTorch 2.11 to vLLM v0.26.0 / PyTorch 2.12
- add a dedicated Ubuntu stage for the vLLM Rust frontend and Python Rust extension
- build vLLM and XPU kernel wheels in OMIX, then install them into a separate OMIX runtime stage
- align the vLLM XPU kernels commit and triton-xpu version with Dockerfile.dev
- initialize oneAPI and oneCCL 2021.15 before starting the vLLM server

## Runtime base

An intel/pytorch PyTorch 2.12 runtime image is not available, so the final stage uses intel/omix:0.1.0-devel-ubuntu24.04 and installs PyTorch 2.12 into /opt/venv. This retains production wheel installation and cleanup behavior, but the final image includes the toolchain already present in the OMIX base.

## Validation

- docker buildx build --check -f docker/Dockerfile .
- full image build not run