### PR TITLE
vllm-0.26.0-b2 release update

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ LLM Scaler is an GenAI solution for text generation, image generation, video gen
 ---
 
 ## Latest Update
+- 🔥[2026.09] We released `intel/llm-scaler-vllm:0.26.0-b2` to fix prefix caching with MTP, correct `sym_int4` output, improve MTP decoding performance, and fix block-FP8 errors during concurrent decoding.
 - 🔥[2026.09] We released `intel/llm-scaler-vllm:0.26.0-b1` to upgrade vLLM to 0.26.0, improve TTFT for Qwen models, and deliver a series of quantization, LoRA serving, and FP8 KV cache optimizations and fixes.
 - 🔥[2026.08] We released `intel/llm-scaler-vllm:0.21.0-b3.1` for Muse-Glimmer-30B multi-modal support. 
 - 🔥[2026.08] We released `intel/llm-scaler-omni:0.2.0-b1` to support ComfyUI 0.31 XPU stack, MiniMax H3 local video generation, Wan Animate 2 workflows, add optimizations for Wan 2.2 14B T2V Turbo, LTX-2, Z-Image/Lumina and Krea2 workflows, and support Quantized ComfyUI workflows (GGUF Q4_1 and Nunchaku W4A16)

--- a/Releases.md
+++ b/Releases.md
@@ -3,9 +3,10 @@
 ## llm-scaler-vllm
 
 ### Latest Release
-* [`intel/llm-scaler-vllm:0.26.0-b1`](https://hub.docker.com/layers/intel/llm-scaler-vllm/0.26.0-b1/images/sha256-70e7eafdd52c281263f2a19266086b88e55064402a17ef731ba5657c4bd86490) [09/2026] 
+* [`intel/llm-scaler-vllm:0.26.0-b2`](https://hub.docker.com/layers/intel/llm-scaler-vllm/0.26.0-b2/images/sha256-52218ad85513ab6686d4c090c83c2bd8c5b02423c63aa4dabd41837fe641fe3b) [09/2026]
     
 ### Previous Releases
+* [`intel/llm-scaler-vllm:0.26.0-b1`](https://hub.docker.com/layers/intel/llm-scaler-vllm/0.26.0-b1/images/sha256-70e7eafdd52c281263f2a19266086b88e55064402a17ef731ba5657c4bd86490) [09/2026]
 * [`intel/llm-scaler-vllm:0.21.0-b3.1`](https://hub.docker.com/layers/intel/llm-scaler-vllm/0.21.0-b3.1/images/sha256-032916bd9264da44cab3e99092ffaf12331072ec51c3b380cbbe5fd98eb0254b) [08/2026] 
 * [`intel/llm-scaler-vllm:0.21.0-b3`](https://hub.docker.com/layers/intel/llm-scaler-vllm/0.21.0-b3/images/sha256-7a526dcfc49c77afeabf77e2e2a41a9a0221126580d144d2d1a15e320befb210) [08/2026] 
 * [`intel/llm-scaler-vllm:0.21.0-b2`](https://hub.docker.com/layers/intel/llm-scaler-vllm/0.21.0-b2/images/sha256-3f0a8c60fbaf376ec09538f093cba91f171238b99c117445c0bcc6096272ec3e) [08/2026] 


### PR DESCRIPTION
## Summary

- announce the `intel/llm-scaler-vllm:0.26.0-b2` release in the main README
- promote `0.26.0-b2` to the latest vLLM image in `Releases.md`
- move `0.26.0-b1` to the previous releases list
- link the release to the immutable Docker Hub image digest

## Validation

- `git diff --check`
- verified Docker Hub reports `0.26.0-b2` as active with digest `sha256:52218ad85513ab6686d4c090c83c2bd8c5b02423c63aa4dabd41837fe641fe3b`
