### PR TITLE
fix: remove stale vLLM offload environment variable

### DIFF
--- a/vllm/docker/Dockerfile
+++ b/vllm/docker/Dockerfile
@@ -175,7 +175,6 @@ ENV VIRTUAL_ENV=/opt/venv \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_NO_CACHE_DIR=1 \
     VLLM_QUANTIZE_Q40_LIB="/opt/venv/lib/python3.12/site-packages/vllm_int4_for_multi_arc.so" \
-    VLLM_OFFLOAD_WEIGHTS_BEFORE_QUANT=1 \
     VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
     VLLM_WORKER_MULTIPROC_METHOD=spawn
 

--- a/vllm/docker/Dockerfile.dev
+++ b/vllm/docker/Dockerfile.dev
@@ -78,7 +78,6 @@ ENV VIRTUAL_ENV=/opt/venv \
     WHEELS=/wheels \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     VLLM_QUANTIZE_Q40_LIB="/opt/venv/lib/python3.12/site-packages/vllm_int4_for_multi_arc.so" \
-    VLLM_OFFLOAD_WEIGHTS_BEFORE_QUANT=1 \
     VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
     VLLM_WORKER_MULTIPROC_METHOD=spawn
 


### PR DESCRIPTION
The v0.26 runtime no longer recognizes `VLLM_OFFLOAD_WEIGHTS_BEFORE_QUANT`, but both production and development Dockerfiles still export it. Every container therefore emits an unknown-environment-variable warning at startup.

Remove the stale default from both Dockerfiles. This does not change the v0.26 loader behavior because the runtime has no reference to the variable.

Validation:

- `git diff --check`
- Confirmed neither active Dockerfile exports the variable.
- Confirmed the matching v0.26 runtime source has no reference to the variable.
