### PR TITLE
fix: prevent GDN state race during concurrent decode

### DIFF
--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/gdn_conv_fused.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/gdn_conv_fused.h
@@ -104,7 +104,6 @@ ESIMD_INLINE void gdn_conv_fused_kernel_v9(
     fp16* __restrict__ z_out_ptr,
     int N, int H, int HV, int gdn_K, int gdn_V,
     float attn_scale, int64_t conv_stride0, int64_t ssm_stride0,
-    int inline_conv_shift,   // 1 = do conv_state shift inline (safe when N*HV<=32)
     nd_item<3>& ndi)
 {
     slm_init<2048>();
@@ -357,24 +356,6 @@ ESIMD_INLINE void gdn_conv_fused_kernel_v9(
             out, simd<fp16, 4>(0.0f));
     }
 
-    // ---- Phase 3: conv_state shift (inline path, only when N*HV <= 32) ----
-    // When N*HV > 32, the shift is done by a separate kernel to avoid a
-    // cross-WG race: hv==0's writes could land before a later-scheduled WG's
-    // Phase 1 reads for the same seq_idx.
-    if (inline_conv_shift && conv_idx >= 0 && hv == 0 && is_valid) {
-        // lo chunk (valid threads only)
-        block_store<fp16, 64>(cstate_base + 0 * dim + chunk_start, simd<fp16, 64>(s1));
-        block_store<fp16, 64>(cstate_base + 1 * dim + chunk_start, simd<fp16, 64>(s2));
-        block_store<fp16, 64>(cstate_base + 2 * dim + chunk_start, x_fp16);
-
-        // hi chunk (v-threads only, when double_v)
-        if (double_v && tid >= 4 * H) {
-            block_store<fp16, 64>(cstate_base + 0 * dim + chunk_start_hi, simd<fp16, 64>(s1_hi));
-            block_store<fp16, 64>(cstate_base + 1 * dim + chunk_start_hi, simd<fp16, 64>(s2_hi));
-            block_store<fp16, 64>(cstate_base + 2 * dim + chunk_start_hi, x_fp16_hi);
-        }
-    }
-
     // ---- z extraction: v-threads copy z from qkvz to z_out ----
     if (tid >= 4 * H && is_valid) {
         int v_tid = tid - 4 * H;
@@ -536,12 +517,6 @@ inline void gdn_conv_fused_host(
     sycl::queue& q)
 {
     constexpr int WG_SIZE = 32;
-    const int total_wgs = N * HV;
-
-    // When total WGs fit in a single scheduling wave (<=32), all WGs run
-    // concurrently so the hv==0 inline conv_state shift is safe.  Otherwise
-    // split into two kernels to avoid the cross-WG read/write race.
-    const int inline_shift = (total_wgs <= WG_SIZE) ? 1 : 0;
 
     sycl::nd_range<3> Range(
         sycl::range<3>(N, HV, WG_SIZE),
@@ -556,25 +531,23 @@ inline void gdn_conv_fused_host(
                 ssm_state_ptr, ssm_state_indices_ptr,
                 output_ptr, z_out_ptr,
                 N, H, HV, K, V, scale, conv_stride0, ssm_stride0,
-                inline_shift, ndi);
+                ndi);
         });
     });
 
-    if (!inline_shift) {
-        // Separate kernel for conv_state shift — runs after kernel 1
-        // completes (in-order queue guarantees ordering).
-        sycl::nd_range<3> ShiftRange(
-            sycl::range<3>(N, 1, WG_SIZE),
-            sycl::range<3>(1, 1, WG_SIZE));
+    // A separate launch provides the global ordering needed before shifting
+    // state shared by all value-head work-groups for a sequence.
+    sycl::nd_range<3> ShiftRange(
+        sycl::range<3>(N, 1, WG_SIZE),
+        sycl::range<3>(1, 1, WG_SIZE));
 
-        q.submit([&](sycl::handler& cgh) {
-            cgh.parallel_for(ShiftRange, [=](sycl::nd_item<3> ndi) SYCL_ESIMD_KERNEL {
-                conv_state_shift_kernel(
-                    qkvz_ptr, qkvz_stride0, conv_state_ptr,
-                    conv_state_indices_ptr,
-                    N, H, HV, K, V,
-                    conv_stride0, ndi);
-            });
+    q.submit([&](sycl::handler& cgh) {
+        cgh.parallel_for(ShiftRange, [=](sycl::nd_item<3> ndi) SYCL_ESIMD_KERNEL {
+            conv_state_shift_kernel(
+                qkvz_ptr, qkvz_stride0, conv_state_ptr,
+                conv_state_indices_ptr,
+                N, H, HV, K, V,
+                conv_stride0, ndi);
         });
-    }
+    });
 }

--- a/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/gdn_conv_fused_seq.h
+++ b/vllm/custom-esimd-kernels-vllm/csrc/xpu/esimd_kernels/gdn_conv_fused_seq.h
@@ -121,7 +121,6 @@ ESIMD_INLINE void gdn_conv_fused_seq_kernel(
     fp16* __restrict__ z_out_ptr,
     int N, int H, int HV, int gdn_K, int gdn_V,
     float attn_scale, int64_t conv_stride0, int64_t ssm_stride0,
-    int inline_conv_shift,   // 1 = do conv_state shift inline (safe when N*HV<=32)
     nd_item<3>& ndi)
 {
     slm_init<2048>();
@@ -401,25 +400,6 @@ ESIMD_INLINE void gdn_conv_fused_seq_kernel(
                 out, simd<fp16, VPT>(0.0f));
         } else {
             block_store<fp16, VPT>(out, simd<fp16, VPT>(0.0f));
-        }
-    }
-
-    // ---- Phase 3: conv_state shift (inline path, only when N*HV <= WG_SIZE) ----
-    // When N*HV > WG_SIZE, the shift is done by a separate kernel to avoid a
-    // cross-WG race: one WG's shift writes could land before another WG's
-    // Phase 1 reads for the same seq_idx.
-    // Uses register-cached s1, s2, x_fp16 from Phase 1 (not re-read from memory).
-    if (inline_conv_shift && conv_idx >= 0 && hv == 0 && !v_oob) {
-        // lo chunk (all threads)
-        block_store<fp16, 64>(cstate_base + 0 * dim + chunk_start, simd<fp16, 64>(s1));
-        block_store<fp16, 64>(cstate_base + 1 * dim + chunk_start, simd<fp16, 64>(s2));
-        block_store<fp16, 64>(cstate_base + 2 * dim + chunk_start, x_fp16);
-
-        // hi chunk (v-threads only, when double_v)
-        if (double_v && tid >= 4 * H) {
-            block_store<fp16, 64>(cstate_base + 0 * dim + chunk_start_hi, simd<fp16, 64>(s1_hi));
-            block_store<fp16, 64>(cstate_base + 1 * dim + chunk_start_hi, simd<fp16, 64>(s2_hi));
-            block_store<fp16, 64>(cstate_base + 2 * dim + chunk_start_hi, x_fp16_hi);
         }
     }
 
@@ -784,9 +764,6 @@ inline void gdn_conv_fused_seq_dispatch(
     int64_t conv_stride0, int64_t ssm_stride0,
     sycl::queue& q)
 {
-    const int total_wgs = N * HV;
-    const int inline_shift = (total_wgs <= WG_SIZE) ? 1 : 0;
-
     sycl::nd_range<3> Range(
         sycl::range<3>(N, HV, WG_SIZE),
         sycl::range<3>(1, 1, WG_SIZE));
@@ -800,25 +777,25 @@ inline void gdn_conv_fused_seq_dispatch(
                 ssm_state_ptr, ssm_state_indices_ptr,
                 output_ptr, z_out_ptr,
                 N, H, HV, K, V, scale, conv_stride0, ssm_stride0,
-                inline_shift, ndi);
+                ndi);
         });
     });
 
-    if (!inline_shift) {
-        sycl::nd_range<3> ShiftRange(
-            sycl::range<3>(N, 1, WG_SIZE),
-            sycl::range<3>(1, 1, WG_SIZE));
+    // A separate launch provides the global ordering needed before shifting
+    // state shared by all value-head work-groups for a sequence.
+    sycl::nd_range<3> ShiftRange(
+        sycl::range<3>(N, 1, WG_SIZE),
+        sycl::range<3>(1, 1, WG_SIZE));
 
-        q.submit([&](sycl::handler& cgh) {
-            cgh.parallel_for(ShiftRange, [=](sycl::nd_item<3> ndi) SYCL_ESIMD_KERNEL {
-                conv_state_shift_seq_kernel<WG_SIZE>(
-                    qkvz_ptr, qkvz_stride0, conv_state_ptr,
-                    conv_state_indices_ptr,
-                    N, H, HV, K, V,
-                    conv_stride0, ndi);
-            });
+    q.submit([&](sycl::handler& cgh) {
+        cgh.parallel_for(ShiftRange, [=](sycl::nd_item<3> ndi) SYCL_ESIMD_KERNEL {
+            conv_state_shift_seq_kernel<WG_SIZE>(
+                qkvz_ptr, qkvz_stride0, conv_state_ptr,
+                conv_state_indices_ptr,
+                N, H, HV, K, V,
+                conv_stride0, ndi);
         });
-    }
+    });
 }
 
 /* ============================================================

--- a/vllm/custom-esimd-kernels-vllm/tests/test_e2e_gdn_conv_fused_seq.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/test_e2e_gdn_conv_fused_seq.py
@@ -69,7 +69,8 @@ def make_strided_states(num_cache, HV, DIM, device="xpu"):
     return conv_state, ssm_state
 
 
-def run_e2e_seq(N=1, num_v_heads_global=32, tp_size=4, num_cache=32, seed=42):
+def run_e2e_seq(N=1, num_v_heads_global=32, tp_size=4, num_cache=32,
+                seed=42, num_steps=1):
     H = NUM_K_HEADS_GLOBAL // tp_size
     HV = num_v_heads_global // tp_size
     HPG = HV // H
@@ -77,13 +78,10 @@ def run_e2e_seq(N=1, num_v_heads_global=32, tp_size=4, num_cache=32, seed=42):
     QKVZ_DIM = H * (K + K + HPG * V * 2)
 
     print(f"\n=== E2E Test seq: N={N}, H={H}, HV={HV}, K={K}, V={V}, "
-          f"num_v_heads_global={num_v_heads_global}, TP={tp_size} ===")
+          f"num_v_heads_global={num_v_heads_global}, TP={tp_size}, "
+          f"steps={num_steps} ===")
     torch.manual_seed(seed)
     device = "xpu"
-
-    # Generate data in SEQUENTIAL layout (matching model's decode path)
-    qkvz_seq = torch.randn(N, QKVZ_DIM, dtype=torch.float16, device=device) * 0.1
-    ba_seq = torch.randn(N, 2 * HV, dtype=torch.float16, device=device) * 0.5
 
     # conv_weight/conv_bias use same dim layout for both kernels
     conv_weight = torch.randn(DIM, 4, dtype=torch.float16, device=device) * 0.1
@@ -98,52 +96,16 @@ def run_e2e_seq(N=1, num_v_heads_global=32, tp_size=4, num_cache=32, seed=42):
     init_conv = torch.randn(num_cache, 3, DIM, dtype=torch.float16, device=device) * 0.01
     init_ssm = torch.zeros(num_cache, HV, V, K, dtype=torch.float16, device=device)
 
-    # Convert qkvz/ba to interleaved layout for reference kernel
-    qkvz_intl = seq_to_interleaved_qkvz(qkvz_seq, H, HV, K, V)
-    ba_intl = seq_to_interleaved_ba(ba_seq, H, HV)
-
-    # ---- Reference: torch.ops._xpu_C.gdn_attention (interleaved, prefill path) ----
+    # Initialize both implementations once. Keeping these states alive across
+    # all steps mirrors autoregressive decode and catches accumulating state
+    # corruption rather than testing several independent one-token calls.
     conv_ref, ssm_ref = make_strided_states(num_cache, HV, DIM, device)
     conv_ref.copy_(init_conv); ssm_ref.copy_(init_ssm)
-    out_ref = torch.empty(N, HV, V, dtype=torch.float16, device=device)
-    z_ref = torch.empty(N, HV, V, dtype=torch.float16, device=device)
-
-    torch.ops._xpu_C.gdn_attention(
-        out_ref, z_ref,
-        qkvz_intl.clone(), ba_intl.clone(),
-        NUM_K_HEADS_GLOBAL, num_v_heads_global, K, V,
-        conv_state=conv_ref, ssm_state=ssm_ref,
-        conv_weights=conv_weight, conv_bias=None, activation="silu",
-        A_log=A_log, dt_bias=dt_bias,
-        num_prefills=0, num_decodes=N, num_spec_decodes=0,
-        has_initial_state=None,
-        non_spec_query_start_loc=query_start_loc,
-        non_spec_token_indx=None,
-        non_spec_state_indices_tensor=state_indices,
-        spec_query_start_loc=None,
-        spec_token_indx=None,
-        spec_state_indices_tensor=None,
-        num_accepted_tokens=None,
-        num_actual_tokens=N, tp_size=tp_size,
-        reorder_input=False)
-    torch.xpu.synchronize()
-
-    # ---- Our kernel: esimd_gdn_conv_fused_seq (sequential, decode path) ----
     from custom_esimd_kernels_vllm import esimd_gdn_conv_fused_seq
 
     conv_ours, ssm_ours = make_strided_states(num_cache, HV, DIM, device)
     conv_ours.copy_(init_conv); ssm_ours.copy_(init_ssm)
-    out_ours = torch.empty(N, HV, V, dtype=torch.float16, device=device)
-    z_ours = torch.empty(N, HV, V, dtype=torch.float16, device=device)
 
-    esimd_gdn_conv_fused_seq(
-        qkvz_seq, conv_ours, conv_weight, conv_bias_zeros, state_indices,
-        A_log.half(), dt_bias, ba_seq,
-        ssm_ours, state_indices, out_ours, z_ours,
-        N, H, HV, K, V, float(K ** -0.5))
-    torch.xpu.synchronize()
-
-    # ---- Compare ----
     def check(name, ref, test, atol=1.0):
         d = (ref.float() - test.float()).abs()
         max_d = d.max().item()
@@ -153,22 +115,65 @@ def run_e2e_seq(N=1, num_v_heads_global=32, tp_size=4, num_cache=32, seed=42):
         return ok
 
     ok = True
-    ok &= check("core_attn_out", out_ref, out_ours, atol=1e-3)
-    ok &= check("z_out", z_ref, z_ours, atol=1e-3)
-    ok &= check("conv_state", conv_ref, conv_ours, atol=1e-3)
-    ok &= check("ssm_state", ssm_ref, ssm_ours, atol=1e-3)
+    for step in range(num_steps):
+        # New projected activations for every decode step; model weights and
+        # reference/ESIMD recurrent states remain unchanged between steps.
+        torch.manual_seed(seed + 2000 + step)
+        qkvz_seq = (
+            torch.randn(N, QKVZ_DIM, dtype=torch.float16, device=device)
+            * 0.1
+        )
+        ba_seq = (
+            torch.randn(N, 2 * HV, dtype=torch.float16, device=device) * 0.5
+        )
+        qkvz_intl = seq_to_interleaved_qkvz(qkvz_seq, H, HV, K, V)
+        ba_intl = seq_to_interleaved_ba(ba_seq, H, HV)
 
-    print(f"  Ref  out[0,0,:4]: {out_ref.float()[0,0,:4].cpu().tolist()}")
-    print(f"  Ours out[0,0,:4]: {out_ours.float()[0,0,:4].cpu().tolist()}")
-    print(f"  Ref  z[0,0,:4]:   {z_ref.float()[0,0,:4].cpu().tolist()}")
-    print(f"  Ours z[0,0,:4]:   {z_ours.float()[0,0,:4].cpu().tolist()}")
+        # Reference: native GDN with interleaved projected-state layout.
+        out_ref = torch.empty(N, HV, V, dtype=torch.float16, device=device)
+        z_ref = torch.empty(N, HV, V, dtype=torch.float16, device=device)
+        torch.ops._xpu_C.gdn_attention(
+            out_ref, z_ref,
+            qkvz_intl.clone(), ba_intl.clone(),
+            NUM_K_HEADS_GLOBAL, num_v_heads_global, K, V,
+            conv_state=conv_ref, ssm_state=ssm_ref,
+            conv_weights=conv_weight, conv_bias=None, activation="silu",
+            A_log=A_log, dt_bias=dt_bias,
+            num_prefills=0, num_decodes=N, num_spec_decodes=0,
+            has_initial_state=None,
+            non_spec_query_start_loc=query_start_loc,
+            non_spec_token_indx=None,
+            non_spec_state_indices_tensor=state_indices,
+            spec_query_start_loc=None,
+            spec_token_indx=None,
+            spec_state_indices_tensor=None,
+            num_accepted_tokens=None,
+            num_actual_tokens=N, tp_size=tp_size,
+            reorder_input=False)
+
+        # ESIMD GDN with sequential projected-state layout.
+        out_ours = torch.empty(N, HV, V, dtype=torch.float16, device=device)
+        z_ours = torch.empty(N, HV, V, dtype=torch.float16, device=device)
+        esimd_gdn_conv_fused_seq(
+            qkvz_seq, conv_ours, conv_weight, conv_bias_zeros, state_indices,
+            A_log.half(), dt_bias, ba_seq,
+            ssm_ours, state_indices, out_ours, z_ours,
+            N, H, HV, K, V, float(K ** -0.5))
+        torch.xpu.synchronize()
+
+        print(f"  Decode step {step}:")
+        ok &= check("core_attn_out", out_ref, out_ours, atol=1e-3)
+        ok &= check("z_out", z_ref, z_ours, atol=1e-3)
+        ok &= check("conv_state", conv_ref, conv_ours, atol=1e-3)
+        ok &= check("ssm_state", ssm_ref, ssm_ours, atol=1e-3)
+
     return ok
 
 
 def test_qwen36_tp2_two_sequence_decode():
-    for seed in range(8):
+    for seed in range(4):
         assert run_e2e_seq(
-            N=2, num_v_heads_global=48, tp_size=2, seed=seed
+            N=2, num_v_heads_global=48, tp_size=2, seed=seed, num_steps=8
         )
 
 

--- a/vllm/custom-esimd-kernels-vllm/tests/test_e2e_gdn_conv_fused_seq.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/test_e2e_gdn_conv_fused_seq.py
@@ -9,6 +9,7 @@ Only qkvz and ba differ in layout.
 """
 
 import torch
+import vllm_xpu_kernels._xpu_C
 
 NUM_K_HEADS_GLOBAL = 16
 K = 128
@@ -68,7 +69,7 @@ def make_strided_states(num_cache, HV, DIM, device="xpu"):
     return conv_state, ssm_state
 
 
-def test_e2e_seq(N=1, num_v_heads_global=32, tp_size=4, num_cache=32, seed=42):
+def run_e2e_seq(N=1, num_v_heads_global=32, tp_size=4, num_cache=32, seed=42):
     H = NUM_K_HEADS_GLOBAL // tp_size
     HV = num_v_heads_global // tp_size
     HPG = HV // H
@@ -114,9 +115,15 @@ def test_e2e_seq(N=1, num_v_heads_global=32, tp_size=4, num_cache=32, seed=42):
         conv_state=conv_ref, ssm_state=ssm_ref,
         conv_weights=conv_weight, conv_bias=None, activation="silu",
         A_log=A_log, dt_bias=dt_bias,
-        num_prefills=0, num_decodes=N, has_initial_state=None,
+        num_prefills=0, num_decodes=N, num_spec_decodes=0,
+        has_initial_state=None,
         non_spec_query_start_loc=query_start_loc,
+        non_spec_token_indx=None,
         non_spec_state_indices_tensor=state_indices,
+        spec_query_start_loc=None,
+        spec_token_indx=None,
+        spec_state_indices_tensor=None,
+        num_accepted_tokens=None,
         num_actual_tokens=N, tp_size=tp_size,
         reorder_input=False)
     torch.xpu.synchronize()
@@ -158,8 +165,14 @@ def test_e2e_seq(N=1, num_v_heads_global=32, tp_size=4, num_cache=32, seed=42):
     return ok
 
 
+def test_qwen36_tp2_two_sequence_decode():
+    for seed in range(8):
+        assert run_e2e_seq(
+            N=2, num_v_heads_global=48, tp_size=2, seed=seed
+        )
+
+
 if __name__ == "__main__":
-    import vllm_xpu_kernels._xpu_C
     ok = True
     # (label, num_v_heads_global, tp_size)
     # TP=4 configs (original)
@@ -167,8 +180,9 @@ if __name__ == "__main__":
         ("Qwen3.5-35B-A3B TP4", 32, 4),
         ("Qwen3.5-27B TP4", 48, 4),
         ("Qwen3.5-122B-A10B TP4", 64, 4),
+        ("Qwen3.6-27B TP2", 48, 2),
     ]
-    # TP=1 configs — triggers H=16, HV=48 (currently fails: WG_SIZE too small)
+    # TP=1 configs use the large-H kernel.
     configs += [
         ("Qwen3.5-27B TP1", 48, 1),
         ("Qwen3.6-27B TP1", 48, 1),
@@ -177,7 +191,7 @@ if __name__ == "__main__":
         for n in [1, 4, 8]:
             print(f"\n--- {label} (num_v_heads_global={num_v_heads}, TP={tp}) N={n} ---")
             try:
-                ok &= test_e2e_seq(N=n, num_v_heads_global=num_v_heads, tp_size=tp)
+                ok &= run_e2e_seq(N=n, num_v_heads_global=num_v_heads, tp_size=tp)
             except RuntimeError as e:
                 print(f"  CRASH: {e}")
                 ok = False

--- a/vllm/custom-esimd-kernels-vllm/tests/test_gdn_conv_fused_tp_fix.py
+++ b/vllm/custom-esimd-kernels-vllm/tests/test_gdn_conv_fused_tp_fix.py
@@ -31,7 +31,7 @@ def make_inputs(N, H, HV, K=128, V=128, dtype=torch.float16, device="xpu"):
     ba = torch.randn(N, 2 * HV, dtype=dtype, device=device) * 0.1
 
     conv_dim = 2 * H * K + HV * V
-    NUM_CACHE = 4
+    NUM_CACHE = max(4, N)
     conv_state = torch.randn(NUM_CACHE, 3, conv_dim, dtype=dtype, device=device) * 0.1
     conv_weight = torch.randn(conv_dim, 4, dtype=dtype, device=device) * 0.1
     conv_bias = torch.zeros(conv_dim, dtype=dtype, device=device)
@@ -50,21 +50,6 @@ def make_inputs(N, H, HV, K=128, V=128, dtype=torch.float16, device="xpu"):
         A_log=A_log, dt_bias=dt_bias,
         ssm_state=ssm_state, ssm_state_indices=ssm_state_indices,
     )
-
-
-def gqa_to_seq_qkvz(qkvz_gqa, H, HV, K, V):
-    """ESIMD GQA-interleaved -> sequential [q|k|v|z] layout for C++ ref."""
-    heads_per_group = HV // H
-    group_dim = K + K + 2 * heads_per_group * V
-    N = qkvz_gqa.shape[0]
-    qkvz_grouped = qkvz_gqa.view(N, H, group_dim)
-    q = qkvz_grouped[:, :, :K].reshape(N, H * K)
-    k = qkvz_grouped[:, :, K:2*K].reshape(N, H * K)
-    v_part = qkvz_grouped[:, :, 2*K:2*K + heads_per_group*V]
-    v = v_part.reshape(N, HV * V)
-    z_part = qkvz_grouped[:, :, 2*K + heads_per_group*V:]
-    z = z_part.reshape(N, HV * V)
-    return torch.cat([q, k, v, z], dim=1)
 
 
 def run_esimd(inp, N, H, HV, K=128, V=128):
@@ -90,8 +75,6 @@ def run_esimd(inp, N, H, HV, K=128, V=128):
 
 def run_reference(inp, N, H, HV, K=128, V=128):
     """跑 C++ gdn_attention (作为 reference)."""
-    qkvz_seq = gqa_to_seq_qkvz(inp["qkvz"], H, HV, K, V)
-
     output = torch.zeros(N, HV, V, dtype=torch.float16, device="xpu")
     z_out = torch.zeros(N, HV, V, dtype=torch.float16, device="xpu")
 
@@ -103,16 +86,21 @@ def run_reference(inp, N, H, HV, K=128, V=128):
 
     torch.ops._xpu_C.gdn_attention(
         output, z_out,
-        qkvz_seq, inp["ba"],
+        inp["qkvz"], inp["ba"],
         H, HV, K, V,
         conv_state=cs, ssm_state=ss,
         conv_weights=inp["conv_weight"], conv_bias=inp["conv_bias"],
         activation="silu",
         A_log=inp["A_log"].float(), dt_bias=inp["dt_bias"],
-        num_prefills=0, num_decodes=N,
+        num_prefills=0, num_decodes=N, num_spec_decodes=0,
         has_initial_state=has_initial_state,
         non_spec_query_start_loc=non_spec_query_start_loc,
+        non_spec_token_indx=None,
         non_spec_state_indices_tensor=inp["conv_state_indices"],
+        spec_query_start_loc=None,
+        spec_token_indx=None,
+        spec_state_indices_tensor=None,
+        num_accepted_tokens=None,
         num_actual_tokens=N,
         tp_size=1, reorder_input=False,
     )
@@ -157,11 +145,10 @@ if __name__ == "__main__":
     # TP=8 等价: 16 dead threads, 修复前会越界
     results["TP=8 (H=2, HV=4)"] = test_config("TP=8 equivalent", H=2, HV=4, N=1)
 
-    # 多 seq 的情况 (N=4): 仍 inline shift (N*HV=16 <= 32)
-    results["TP=8 N=4 inline shift"] = test_config("TP=8 N=4 inline", H=2, HV=4, N=4)
+    # 多 seq 的情况 (N=4)
+    results["TP=8 N=4"] = test_config("TP=8 N=4", H=2, HV=4, N=4)
 
-    # 多 seq 走 non-inline shift (N*HV > 32)
-    results["TP=8 N=16 non-inline shift"] = test_config("TP=8 N=16 non-inline", H=2, HV=4, N=16)
+    results["TP=8 N=16"] = test_config("TP=8 N=16", H=2, HV=4, N=16)
 
     print("\n" + "=" * 60)
     all_ok = True


### PR DESCRIPTION
Fixes #676

## Summary

- remove the unsafe inline conv-state update from the fused GDN kernels
- always shift conv state in a separate kernel after the main GDN kernel
- add a Qwen3.6 TP2 regression test that exercises two active sequences across successive decode steps
- update the existing GDN tests for the current native reference-op API and correct their reference-state layout

## Root cause

With `--mamba-ssm-cache-dtype float16`, vLLM enables the custom ESIMD fused GDN path. For small batches, the kernel previously let the `hv == 0` work-group update shared `conv_state` inline. There is no cross-work-group barrier, so that update could race with other value-head work-groups that were still reading the same state. The resulting state corruption accumulated during autoregressive decoding and could produce repeated or garbled output under concurrent requests.

The default FP32 SSM cache does not select this custom fast path, which is why the issue was specific to the FP16 cache setting.

## Validation

Kernel regression tests on XPU card 6:

- Qwen3.6 TP2, two sequences, 4 seeds x 8 successive decode steps: passed
- outputs, conv_state, and ssm_state compared after every decode step
- sequential-layout matrix covering TP1, TP2, TP4 and batch sizes 1, 4, 8: passed
- interleaved-layout matrix covering TP4, TP8 and batch sizes 1, 4, 16: passed
- `git diff --check`: passed

End-to-end validation on cards 6 and 7:

- model: Qwen3.6-27B-FP8
- tensor parallel size: 2
- Mamba SSM cache dtype: FP16
- three concurrent-request rounds completed with normal, deterministic output
- the same workload reproduced repeated/garbled output in all three rounds before the fix

AI assistance was used for investigation, implementation, and test preparation. All changes and validation results were reviewed locally.