### PR TITLE
omni: INT4 per-block zero-point GEMM + calling adapter (torchao asymmetric INT4)

### DIFF
--- a/omni/ComfyUI-OmniXPU/adapters/int4_gemm.py
+++ b/omni/ComfyUI-OmniXPU/adapters/int4_gemm.py
@@ -1,11 +1,11 @@
 """INT4 GEMM calling wrapper over omni_xpu_kernel svdq ops.
 
-Exposes ``onednn_int4_gemm_preconverted`` with an optional per-block
-zero-point parameter (TINT4/torchao format). The caller passes ``zp_u8``
-only when the kernel supports it; otherwise the op falls back to the
-scalar zp=8 path.
+Exposes ``onednn_int4_gemm_preconverted`` (wa4 对称) 与可选的 per-block
+zero-point 参数（TINT4/torchao 非对称）。kernel 不支持 zp 时 tint4 不处理
+（返回 None，调用方回退自身 python/torchao 路径），不报错、不强行走 kernel。
 """
 
+import inspect
 import logging
 
 import torch
@@ -28,24 +28,44 @@ def int4_gemm(act, packed_u4, scales_f16, zp_u8=None):
 
     Args:
         act: [M, K] bf16/f16/f32 activations.
-        packed_u4: [N, K/2] uint8 — unsigned u4 weights (packed ^ 0x88).
+        packed_u4: [N, K/2] uint8 — unsigned u4 weights (packed ^ 0x88，
+            preconverted 约定，wa4 与 tint4 均适用)。
         scales_f16: [G, N] f16 — weight scales.
         zp_u8: [G, N] uint8, optional — per-block zero points (TINT4/torchao,
             w = (q - zp) * scale inside oneDNN).
 
     Returns:
-        [M, N] same dtype as act.
+        [M, N] same dtype as act；kernel 不支持 zp 时返回 None（不处理）。
     """
-    return _get_svdq().onednn_int4_gemm_preconverted(act, packed_u4, scales_f16, zp_u8)
+    svdq = _get_svdq()
+    if zp_u8 is not None:
+        if not _kernel_accepts_zp(svdq):
+            log.warning(
+                "[OmniXPU] int4_gemm: kernel 不支持 zp_u8，tint4 不处理"
+                "（调用方回退自身 python/torchao 路径）"
+            )
+            return None
+        return svdq.onednn_int4_gemm_preconverted(act, packed_u4, scales_f16, zp_u8)
+    # 无 zp（wa4）：3 参调用，兼容不支持 zp 的老 kernel
+    return svdq.onednn_int4_gemm_preconverted(act, packed_u4, scales_f16)
+
+
+def _kernel_accepts_zp(svdq):
+    try:
+        return "zp_u8" in inspect.signature(
+            svdq.onednn_int4_gemm_preconverted).parameters
+    except (TypeError, ValueError):
+        return False
 
 
 def apply():
-    """Verify the kernel exposes the INT4 GEMM op used by the wrapper."""
+    """报告 kernel 的 INT4 GEMM 可用性与 zp 支持。"""
     try:
         svdq = _get_svdq()
         if not hasattr(svdq, "onednn_int4_gemm_preconverted"):
             return False, "kernel missing onednn_int4_gemm_preconverted"
-        log.info("[OmniXPU] int4_gemm adapter: INT4 GEMM (zp) op available")
+        log.info("[OmniXPU] int4_gemm adapter: preconverted available, "
+                 "zp_u8 supported=%s", _kernel_accepts_zp(svdq))
         return True, ""
     except Exception as exc:
         return False, str(exc)

--- a/omni/ComfyUI-OmniXPU/adapters/int4_gemm.py
+++ b/omni/ComfyUI-OmniXPU/adapters/int4_gemm.py
@@ -1,0 +1,51 @@
+"""INT4 GEMM calling wrapper over omni_xpu_kernel svdq ops.
+
+Exposes ``onednn_int4_gemm_preconverted`` with an optional per-block
+zero-point parameter (TINT4/torchao format). The caller passes ``zp_u8``
+only when the kernel supports it; otherwise the op falls back to the
+scalar zp=8 path.
+"""
+
+import logging
+
+import torch
+
+log = logging.getLogger("ComfyUI-OmniXPU")
+
+_svdq = None
+
+
+def _get_svdq():
+    global _svdq
+    if _svdq is None:
+        from omni_xpu_kernel import svdq
+        _svdq = svdq
+    return _svdq
+
+
+def int4_gemm(act, packed_u4, scales_f16, zp_u8=None):
+    """Fused INT4 dequant + GEMM via oneDNN u4 matmul.
+
+    Args:
+        act: [M, K] bf16/f16/f32 activations.
+        packed_u4: [N, K/2] uint8 — unsigned u4 weights (packed ^ 0x88).
+        scales_f16: [G, N] f16 — weight scales.
+        zp_u8: [G, N] uint8, optional — per-block zero points (TINT4/torchao,
+            w = (q - zp) * scale inside oneDNN).
+
+    Returns:
+        [M, N] same dtype as act.
+    """
+    return _get_svdq().onednn_int4_gemm_preconverted(act, packed_u4, scales_f16, zp_u8)
+
+
+def apply():
+    """Verify the kernel exposes the INT4 GEMM op used by the wrapper."""
+    try:
+        svdq = _get_svdq()
+        if not hasattr(svdq, "onednn_int4_gemm_preconverted"):
+            return False, "kernel missing onednn_int4_gemm_preconverted"
+        log.info("[OmniXPU] int4_gemm adapter: INT4 GEMM (zp) op available")
+        return True, ""
+    except Exception as exc:
+        return False, str(exc)

--- a/omni/ComfyUI-OmniXPU/config.py
+++ b/omni/ComfyUI-OmniXPU/config.py
@@ -15,6 +15,7 @@ class Config:
         self.norm = master and os.environ.get("OMNIXPU_NORM", "1") != "0"
         self.fp8_gemm = master and os.environ.get("OMNIXPU_FP8_GEMM", "1") != "0"
         self.int8_ffn = master and os.environ.get("OMNIXPU_INT8_FFN", "1") != "0"
+        self.int4_gemm = master and os.environ.get("OMNIXPU_INT4_GEMM", "1") != "0"
         self.lora_memory = (
             master and os.environ.get("OMNIXPU_LORA_MEMORY", "1") != "0"
         )

--- a/omni/ComfyUI-OmniXPU/patches/__init__.py
+++ b/omni/ComfyUI-OmniXPU/patches/__init__.py
@@ -58,6 +58,13 @@ COMPONENTS = (
         "adapters/int8_ffn.py",
     ),
     Component(
+        "int4_gemm_adapter",
+        "int4_gemm",
+        "adapter",
+        "ComfyUI-OmniXPU",
+        "adapters/int4_gemm.py",
+    ),
+    Component(
         "dynamic_vram_boundary_trim",
         "dynamic_vram_boundary_trim",
         "adapter",

--- a/omni/omni_xpu_kernel/omni_xpu_kernel/csrc/bindings.cpp
+++ b/omni/omni_xpu_kernel/omni_xpu_kernel/csrc/bindings.cpp
@@ -62,7 +62,10 @@ namespace svdq {
     std::tuple<torch::Tensor, torch::Tensor> quantize_svdq_act_int4(const torch::Tensor& input, int64_t group_size);
     std::tuple<torch::Tensor, torch::Tensor> quantize_svdq_act_uint4(const torch::Tensor& input, int64_t group_size);
     torch::Tensor onednn_int4_gemm(const torch::Tensor& act, const torch::Tensor& packed, const torch::Tensor& wscales);
-    torch::Tensor onednn_int4_gemm_preconverted(const torch::Tensor& act, const torch::Tensor& packed_u4, const torch::Tensor& scales_f16);
+    torch::Tensor onednn_int4_gemm_preconverted(
+        const torch::Tensor& act, const torch::Tensor& packed_u4,
+        const torch::Tensor& scales_f16,
+        std::optional<torch::Tensor> zp_u8);
     void onednn_int4_gemm_add_to_output(const torch::Tensor& act, const torch::Tensor& packed_u4, const torch::Tensor& scales_f16, torch::Tensor& dst);
     void fused_convert_add(torch::Tensor& out, const torch::Tensor& result, const torch::Tensor& residual);
     torch::Tensor fused_smooth_convert(const torch::Tensor& x, const torch::Tensor& smooth_factor);
@@ -425,10 +428,13 @@ PYBIND11_MODULE(_C, m) {
 
     svdq.def("onednn_int4_gemm_preconverted", &omni_xpu::svdq::onednn_int4_gemm_preconverted,
         "Fused INT4 dequant + GEMM using oneDNN u4 matmul (pre-converted weights)\n"
-        "Accepts already-converted u4 weights (packed^0x88) and f16 scales\n"
+        "Accepts already-converted u4 weights (packed^0x88) and f16 scales; "
+        "optional zp_u8 [G, N] enables TINT4/torchao per-block zero points "
+        "w = (q - zp) * scale inside oneDNN\n"
         "Input: act [M, K] bf16/f16/f32, packed_u4 [N, K/2] uint8, scales_f16 [G, N] f16\n"
         "Output: [M, N] same dtype as act",
-        py::arg("act"), py::arg("packed_u4"), py::arg("scales_f16"));
+        py::arg("act"), py::arg("packed_u4"), py::arg("scales_f16"),
+        py::arg("zp_u8") = py::none());
 
     svdq.def("onednn_int4_gemm_add_to_output", &omni_xpu::svdq::onednn_int4_gemm_add_to_output,
         "Fused INT4 GEMM + accumulate into bf16 output using oneDNN append_sum post-op\n"

--- a/omni/omni_xpu_kernel/omni_xpu_kernel/csrc/onednn_int4_gemm.cpp
+++ b/omni/omni_xpu_kernel/omni_xpu_kernel/csrc/onednn_int4_gemm.cpp
@@ -21,6 +21,7 @@
 #include <cstdio>
 #include <map>
 #include <mutex>
+#include <optional>
 #include <tuple>
 #include <unordered_map>
 
@@ -45,6 +46,7 @@ struct CachedPrimitive {
 
 static std::map<CacheKey, CachedPrimitive> g_cache;       // plain GEMM
 static std::map<CacheKey, CachedPrimitive> g_cache_sum;   // GEMM + append_sum
+static std::map<CacheKey, CachedPrimitive> g_cache_zp;    // per-block zero-point GEMM (TINT4)
 static std::mutex g_cache_mutex;
 
 // Per-device engine/stream (keyed by device index for multi-XPU support)
@@ -150,6 +152,86 @@ static void onednn_int4_gemm_kernel(
     cached->prim.execute(cached->strm, args);
 }
 
+// TINT4/torchao variant: unsigned u4 weights + per-block zero points + per-block
+// f16 scales. w = (q - zp) * scale exactly inside oneDNN (no Python correction).
+template <dnnl::memory::data_type ActDT>
+static CachedPrimitive& get_or_create_primitive_zp(
+    const CacheKey& key,
+    int64_t M, int64_t K, int64_t N, int64_t group_size,
+    const dnnl::engine& eng,
+    const dnnl::stream& strm
+) {
+    auto it = g_cache_zp.find(key);
+    if (it != g_cache_zp.end()) return it->second;
+
+    CachedPrimitive cp;
+    cp.eng = eng;
+    cp.strm = strm;
+
+    cp.src_md = dnnl::memory::desc({M, K}, ActDT, dnnl::memory::format_tag::ab);
+    cp.wei_md = dnnl::memory::desc({K, N}, dnnl::memory::data_type::u4,
+                                   dnnl::memory::format_tag::ba);
+    cp.dst_md = dnnl::memory::desc({M, N}, ActDT, dnnl::memory::format_tag::ab);
+
+    int64_t num_groups = K / group_size;
+    cp.scale_md = dnnl::memory::desc({num_groups, N}, dnnl::memory::data_type::f16,
+                                     dnnl::memory::format_tag::ab);
+    cp.zp_md = dnnl::memory::desc({num_groups, N}, dnnl::memory::data_type::u8,
+                                  dnnl::memory::format_tag::ab);
+
+    dnnl::primitive_attr attr;
+    attr.set_scales(DNNL_ARG_WEIGHTS, (1 << 0) | (1 << 1),
+                    {group_size, 1}, dnnl::memory::data_type::f16);
+    attr.set_zero_points(DNNL_ARG_WEIGHTS, (1 << 0) | (1 << 1),
+                         {group_size, 1}, dnnl::memory::data_type::u8);
+    attr.set_fpmath_mode(dnnl::fpmath_mode::any, true);
+
+    dnnl::matmul::primitive_desc pd(cp.eng, cp.src_md, cp.wei_md, cp.dst_md, attr);
+
+    std::string impl_info = pd.impl_info_str();
+    fprintf(stderr, "[onednn_int4_gemm_zp] CACHE MISS: impl=%s (M=%ld K=%ld N=%ld gs=%ld)\n",
+            impl_info.c_str(), M, K, N, group_size);
+    if (impl_info.find("ref") != std::string::npos) {
+        fprintf(stderr, "[onednn_int4_gemm_zp] WARNING: reference fallback (slow)\n");
+    }
+
+    cp.prim = dnnl::matmul(pd);
+
+    auto [ins, _] = g_cache_zp.emplace(key, std::move(cp));
+    return ins->second;
+}
+
+template <dnnl::memory::data_type ActDT>
+static void onednn_int4_gemm_zp_kernel(
+    void* act_ptr,
+    void* weight_ptr,
+    void* scales_ptr,
+    void* zero_ptr,
+    void* output_ptr,
+    int64_t M, int64_t K, int64_t N,
+    int64_t group_size,
+    const torch::Device& device
+) {
+    CacheKey key(static_cast<int>(ActDT), M, K, N, group_size);
+
+    CachedPrimitive* cached = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(g_cache_mutex);
+        auto& [eng, strm] = ensure_engine_initialized(device);
+        cached = &get_or_create_primitive_zp<ActDT>(key, M, K, N, group_size, eng, strm);
+    }
+
+    std::unordered_map<int, dnnl::memory> args = {
+        {DNNL_ARG_SRC,                                  dnnl::memory(cached->src_md,   cached->eng, act_ptr)},
+        {DNNL_ARG_WEIGHTS,                              dnnl::memory(cached->wei_md,   cached->eng, weight_ptr)},
+        {DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS,       dnnl::memory(cached->scale_md, cached->eng, scales_ptr)},
+        {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS,  dnnl::memory(cached->zp_md,    cached->eng, zero_ptr)},
+        {DNNL_ARG_DST,                                  dnnl::memory(cached->dst_md,   cached->eng, output_ptr)},
+    };
+
+    cached->prim.execute(cached->strm, args);
+}
+
 // GEMM with append_sum: dst = GEMM(act, wgt) + dst
 // Caller must pre-fill dst with the residual before calling this.
 // Activation: f16, Weights: u4, Dst: bf16.
@@ -189,7 +271,8 @@ static void onednn_int4_gemm_sum_kernel(
 torch::Tensor onednn_int4_gemm_preconverted(
     const torch::Tensor& act,
     const torch::Tensor& packed_u4,
-    const torch::Tensor& scales_f16
+    const torch::Tensor& scales_f16,
+    std::optional<torch::Tensor> zp_u8 = std::nullopt
 );
 
 // Convenience wrapper: converts signed INT4 packed → u4 and bf16 scales → f16 per call
@@ -211,7 +294,8 @@ torch::Tensor onednn_int4_gemm(
 torch::Tensor onednn_int4_gemm_preconverted(
     const torch::Tensor& act,
     const torch::Tensor& packed_u4,
-    const torch::Tensor& scales_f16
+    const torch::Tensor& scales_f16,
+    std::optional<torch::Tensor> zp_u8
 ) {
     TORCH_CHECK(act.dim() == 2, "act must be 2D [M, K], got ", act.dim(), "D");
     TORCH_CHECK(packed_u4.dim() == 2, "packed_u4 must be 2D [N, K/2], got ", packed_u4.dim(), "D");
@@ -242,33 +326,61 @@ torch::Tensor onednn_int4_gemm_preconverted(
     torch::Tensor output = torch::empty({M, N},
         torch::TensorOptions().dtype(act.scalar_type()).device(act.device()));
 
-    // Persistent scalar zero-point = 8 on XPU
-    static torch::Tensor zp;
-    if (!zp.defined() || zp.device() != act.device()) {
-        zp = torch::tensor({8}, torch::TensorOptions().dtype(torch::kUInt8).device(act.device()));
-    }
-
     torch::Tensor act_c = act.contiguous();
 
-    switch (act_c.scalar_type()) {
-        case torch::kBFloat16:
-            onednn_int4_gemm_kernel<dnnl::memory::data_type::bf16>(
-                act_c.data_ptr(), packed_u4.data_ptr(), scales_f16.data_ptr(),
-                zp.data_ptr(), output.data_ptr(), M, K, N, group_size, act_c.device());
-            break;
-        case torch::kFloat16:
-            onednn_int4_gemm_kernel<dnnl::memory::data_type::f16>(
-                act_c.data_ptr(), packed_u4.data_ptr(), scales_f16.data_ptr(),
-                zp.data_ptr(), output.data_ptr(), M, K, N, group_size, act_c.device());
-            break;
-        case torch::kFloat:
-            onednn_int4_gemm_kernel<dnnl::memory::data_type::f32>(
-                act_c.data_ptr(), packed_u4.data_ptr(), scales_f16.data_ptr(),
-                zp.data_ptr(), output.data_ptr(), M, K, N, group_size, act_c.device());
-            break;
-        default:
-            TORCH_CHECK(false, "Unsupported activation dtype: ", act_c.scalar_type(),
-                        ". Only bf16, f16, f32 are supported.");
+    if (zp_u8.has_value()) {
+        // TINT4/torchao: per-block zero points, w = (q - zp) * scale.
+        const torch::Tensor& zpt = zp_u8.value();
+        TORCH_CHECK(zpt.dim() == 2, "zp_u8 must be 2D [G, N]");
+        TORCH_CHECK(zpt.scalar_type() == torch::kUInt8, "zp_u8 must be uint8");
+        TORCH_CHECK(zpt.size(0) == num_groups && zpt.size(1) == N,
+                    "zp_u8 must be [G, N] = [", num_groups, ", ", N, "]");
+        switch (act_c.scalar_type()) {
+            case torch::kBFloat16:
+                onednn_int4_gemm_zp_kernel<dnnl::memory::data_type::bf16>(
+                    act_c.data_ptr(), packed_u4.data_ptr(), scales_f16.data_ptr(),
+                    zpt.data_ptr(), output.data_ptr(), M, K, N, group_size, act_c.device());
+                break;
+            case torch::kFloat16:
+                onednn_int4_gemm_zp_kernel<dnnl::memory::data_type::f16>(
+                    act_c.data_ptr(), packed_u4.data_ptr(), scales_f16.data_ptr(),
+                    zpt.data_ptr(), output.data_ptr(), M, K, N, group_size, act_c.device());
+                break;
+            case torch::kFloat:
+                onednn_int4_gemm_zp_kernel<dnnl::memory::data_type::f32>(
+                    act_c.data_ptr(), packed_u4.data_ptr(), scales_f16.data_ptr(),
+                    zpt.data_ptr(), output.data_ptr(), M, K, N, group_size, act_c.device());
+                break;
+            default:
+                TORCH_CHECK(false, "Unsupported activation dtype: ", act_c.scalar_type(),
+                            ". Only bf16, f16, f32 are supported.");
+        }
+    } else {
+        // Persistent scalar zero-point = 8 on XPU
+        static torch::Tensor zp;
+        if (!zp.defined() || zp.device() != act.device()) {
+            zp = torch::tensor({8}, torch::TensorOptions().dtype(torch::kUInt8).device(act.device()));
+        }
+        switch (act_c.scalar_type()) {
+            case torch::kBFloat16:
+                onednn_int4_gemm_kernel<dnnl::memory::data_type::bf16>(
+                    act_c.data_ptr(), packed_u4.data_ptr(), scales_f16.data_ptr(),
+                    zp.data_ptr(), output.data_ptr(), M, K, N, group_size, act_c.device());
+                break;
+            case torch::kFloat16:
+                onednn_int4_gemm_kernel<dnnl::memory::data_type::f16>(
+                    act_c.data_ptr(), packed_u4.data_ptr(), scales_f16.data_ptr(),
+                    zp.data_ptr(), output.data_ptr(), M, K, N, group_size, act_c.device());
+                break;
+            case torch::kFloat:
+                onednn_int4_gemm_kernel<dnnl::memory::data_type::f32>(
+                    act_c.data_ptr(), packed_u4.data_ptr(), scales_f16.data_ptr(),
+                    zp.data_ptr(), output.data_ptr(), M, K, N, group_size, act_c.device());
+                break;
+            default:
+                TORCH_CHECK(false, "Unsupported activation dtype: ", act_c.scalar_type(),
+                            ". Only bf16, f16, f32 are supported.");
+        }
     }
 
     return output;

--- a/omni/omni_xpu_kernel/omni_xpu_kernel/csrc/onednn_int4_gemm.cpp
+++ b/omni/omni_xpu_kernel/omni_xpu_kernel/csrc/onednn_int4_gemm.cpp
@@ -108,10 +108,14 @@ static CachedPrimitive& get_or_create_primitive(
 
     std::string impl_info = pd.impl_info_str();
     const char* tag = use_sum_postop ? "onednn_int4_gemm_sum" : "onednn_int4_gemm";
-    fprintf(stderr, "[%s] CACHE MISS: impl=%s (M=%ld K=%ld N=%ld gs=%ld)\n",
-            tag, impl_info.c_str(), M, K, N, group_size);
-    if (impl_info.find("ref") != std::string::npos) {
-        fprintf(stderr, "[%s] WARNING: reference fallback (slow)\n", tag);
+    // Primitive cache misses are expected during warm-up (one per new shape).
+    // Print only when requested: OMNI_XPU_DEBUG=gemm (or =1 / =all).
+    if (omni_xpu::debug::is_enabled("gemm")) {
+        fprintf(stderr, "[%s] CACHE MISS: impl=%s (M=%ld K=%ld N=%ld gs=%ld)\n",
+                tag, impl_info.c_str(), M, K, N, group_size);
+        if (impl_info.find("ref") != std::string::npos) {
+            fprintf(stderr, "[%s] WARNING: reference fallback (slow)\n", tag);
+        }
     }
 
     cp.prim = dnnl::matmul(pd);
@@ -189,10 +193,14 @@ static CachedPrimitive& get_or_create_primitive_zp(
     dnnl::matmul::primitive_desc pd(cp.eng, cp.src_md, cp.wei_md, cp.dst_md, attr);
 
     std::string impl_info = pd.impl_info_str();
-    fprintf(stderr, "[onednn_int4_gemm_zp] CACHE MISS: impl=%s (M=%ld K=%ld N=%ld gs=%ld)\n",
-            impl_info.c_str(), M, K, N, group_size);
-    if (impl_info.find("ref") != std::string::npos) {
-        fprintf(stderr, "[onednn_int4_gemm_zp] WARNING: reference fallback (slow)\n");
+    // Primitive cache misses are expected during warm-up (one per new shape).
+    // Print only when requested: OMNI_XPU_DEBUG=gemm (or =1 / =all).
+    if (omni_xpu::debug::is_enabled("gemm")) {
+        fprintf(stderr, "[onednn_int4_gemm_zp] CACHE MISS: impl=%s (M=%ld K=%ld N=%ld gs=%ld)\n",
+                impl_info.c_str(), M, K, N, group_size);
+        if (impl_info.find("ref") != std::string::npos) {
+            fprintf(stderr, "[onednn_int4_gemm_zp] WARNING: reference fallback (slow)\n");
+        }
     }
 
     cp.prim = dnnl::matmul(pd);
@@ -335,6 +343,7 @@ torch::Tensor onednn_int4_gemm_preconverted(
         TORCH_CHECK(zpt.scalar_type() == torch::kUInt8, "zp_u8 must be uint8");
         TORCH_CHECK(zpt.size(0) == num_groups && zpt.size(1) == N,
                     "zp_u8 must be [G, N] = [", num_groups, ", ", N, "]");
+        TORCH_CHECK(zpt.device().is_xpu(), "zp_u8 must be on XPU device");
         switch (act_c.scalar_type()) {
             case torch::kBFloat16:
                 onednn_int4_gemm_zp_kernel<dnnl::memory::data_type::bf16>(

--- a/omni/omni_xpu_kernel/omni_xpu_kernel/svdq/__init__.py
+++ b/omni/omni_xpu_kernel/omni_xpu_kernel/svdq/__init__.py
@@ -105,6 +105,7 @@ def onednn_int4_gemm_preconverted(
     act: torch.Tensor,
     packed_u4: torch.Tensor,
     scales_f16: torch.Tensor,
+    zp_u8: torch.Tensor = None,
 ) -> torch.Tensor:
     """
     Fused INT4 dequant + GEMM using oneDNN u4 matmul (pre-converted weights).
@@ -118,11 +119,13 @@ def onednn_int4_gemm_preconverted(
         act: [M, K] bf16/f16/f32 activations (f16 is ~3.5x faster than bf16)
         packed_u4: [N, K/2] uint8 — unsigned u4 weights (from packed ^ 0x88)
         scales_f16: [num_groups, N] f16 — weight scales
+        zp_u8: [num_groups, N] uint8, optional — per-block zero points
+            (TINT4/torchao format, w = (q - zp) * scale inside oneDNN)
 
     Returns:
         [M, N] same dtype as act
     """
-    return _get_native().onednn_int4_gemm_preconverted(act, packed_u4, scales_f16)
+    return _get_native().onednn_int4_gemm_preconverted(act, packed_u4, scales_f16, zp_u8)
 
 
 def onednn_int4_gemm_add_to_output(

--- a/omni/omni_xpu_kernel/tests/test_int4_preconverted_correctness.py
+++ b/omni/omni_xpu_kernel/tests/test_int4_preconverted_correctness.py
@@ -1,0 +1,122 @@
+"""
+Correctness tests for the torchao/asymmetric INT4 path of
+onednn_int4_gemm_preconverted (per-block zero points).
+
+Regression-protects the format contract:
+    w = (q - zp) * scale  (q = raw u4 qdata [0,15], per-block zp + f16 scale)
+applied entirely inside oneDNN — no conversion, no Python-side correction.
+
+Covers the reviewer's verified shapes (gs 32/64/128/256, fp16/bf16/f32),
+plus a Qwen-scale K=12288 no-NaN case (bf16 accumulation path).
+"""
+
+import pytest
+import torch
+
+
+def has_xpu():
+    try:
+        return torch.xpu.is_available()
+    except AttributeError:
+        return False
+
+
+@pytest.fixture
+def xpu_device():
+    if not has_xpu():
+        pytest.skip("XPU not available")
+    return torch.device("xpu")
+
+
+def _native_svdq():
+    try:
+        from omni_xpu_kernel import svdq
+        return svdq
+    except (ImportError, AttributeError):
+        pytest.skip("omni_xpu_kernel svdq extension not available")
+
+
+def ref_pack_u4(q_nk: torch.Tensor) -> torch.Tensor:
+    """Pack [N, K] u4 values (0..15) into [N, K/2] uint8 (lo | hi << 4)."""
+    v = q_nk.to(torch.int16)
+    lo = v[..., 0::2] & 0x0F
+    hi = (v[..., 1::2] & 0x0F) << 4
+    return (lo | hi).to(torch.uint8)
+
+
+def ref_forward(act, q_nk, zp, scale, group_size):
+    """Manual w = (q - zp) * scale reference: out = act @ W."""
+    N, K = q_nk.shape
+    G = K // group_size
+    q_t = q_nk.float().t()                       # [K, N]
+    zp_g = zp.float().repeat_interleave(group_size, dim=0)   # [K, N]
+    sc_g = scale.float().repeat_interleave(group_size, dim=0)  # [K, N]
+    w = (q_t - zp_g) * sc_g                      # [K, N]
+    return act.float() @ w
+
+
+@pytest.mark.parametrize("M,K,N,gs,dtype", [
+    (128, 256, 512, 64, torch.bfloat16),   # reviewer case
+    (64, 4096, 1024, 128, torch.float16),  # reviewer case
+    (256, 1024, 256, 32, torch.bfloat16),  # reviewer case
+    (8, 512, 512, 256, torch.float32),     # reviewer case (tiny shape)
+])
+def test_preconverted_zp_matches_reference(xpu_device, M, K, N, gs, dtype):
+    svdq = _native_svdq()
+    torch.manual_seed(7)
+
+    act = torch.randn(M, K, dtype=dtype, device=xpu_device)
+    q_nk = torch.randint(0, 16, (N, K), dtype=torch.uint8, device=xpu_device)
+    G = K // gs
+    zp = torch.randint(0, 16, (G, N), dtype=torch.uint8, device=xpu_device)
+    # Realistic weight scale magnitudes keep output ~O(1-100): with larger
+    # scales the bf16 accumulation noise (the kernel's fpmath-any path) grows
+    # into whole units and masks the format contract we are testing.
+    scale = (torch.rand(G, N, dtype=torch.float16, device=xpu_device) * 0.6 + 0.05)
+
+    packed = ref_pack_u4(q_nk)
+    out = svdq.onednn_int4_gemm_preconverted(act, packed, scale, zp)
+    ref = ref_forward(act, q_nk, zp, scale, gs)
+
+    assert out.shape == ref.shape
+    assert torch.isfinite(out).all()
+    # bf16 accumulation (fpmath-any) leaves ~O(0.5) absolute error even on
+    # near-zero outputs from large-sum cancellation; check absolute + 2% rel.
+    atol, rtol = (1e-3, 1e-3) if dtype == torch.float32 else (1.0, 2e-2)
+    assert torch.allclose(out.to(torch.float32), ref, atol=atol, rtol=rtol), (
+        f"preconverted+zp GEMM mismatch: max abs {torch.abs(out - ref).max().item():.3e}")
+
+
+def test_preconverted_zp_qwen_scale_k_no_nan(xpu_device):
+    """K=12288 (Qwen scale) must not overflow to NaN via bf16 accumulation."""
+    svdq = _native_svdq()
+    torch.manual_seed(11)
+
+    M, K, N, gs = 32, 12288, 512, 128
+    act = torch.randn(M, K, dtype=torch.bfloat16, device=xpu_device)
+    q_nk = torch.randint(0, 16, (N, K), dtype=torch.uint8, device=xpu_device)
+    G = K // gs
+    zp = torch.randint(0, 16, (G, N), dtype=torch.uint8, device=xpu_device)
+    scale = torch.rand(G, N, dtype=torch.float16, device=xpu_device) * 0.6 + 0.1
+
+    packed = ref_pack_u4(q_nk)
+    out = svdq.onednn_int4_gemm_preconverted(act, packed, scale, zp)
+    ref = ref_forward(act, q_nk, zp, scale, gs)
+
+    assert torch.isfinite(out).all()
+    # K=12288 bf16 accumulation noise scales with output magnitude (~0.4%).
+    assert torch.allclose(out.to(torch.float32), ref, atol=8.0, rtol=2e-2)
+
+
+def test_preconverted_zp_rejects_cpu_tensors(xpu_device):
+    """Format contract: every argument must be XPU-resident."""
+    svdq = _native_svdq()
+    M, K, N, gs = 8, 256, 64, 64
+    G = K // gs
+    act = torch.randn(M, K, dtype=torch.float16, device=xpu_device)
+    packed = ref_pack_u4(torch.randint(0, 16, (N, K), dtype=torch.uint8))
+    zp = torch.randint(0, 16, (G, N), dtype=torch.uint8)
+    scale = torch.rand(G, N, dtype=torch.float16)
+
+    with pytest.raises(RuntimeError, match="XPU"):
+        svdq.onednn_int4_gemm_preconverted(act, packed, scale, zp)


### PR DESCRIPTION
This PR ports the **INT4 per-block zero-point GEMM** (torchao asymmetric INT4 format) and its ComfyUI calling adapter:

- `onednn_int4_gemm_preconverted`: per-block zero points (`w = (q - zp) * scale` inside oneDNN), fp16/bf16 activations × u4 weights, group sizes 32/64/128/256, K up to 12288 without NaN.
- ComfyUI-OmniXPU `int4_gemm` adapter with runtime capability probing (falls back cleanly when the kernel lacks per-block zp support).
- Regression tests: `tests/test_int4_preconverted_correctness.py` (per-block zp vs manual `w=(q-zp)*scale`, fp16/bf16/f32, K=12288, CPU-tensor rejection).

Verification:

- A770 (DG2): 62/62 kernel tests pass (including this PR's tests).
- B580 (BMG, tested by yzwzhanghao2): `onednn_int4_gemm_preconverted` 6/6 pass on the same wheel.

Note: the W4A8 s8u4 GEMM previously bundled here is split out and stays in #629; this PR only carries the verified INT4 (a16) path.
