### PR TITLE
SGL: disable GGUF probes by default for FP8

### DIFF
--- a/sglang/patches/sglang_for_multi_arc.patch
+++ b/sglang/patches/sglang_for_multi_arc.patch
@@ -1,5 +1,111 @@
+diff --git a/GEMMA4_FP16_OPTIMIZATION_PLAN.md b/GEMMA4_FP16_OPTIMIZATION_PLAN.md
+new file mode 100644
+index 0000000000000000000000000000000000000000..0ff498a9df9c7c910cdbbf01a7a25a3fe27de0c3
+--- /dev/null
++++ b/GEMMA4_FP16_OPTIMIZATION_PLAN.md
+@@ -0,0 +1,100 @@
++# Gemma4-31B FP16 Decode Optimization Plan (BMG TP=2)
++
++## Baseline (2026-06-30)
++
++| Config | TPOT | gsm8k | Notes |
++|--------|------|-------|-------|
++| bf16 (overlap ON) | 65.5ms | 0.975 | Previous best |
++| fp16 (kernel fix only) | 56.15ms | 0.975 | sgl-kernel-xpu fp16 dispatch fix |
++| fp16 + Step 1 (ESIMD QKV) | 53.68ms | — | + esimd_qkv_split_norm_rope |
++| **fp16 + Step 1+2 (QKV + fused norm)** | **52.27ms** | **0.980** | + esimd_fused_add_rms_norm |
++
++Decode profile (pure-decode, 12 steps, fp16 native):
++- ESIMD FP8 GEMV: **50.4%** (2880 calls, M=1)
++- oneCCL allreduce: **28.8%** (1452 calls, TP comm)
++- oneDNN bf16 GEMM (lm_head): **9.3%** (12 calls = 1/step, 4.7ms each)
++- SYCL elem/copy: 4.5%
++- RMSNorm (SYCL sgl_kernel): **2.9%**
++- FMHA attention: 1.7%
++- Triton gemma norm (qkv_rmsnorm + residual_scalar): **1.1%**
++- Activations (gelu etc): 1.0%
++- RoPE: 0.2%
++
++## Available ESIMD Ops (container `custom_esimd_kernels_sglang`)
++
++```
++esimd_fused_add_rms_norm          # residual_add + rmsnorm in-place
++esimd_fused_add_rms_norm_batched  # batched variant
++esimd_qkv_split_norm_rope         # QKV split + Q/K RMSNorm + RoPE
++esimd_norm_gemv_fp8_pert          # rmsnorm + FP8 GEMV fused
++esimd_resadd_norm_gemv_fp8_pert   # residual_add + rmsnorm + FP8 GEMV fused
++esimd_resadd_norm_gemv2_fp8_pert  # residual_add + rmsnorm + 2x FP8 GEMV fused
++esimd_gemv_fp8_pert_fused2        # 2x FP8 GEMV fused
++esimd_gemv_fp8_pert_fused3        # 3x FP8 GEMV fused
++esimd_rms_norm_gated              # gated rmsnorm (for GDN, not gemma4)
++```
++
++## Optimization Steps
++
++### Step 1: `esimd_qkv_split_norm_rope`
++
++**What:** Replace Triton `gemma_qkv_rmsnorm` + separate RoPE with a single ESIMD kernel that does QKV split + per-head Q/K RMSNorm + RoPE in one launch.
++
++**Where:** `gemma4_causal.py` → `Gemma4Attention.forward()`, lines 415-498.
++
++**Constraints from vLLM:**
++- Gated `head_dim == 256` only (kernel hardcoded); global attention layers (head_dim=512) must fallback
++- Requires fp16 input (we now run fp16 ✓)
++- Norm weight convention: kernel expects `w - 1.0` (Qwen convention); gemma4 stores raw weight → must precompute `q_norm.weight - 1.0` and `k_norm.weight - 1.0`
++- V norm has `with_scale=False` (weight=1) → pass zeros to kernel (kernel adds 1.0 internally)
++- `partial_rotary_factor=0.25` for gemma4 sliding layers → the rope_dim arg to kernel = `head_dim * 0.25 = 64`
++
++**Covers:** 50/60 layers (sliding attention, head_dim=256). 10 global layers (head_dim=512) stay on the current path.
++
++**Expected gain:** ~1.5-2% decode time (eliminates Triton qkv_rmsnorm 1.1% + RoPE 0.2% for 83% of layers + reduces launch count by ~100/step)
++
++---
++
++### Step 2: `esimd_fused_add_rms_norm`
++
++**What:** At decode M=1, fuse `hidden_states + residual → residual; rmsnorm(residual) → hidden_states` into one ESIMD kernel call, replacing the current `sgl_kernel.fused_add_rmsnorm` (SYCL) + the Triton `gemma_rmsnorm_residual_scalar`.
++
++**Where:** `gemma4_causal.py` → `Gemma4DecoderLayer.forward()`:
++- Line 678/723: `self.pre_feedforward_layernorm(hidden_states, residual)` — this is `RMSNorm.forward_xpu` which calls `sgl_kernel.fused_add_rmsnorm`
++- Lines 728-742: `gemma_rmsnorm_residual_scalar` (Triton, fused post_ff_norm + residual + scalar)
++
++**API (from container):**
++```python
++from custom_esimd_kernels_sglang import esimd_fused_add_rms_norm
++# Signature: esimd_fused_add_rms_norm(x, residual, weight, eps)
++# In-place: x = rmsnorm(x + residual), residual = x + residual
++```
++
++**Constraints:**
++- Decode M=1 only, fp16, contiguous
++- The `layer_scalar` multiplication (gemma4-specific) needs to be handled separately or folded in
++
++**Expected gain:** ~1-2% (reduces norm kernel launches from ~4/layer to ~2/layer for 60 layers)
++
++---
++
++### Step 3: `esimd_resadd_norm_gemv_fp8_pert` — DEFERRED
++
++**Status:** Investigated but deferred. The available kernels have constraints:
++- `esimd_norm_gemv_fp8_pert` is GDN-specific (gated norm, needs x + z inputs)
++- `esimd_resadd_norm_gemv_fp8_pert` does residual_add + norm + GEMV but requires the FP8 weight in `[N, K]` format (transposed from sglang's `[K, N]` storage) — the `_esimd_t` cache in fp8_utils.py provides this but is only created lazily on first forward. Also requires restructuring MLP call path to extract gate_up_proj from MLP.forward().
++- `esimd_gemv_fp8_pert_fused2/3` can batch 2-3 GEMVs sharing one input read, but gemma4 doesn't have consecutive GEMVs without intermediate ops (norms/activations between them).
++
++**Conclusion:** The remaining ~4% norm overhead is now split across many small kernels that already individually run fast. Further fusion needs either XPU graph capture (bundles all launches) or custom kernels not in this container.
++
++---
++
++### Future Opportunities (not achievable with current container ops)
++
++| # | Op | What | Est. gain | Blocker |
++|---|---|---|---|---|
++| 4 | `esimd_gemv_fp16` for lm_head | Replace oneDNN bf16 GEMM [1,5376]×[5376,131072] | ~9% (4.7ms/step) | Op not in `custom_esimd_kernels_sglang` |
++| 5 | XPU Graph decode capture | Bundle all decode-step kernels into one launch | ~5-10% (kills 38% inter-op gap) | Needs SGLANG_XPU_ENABLE_GRAPH validation for gemma4 |
++| 6 | `esimd_norm_add_norm` | post_attn + pre_ff double-norm in one kernel | ~1% | Op not in container (vLLM has it) |
++| 7 | `esimd_fused_scaled_add_rms_norm` | Cross-layer: defer scalar×add to next layer's input_norm | ~0.5% | Op not in container |
++| 8 | Allreduce overlap with compute | Overlap TP comm with non-dependent kernels | ~5-10% | Algorithmic; ⚠️ **修正 2026-07-06**：`overlap_schedule` 实测在 bsz=1 **decode 上有收益（TPOT −1.4ms/~3.7%）**，对 prefill(TTFT) 反而略有负担（见 STATUS 文档 "Overlap Schedule A/B"）。此处旧论断"helps prefill not decode"已被推翻。保持 overlap ON（默认）。 |
 diff --git a/python/pyproject.toml b/python/pyproject.toml
-index a8e086c36..bec093537 100755
+index a8e086c3612bac67c907ccb88f4ff529e06eefc8..bec0935373211eb2a63c9be415b8c64dc046ef2d 100755
 --- a/python/pyproject.toml
 +++ b/python/pyproject.toml
 @@ -1,5 +1,5 @@
@@ -195,7 +301,7 @@ index a8e086c36..bec093537 100755
 -[tool.kernels.dependencies]
 -"kernels-community/sgl-flash-attn3" = 1
 diff --git a/python/sglang/srt/configs/load_config.py b/python/sglang/srt/configs/load_config.py
-index 44ee91a1a..38de4d83a 100644
+index 44ee91a1a2106212ecbb2ef26a367893eaf1f41b..38de4d83abb81bf8033d10fa6192a121b89dc27f 100644
 --- a/python/sglang/srt/configs/load_config.py
 +++ b/python/sglang/srt/configs/load_config.py
 @@ -25,6 +25,7 @@ class LoadFormat(str, enum.Enum):
@@ -207,7 +313,7 @@ index 44ee91a1a..38de4d83a 100644
      JAX = "jax"
      REMOTE = "remote"
 diff --git a/python/sglang/srt/distributed/device_communicators/xpu_communicator.py b/python/sglang/srt/distributed/device_communicators/xpu_communicator.py
-index 78931ac7c..ed639a3b6 100644
+index 78931ac7c4fb5efae9035e089a0d9589153e759a..ed639a3b60939b0e9bd00909b1adf03ed1991338 100644
 --- a/python/sglang/srt/distributed/device_communicators/xpu_communicator.py
 +++ b/python/sglang/srt/distributed/device_communicators/xpu_communicator.py
 @@ -9,6 +9,14 @@ from torch.distributed import ProcessGroup
@@ -244,7 +350,7 @@ index 78931ac7c..ed639a3b6 100644
          return x
  
 diff --git a/python/sglang/srt/environ.py b/python/sglang/srt/environ.py
-index 435c30a5c..5abb15f22 100644
+index 435c30a5cfd99f457b580bd3d3894424a89d3df8..5abb15f221ee34af22fc31b46fb48d76eaa79888 100644
 --- a/python/sglang/srt/environ.py
 +++ b/python/sglang/srt/environ.py
 @@ -656,6 +656,11 @@ class Envs:
@@ -261,7 +367,7 @@ index 435c30a5c..5abb15f22 100644
  
 diff --git a/python/sglang/srt/layers/attention/fla/chunk_torch_xpu.py b/python/sglang/srt/layers/attention/fla/chunk_torch_xpu.py
 new file mode 100644
-index 000000000..7c2b07690
+index 0000000000000000000000000000000000000000..7c2b0769003ff2ba169c49cde30871acd59b9580
 --- /dev/null
 +++ b/python/sglang/srt/layers/attention/fla/chunk_torch_xpu.py
 @@ -0,0 +1,167 @@
@@ -433,7 +539,7 @@ index 000000000..7c2b07690
 +        h_out = h_out.unsqueeze(0)  # [1, total_chunks, H, V, K]
 +    return o, last_state, h_out
 diff --git a/python/sglang/srt/layers/attention/fla/layernorm_gated.py b/python/sglang/srt/layers/attention/fla/layernorm_gated.py
-index 5a8fda41b..99c56f9ff 100644
+index 5a8fda41b4f1620ddb428484f7229d5d99556dad..99c56f9ff86ab66af82b89f81d0eed8bde39af19 100644
 --- a/python/sglang/srt/layers/attention/fla/layernorm_gated.py
 +++ b/python/sglang/srt/layers/attention/fla/layernorm_gated.py
 @@ -22,11 +22,27 @@ from sglang.srt.utils import (
@@ -523,7 +629,7 @@ index 5a8fda41b..99c56f9ff 100644
 +            activation=self.activation,
 +        )
 diff --git a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
-index d0a8ff7a9..391da7cff 100644
+index d0a8ff7a90bbea0a4d22232c6640f2678cc470a7..391da7cff64c94b8f5de9aa96f913980256ce8ba 100644
 --- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
 +++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
 @@ -1,4 +1,5 @@
@@ -667,7 +773,7 @@ index d0a8ff7a9..391da7cff 100644
                  ssm_states[forward_metadata.track_ssm_final_dst] = ssm_states[
                      forward_metadata.track_ssm_final_src
 diff --git a/python/sglang/srt/layers/attention/linear/gdn_backend.py b/python/sglang/srt/layers/attention/linear/gdn_backend.py
-index ade156e98..24473a357 100644
+index ade156e98cdbd5e95746a7387450ef55aa17e3c3..24473a3575e71ee833b0a05538518b27e1126c6b 100644
 --- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
 +++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
 @@ -1,10 +1,15 @@
@@ -876,7 +982,7 @@ index ade156e98..24473a357 100644
  
          return core_attn_out
 diff --git a/python/sglang/srt/layers/attention/linear/kernels/gdn_triton.py b/python/sglang/srt/layers/attention/linear/kernels/gdn_triton.py
-index 0daf8f4e2..24b513554 100644
+index 0daf8f4e25714bccc4debc93a75c02304335dbab..24b513554a30aec626cddf6e2f0d933c6887cd8e 100644
 --- a/python/sglang/srt/layers/attention/linear/kernels/gdn_triton.py
 +++ b/python/sglang/srt/layers/attention/linear/kernels/gdn_triton.py
 @@ -5,6 +5,62 @@ from sglang.srt.layers.attention.linear.kernels.kernel_backend import (
@@ -1130,7 +1236,7 @@ index 0daf8f4e2..24b513554 100644
              A_log=A_log,
              dt_bias=dt_bias,
 diff --git a/python/sglang/srt/layers/attention/mamba/mamba_state_scatter_triton.py b/python/sglang/srt/layers/attention/mamba/mamba_state_scatter_triton.py
-index 28c0e4929..c24a616f9 100644
+index 28c0e4929cbc84742f8cd02505cf544bcc21f73b..c24a616f9db67ebcf2e86d5629da6bc803e7d5e3 100644
 --- a/python/sglang/srt/layers/attention/mamba/mamba_state_scatter_triton.py
 +++ b/python/sglang/srt/layers/attention/mamba/mamba_state_scatter_triton.py
 @@ -115,6 +115,29 @@ def fused_mamba_state_scatter_with_mask(
@@ -1164,7 +1270,7 @@ index 28c0e4929..c24a616f9 100644
          raise ValueError(
              "fused_mamba_state_scatter_with_mask only supports CUDA tensors."
 diff --git a/python/sglang/srt/layers/attention/triton_backend.py b/python/sglang/srt/layers/attention/triton_backend.py
-index ae5365e8d..0f54d2a8c 100644
+index ae5365e8d6f760ff5837216f5e235495e7f44683..0f54d2a8ceb03e37f529a72df7833ca23cabc014 100644
 --- a/python/sglang/srt/layers/attention/triton_backend.py
 +++ b/python/sglang/srt/layers/attention/triton_backend.py
 @@ -36,6 +36,21 @@ _is_gfx942 = is_gfx942_supported()
@@ -1274,7 +1380,7 @@ index ae5365e8d..0f54d2a8c 100644
              q.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
              self.token_to_kv_pool.get_key_buffer(layer.layer_id),
 diff --git a/python/sglang/srt/layers/attention/xpu_backend.py b/python/sglang/srt/layers/attention/xpu_backend.py
-index ea02e001f..1ecad5d71 100644
+index ea02e001f13ef31d784ffc9623198a174694f594..1ecad5d71d671a8f1ce70a77d660b75931d4668f 100644
 --- a/python/sglang/srt/layers/attention/xpu_backend.py
 +++ b/python/sglang/srt/layers/attention/xpu_backend.py
 @@ -1,9 +1,68 @@
@@ -2434,7 +2540,7 @@ index ea02e001f..1ecad5d71 100644
 +    def get_cuda_graph_seq_len_fill_value(self):
 +        return self.attn_backends[0].get_cuda_graph_seq_len_fill_value()
 diff --git a/python/sglang/srt/layers/dp_attention.py b/python/sglang/srt/layers/dp_attention.py
-index eff8ce4f9..ad0a495c2 100644
+index eff8ce4f956e5e8796decad9d801164978bf43c4..ad0a495c245bb0c8ff55356dc0397ec0140d5874 100644
 --- a/python/sglang/srt/layers/dp_attention.py
 +++ b/python/sglang/srt/layers/dp_attention.py
 @@ -310,6 +310,14 @@ def initialize_dp_attention(
@@ -2453,7 +2559,7 @@ index eff8ce4f9..ad0a495c2 100644
  def is_dp_attention_enabled() -> bool:
      return _ENABLE_DP_ATTENTION_FLAG
 diff --git a/python/sglang/srt/layers/linear.py b/python/sglang/srt/layers/linear.py
-index fc197860d..9b01ec583 100644
+index fc197860da3097e1416f2aa7c7b88c0e8eb2ccc2..9b01ec583f29b37ae03287802e6c8f0b67bb0ef9 100644
 --- a/python/sglang/srt/layers/linear.py
 +++ b/python/sglang/srt/layers/linear.py
 @@ -6,6 +6,7 @@ from __future__ import annotations
@@ -2476,7 +2582,7 @@ index fc197860d..9b01ec583 100644
              else:
                  quantize_communications = (
 diff --git a/python/sglang/srt/layers/logits_processor.py b/python/sglang/srt/layers/logits_processor.py
-index 15a3d6aac..4fe805001 100644
+index 15a3d6aac9b15878b314a411e3535359fa2987a5..4fe805001c389e7c57a9f120306b03c30ed4fd67 100644
 --- a/python/sglang/srt/layers/logits_processor.py
 +++ b/python/sglang/srt/layers/logits_processor.py
 @@ -21,6 +21,12 @@ from typing import Any, Dict, List, Optional, Tuple, Union
@@ -2512,7 +2618,7 @@ index 15a3d6aac..4fe805001 100644
                  logits = torch.matmul(
                      hidden_states.to(lm_head.weight.dtype), lm_head.weight.T
 diff --git a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
-index 59ca3f9cc..e104249d2 100644
+index 59ca3f9cce61ce71ccd0df02ee14f22018b8e78e..e104249d26334b6e00cfb27c96d7ae7d6805c280 100644
 --- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
 +++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
 @@ -733,12 +733,23 @@ class FusedMoE(torch.nn.Module):
@@ -2541,7 +2647,7 @@ index 59ca3f9cc..e104249d2 100644
              # Store in data_container with expert/shard info
              if not hasattr(param, "expert_data_map"):
 diff --git a/python/sglang/srt/layers/moe/moe_runner/triton.py b/python/sglang/srt/layers/moe/moe_runner/triton.py
-index 96e431d4e..cd890f194 100644
+index 96e431d4e38597be063d4366aa44067e139ac9eb..cd890f19473121a088ff756e03360a1e742a7308 100644
 --- a/python/sglang/srt/layers/moe/moe_runner/triton.py
 +++ b/python/sglang/srt/layers/moe/moe_runner/triton.py
 @@ -1,5 +1,6 @@
@@ -2960,7 +3066,7 @@ index 96e431d4e..cd890f194 100644
          hidden_states=dispatch_output.hidden_states,
          w1=quant_info.w13_weight,
 diff --git a/python/sglang/srt/layers/moe/topk.py b/python/sglang/srt/layers/moe/topk.py
-index b104e40d7..4da941e2e 100644
+index b104e40d7437a8cd2aee0855f27f00bbe6853612..4da941e2edec1b6bef39068761a93dd886a95836 100644
 --- a/python/sglang/srt/layers/moe/topk.py
 +++ b/python/sglang/srt/layers/moe/topk.py
 @@ -114,6 +114,11 @@ from sglang.srt.utils import (
@@ -2987,7 +3093,7 @@ index b104e40d7..4da941e2e 100644
          raise ValueError(
              "SGLANG_SIMULATE_UNIFORM_EXPERTS and "
 diff --git a/python/sglang/srt/layers/moe/utils.py b/python/sglang/srt/layers/moe/utils.py
-index e29f7efec..c4c01342a 100644
+index e29f7efec17a894de2bd8cfe50f3efc353d22655..c4c01342ac51bf25279708a7e664bd6f909dfa8f 100644
 --- a/python/sglang/srt/layers/moe/utils.py
 +++ b/python/sglang/srt/layers/moe/utils.py
 @@ -258,6 +258,19 @@ DEEPEP_CONFIG: Optional[str] = None
@@ -3074,7 +3180,7 @@ index e29f7efec..c4c01342a 100644
  
  def should_skip_post_experts_all_reduce(
 diff --git a/python/sglang/srt/layers/quantization/fp8.py b/python/sglang/srt/layers/quantization/fp8.py
-index b4e05df01..5386abbd1 100644
+index b4e05df0132f56f4e8e2cd2cc638cc5afa2ead37..5386abbd1b6af0a7c1c4ffc24028e2194bf89b28 100644
 --- a/python/sglang/srt/layers/quantization/fp8.py
 +++ b/python/sglang/srt/layers/quantization/fp8.py
 @@ -116,6 +116,317 @@ _use_aiter = envs.SGLANG_USE_AITER.get() and _is_hip
@@ -3485,7 +3591,7 @@ index b4e05df01..5386abbd1 100644
                  x,
                  layer.w13_weight,
 diff --git a/python/sglang/srt/layers/quantization/fp8_kernel.py b/python/sglang/srt/layers/quantization/fp8_kernel.py
-index 30a035a23..c82c83ed6 100644
+index 30a035a23c0126ffc1f0e57dd9325f29dbba0c10..c82c83ed6df77d6d44aa8ee9f248b86fc534fb19 100644
 --- a/python/sglang/srt/layers/quantization/fp8_kernel.py
 +++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
 @@ -40,6 +40,7 @@ from sglang.srt.utils import (
@@ -3587,7 +3693,7 @@ index 30a035a23..c82c83ed6 100644
              # Dynamic scaling
              if use_per_token_if_dynamic:
 diff --git a/python/sglang/srt/layers/quantization/fp8_utils.py b/python/sglang/srt/layers/quantization/fp8_utils.py
-index 6c6827c7d..59bdd5338 100755
+index 6c6827c7d20bf351bbbc2c7ee2b838899540c281..59bdd53384f3e12cf132e084f60cdab907683767 100755
 --- a/python/sglang/srt/layers/quantization/fp8_utils.py
 +++ b/python/sglang/srt/layers/quantization/fp8_utils.py
 @@ -1,6 +1,7 @@
@@ -4001,7 +4107,7 @@ index 6c6827c7d..59bdd5338 100755
                      qinput, x_scale = per_token_group_quant_fp8(
                          input_2d, group_size=input_2d.shape[1]
 diff --git a/python/sglang/srt/layers/quantization/gguf.py b/python/sglang/srt/layers/quantization/gguf.py
-index 5c1e7a63e..46ab6bb8e 100644
+index 5c1e7a63e6d90693033108dedd016df02ef5a19b..46ab6bb8e243da053a572ae2ff95785653d587ad 100644
 --- a/python/sglang/srt/layers/quantization/gguf.py
 +++ b/python/sglang/srt/layers/quantization/gguf.py
 @@ -1,9 +1,9 @@
@@ -6342,7 +6448,7 @@ index 5c1e7a63e..46ab6bb8e 100644
      """Embedding method for GGUF.
  
 diff --git a/python/sglang/srt/managers/cache_controller.py b/python/sglang/srt/managers/cache_controller.py
-index ba1e27479..e538976e2 100644
+index ba1e27479e4774323badac3a415dec90bbbdacbe..e538976e2e2031160a2d7dd8aa50726cfcc4095e 100644
 --- a/python/sglang/srt/managers/cache_controller.py
 +++ b/python/sglang/srt/managers/cache_controller.py
 @@ -50,6 +50,12 @@ from sglang.srt.utils import get_device_module
@@ -6430,7 +6536,7 @@ index ba1e27479..e538976e2 100644
  
          self.ack_load_queue.append(
 diff --git a/python/sglang/srt/managers/scheduler.py b/python/sglang/srt/managers/scheduler.py
-index 8e32640fc..120fc5e29 100644
+index 8e32640fc6a9085425a0dd2e45b38c09a5bc643d..120fc5e29a42c7102a5e99227f708a634cc022ca 100644
 --- a/python/sglang/srt/managers/scheduler.py
 +++ b/python/sglang/srt/managers/scheduler.py
 @@ -2542,6 +2542,15 @@ class Scheduler(
@@ -6450,7 +6556,7 @@ index 8e32640fc..120fc5e29 100644
  
      def get_new_batch_prefill(self) -> Optional[ScheduleBatch]:
 diff --git a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
-index a28233958..3b7c99c7b 100644
+index a282339587133c315eec0e47770a8c7bbf8bab0b..3b7c99c7b01ceb48864f612c95c7866c7aebff82 100644
 --- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
 +++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
 @@ -1,6 +1,7 @@
@@ -6527,7 +6633,7 @@ index a28233958..3b7c99c7b 100644
          self,
          *,
 diff --git a/python/sglang/srt/mem_cache/common.py b/python/sglang/srt/mem_cache/common.py
-index f201c2257..4814fcb79 100644
+index f201c225766b67cf49deec28d9417871384c3749..4814fcb79826d36753a243f133037d19877a2fc6 100644
 --- a/python/sglang/srt/mem_cache/common.py
 +++ b/python/sglang/srt/mem_cache/common.py
 @@ -74,7 +74,10 @@ def write_cache_indices(
@@ -6543,7 +6649,7 @@ index f201c2257..4814fcb79 100644
              [t.data_ptr() for t in prefix_tensors],
              device=req_to_token_pool.device,
 diff --git a/python/sglang/srt/mem_cache/hicache_storage.py b/python/sglang/srt/mem_cache/hicache_storage.py
-index a982cb7c8..531027db3 100644
+index a982cb7c8258951fde9a0c1bbc73499c9c39ff9a..531027db38e2263cb3fbf84d38b8b212f57f33f7 100644
 --- a/python/sglang/srt/mem_cache/hicache_storage.py
 +++ b/python/sglang/srt/mem_cache/hicache_storage.py
 @@ -34,6 +34,16 @@ class HiCacheStorageConfig:
@@ -6582,7 +6688,7 @@ index a982cb7c8..531027db3 100644
              os.makedirs(self.file_path)
              logger.info(f"Created HiCacheFile storage directory at {self.file_path}")
 diff --git a/python/sglang/srt/mem_cache/hisparse_memory_pool.py b/python/sglang/srt/mem_cache/hisparse_memory_pool.py
-index c0dcd02b8..cfc476438 100644
+index c0dcd02b8a111692aed7d35cf54a4957aaca29f6..cfc476438dc8a11d3ba9b95a9649aca713e61f98 100644
 --- a/python/sglang/srt/mem_cache/hisparse_memory_pool.py
 +++ b/python/sglang/srt/mem_cache/hisparse_memory_pool.py
 @@ -16,22 +16,24 @@ from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
@@ -6616,7 +6722,7 @@ index c0dcd02b8..cfc476438 100644
  
  
 diff --git a/python/sglang/srt/mem_cache/memory_pool.py b/python/sglang/srt/mem_cache/memory_pool.py
-index 8efe9aae9..8a33403ef 100644
+index 8efe9aae94e05a94e56e8507396d0ad3964dbe3a..8a33403ef3fe5852789b4b3c72654633c0a18ae4 100644
 --- a/python/sglang/srt/mem_cache/memory_pool.py
 +++ b/python/sglang/srt/mem_cache/memory_pool.py
 @@ -62,6 +62,7 @@ from sglang.srt.utils import (
@@ -6693,7 +6799,7 @@ index 8efe9aae9..8a33403ef 100644
                      for conv_shape in conv_state_shape
                  ]
 diff --git a/python/sglang/srt/mem_cache/memory_pool_host.py b/python/sglang/srt/mem_cache/memory_pool_host.py
-index b42ad7ba6..fe35698ef 100644
+index b42ad7ba6fa7f08da9f8801ad424467b2e83a24e..fe35698efcf7db0b98fc7ecfa9ee38af3a827476 100644
 --- a/python/sglang/srt/mem_cache/memory_pool_host.py
 +++ b/python/sglang/srt/mem_cache/memory_pool_host.py
 @@ -46,7 +46,17 @@ _is_hip = is_hip()
@@ -6812,7 +6918,7 @@ index b42ad7ba6..fe35698ef 100644
              [x.data_ptr() for x in self.device_pool.index_k_with_scale_buffer],
              dtype=torch.uint64,
 diff --git a/python/sglang/srt/model_executor/breakable_cuda_graph/breakable_cuda_graph.py b/python/sglang/srt/model_executor/breakable_cuda_graph/breakable_cuda_graph.py
-index 7341301ef..464151c42 100644
+index 7341301ef4b2503cb93bcf72228a65a617a7c535..464151c42ea66f4fd1c32612032cc6516c73e8c8 100644
 --- a/python/sglang/srt/model_executor/breakable_cuda_graph/breakable_cuda_graph.py
 +++ b/python/sglang/srt/model_executor/breakable_cuda_graph/breakable_cuda_graph.py
 @@ -315,9 +315,13 @@ class BreakableCUDAGraphCapture:
@@ -6834,7 +6940,7 @@ index 7341301ef..464151c42 100644
      def _end_current_segment(self) -> None:
 diff --git a/python/sglang/srt/model_executor/breakable_cuda_graph/xpu_breakable_graph.py b/python/sglang/srt/model_executor/breakable_cuda_graph/xpu_breakable_graph.py
 new file mode 100644
-index 000000000..7bbbd2d5b
+index 0000000000000000000000000000000000000000..7bbbd2d5b5c28fb3a826c1cf4cca072edcbd5441
 --- /dev/null
 +++ b/python/sglang/srt/model_executor/breakable_cuda_graph/xpu_breakable_graph.py
 @@ -0,0 +1,271 @@
@@ -7110,7 +7216,7 @@ index 000000000..7bbbd2d5b
 +    """
 +    return fn(*args, **kwargs)
 diff --git a/python/sglang/srt/model_executor/cuda_graph_runner.py b/python/sglang/srt/model_executor/cuda_graph_runner.py
-index ebbfc2b28..56497dcc7 100644
+index ebbfc2b288d8a82978e13bb83ac156980cc00ae6..56497dcc763b5cd8e42c857000f19a7dd705b701 100644
 --- a/python/sglang/srt/model_executor/cuda_graph_runner.py
 +++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
 @@ -75,6 +75,7 @@ from sglang.srt.utils import (
@@ -7227,7 +7333,7 @@ index ebbfc2b28..56497dcc7 100644
              if _is_hip:
                  raise RuntimeError("Breakable CUDA graph is not supported on ROCm/HIP")
 diff --git a/python/sglang/srt/model_executor/model_runner.py b/python/sglang/srt/model_executor/model_runner.py
-index 3b30eb0e1..93c745eef 100644
+index 3b30eb0e1f74721eaacd2d066b6de30c78ceec64..93c745eefe157ccbd93cc4ac67766532e1171588 100644
 --- a/python/sglang/srt/model_executor/model_runner.py
 +++ b/python/sglang/srt/model_executor/model_runner.py
 @@ -849,6 +849,19 @@ class ModelRunner(ModelRunnerKVCacheMixin):
@@ -7335,7 +7441,7 @@ index 3b30eb0e1..93c745eef 100644
              if self.server_args.quantization_param_path is not None:
                  if callable(getattr(self.model, "load_kv_cache_scales", None)):
 diff --git a/python/sglang/srt/model_loader/loader.py b/python/sglang/srt/model_loader/loader.py
-index 32ff5bac2..fa15cebe2 100644
+index 32ff5bac255940253408e70a361e2bb843505986..fa15cebe26502b7299a7a92ba0342364afdedc68 100644
 --- a/python/sglang/srt/model_loader/loader.py
 +++ b/python/sglang/srt/model_loader/loader.py
 @@ -100,6 +100,7 @@ from sglang.srt.model_loader.weight_utils import (
@@ -7899,7 +8005,7 @@ index 32ff5bac2..fa15cebe2 100644
      # FP8 approach: BF16/FP16 model with native FP8 quantization
      if load_config.load_format == LoadFormat.FLASH_RL:
 diff --git a/python/sglang/srt/model_loader/weight_utils.py b/python/sglang/srt/model_loader/weight_utils.py
-index e53a3193b..f1ac3ebf1 100644
+index e53a3193b00165d1178906941f4b723783cb9aff..f1ac3ebf18674ad7734b51cda724e6bc5d6f0283 100644
 --- a/python/sglang/srt/model_loader/weight_utils.py
 +++ b/python/sglang/srt/model_loader/weight_utils.py
 @@ -26,6 +26,7 @@ from typing import (
@@ -8155,7 +8261,7 @@ index e53a3193b..f1ac3ebf1 100644
      """convert PySafeSlice object from safetensors to torch.Tensor
  
 diff --git a/python/sglang/srt/models/gemma4_causal.py b/python/sglang/srt/models/gemma4_causal.py
-index 9c2f9c25d..864aeb208 100644
+index 9c2f9c25dbf7c2d8cbd9b10bd8f34fa51f457b40..864aeb208dfd2e19d8cbdfb10f6b7b6f7f175920 100644
 --- a/python/sglang/srt/models/gemma4_causal.py
 +++ b/python/sglang/srt/models/gemma4_causal.py
 @@ -13,6 +13,7 @@
@@ -8799,7 +8905,7 @@ index 9c2f9c25d..864aeb208 100644
              hidden_states = self.post_feedforward_layernorm(hidden_states)
              hidden_states = hidden_states + residual
 diff --git a/python/sglang/srt/models/gemma4_mm.py b/python/sglang/srt/models/gemma4_mm.py
-index 3629782ca..3d7068ab4 100644
+index 3629782ca3ba6bf6c84ca16a40cf99dac72a6700..3d7068ab445cbca34cba2e6cd00513acc45cf2c1 100644
 --- a/python/sglang/srt/models/gemma4_mm.py
 +++ b/python/sglang/srt/models/gemma4_mm.py
 @@ -606,12 +606,17 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
@@ -8827,7 +8933,7 @@ index 3629782ca..3d7068ab4 100644
          # Prepare bidirectional attention masks for image tokens during prefill.
          # mm_inputs is preserved on every PP rank up to the first-rank embed
 diff --git a/python/sglang/srt/models/qwen2_moe.py b/python/sglang/srt/models/qwen2_moe.py
-index 37552404b..8aa941fdd 100644
+index 37552404b90d46726cdf0debf7e831254cc55baf..8aa941fdd6f2c84d947ae6ae017a142ac354a067 100644
 --- a/python/sglang/srt/models/qwen2_moe.py
 +++ b/python/sglang/srt/models/qwen2_moe.py
 @@ -19,6 +19,7 @@
@@ -9916,7 +10022,7 @@ index 37552404b..8aa941fdd 100644
  class Qwen2MoeAttention(nn.Module):
      def __init__(
 diff --git a/python/sglang/srt/models/qwen3_5.py b/python/sglang/srt/models/qwen3_5.py
-index 65f78e691..fabd3bcaa 100644
+index 65f78e6917e8c6f9e0c418f9afc00375347a361d..e168033e697baf8d3ab5ef7bbd661f862f78b30f 100644
 --- a/python/sglang/srt/models/qwen3_5.py
 +++ b/python/sglang/srt/models/qwen3_5.py
 @@ -15,8 +15,11 @@
@@ -10126,19 +10232,19 @@ index 65f78e691..fabd3bcaa 100644
 +# an fp16 mm for in_proj_ba. `esimd_resadd_norm_gemv_kq` folds all of them into
 +# one launch. Independent of SGL_XPU_GGUF_MOE_FULL because 27B is dense.
 +_XPU_GGUF_RESADD_NORM_KQ = (
-+    os.environ.get("SGL_XPU_GGUF_RESADD_NORM_KQ", "1") == "1"
++    os.environ.get("SGL_XPU_GGUF_RESADD_NORM_KQ", "0") == "1"
 +)
 +
 +# Phase 5e (GGUF k-quant dense MLP): folds post_attention_layernorm, the merged
 +# gate_up q4_K GEMV and silu_and_mul into `esimd_resadd_norm_gemv_q4k_silu`,
 +# i.e. three dispatches per layer down to one.
-+_XPU_GGUF_MLP_SILU = os.environ.get("SGL_XPU_GGUF_MLP_SILU", "1") == "1"
++_XPU_GGUF_MLP_SILU = os.environ.get("SGL_XPU_GGUF_MLP_SILU", "0") == "1"
 +
 +# Phase 5f (GGUF k-quant GDN out_proj): folds the standalone
 +# gdn_rms_norm_gated into the q5_K out_proj GEMV. The q8_0 twin
 +# (`_gguf_norm_out_proj`) only matches a Q8_0 build.
 +_XPU_GGUF_NORM_OUT_Q5K = (
-+    os.environ.get("SGL_XPU_GGUF_NORM_OUT_Q5K", "1") == "1"
++    os.environ.get("SGL_XPU_GGUF_NORM_OUT_Q5K", "0") == "1"
 +)
 +
 +
@@ -13403,7 +13509,7 @@ index 65f78e691..fabd3bcaa 100644
 +
  EntryClass = [Qwen3_5MoeForConditionalGeneration, Qwen3_5ForConditionalGeneration]
 diff --git a/python/sglang/srt/models/qwen3_5_mtp.py b/python/sglang/srt/models/qwen3_5_mtp.py
-index 6b39a590c..323f0a8f4 100644
+index 6b39a590ccd5c121193f4723125320f3806b1bd9..323f0a8f465a4fe53e3590209a75bdcd9a0da48c 100644
 --- a/python/sglang/srt/models/qwen3_5_mtp.py
 +++ b/python/sglang/srt/models/qwen3_5_mtp.py
 @@ -33,7 +33,11 @@ from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
@@ -13483,7 +13589,7 @@ index 6b39a590c..323f0a8f4 100644
                  # Remove the mtp. prefix for processing
                  name = name.replace("mtp.", "model.")
 diff --git a/python/sglang/srt/server_args.py b/python/sglang/srt/server_args.py
-index 6c77ff64f..127dedb7b 100644
+index 6c77ff64f92cd08d9f00eb96f8f1514a39d4dd2c..127dedb7bf2128d8fc37e0323782deb16a213809 100644
 --- a/python/sglang/srt/server_args.py
 +++ b/python/sglang/srt/server_args.py
 @@ -119,6 +119,7 @@ LOAD_FORMAT_CHOICES = [
@@ -13624,7 +13730,7 @@ index 6c77ff64f..127dedb7b 100644
          if (
              self.hicache_mem_layout == "page_first_direct"
 diff --git a/python/sglang/srt/speculative/draft_utils.py b/python/sglang/srt/speculative/draft_utils.py
-index 10bc78954..58bf777e4 100644
+index 10bc789545982a976fb60921e1dd43ac6f092d16..58bf777e4aee9fb8799e790a366f9aed4e073570 100644
 --- a/python/sglang/srt/speculative/draft_utils.py
 +++ b/python/sglang/srt/speculative/draft_utils.py
 @@ -43,6 +43,7 @@ class DraftBackendFactory:
@@ -13670,7 +13776,7 @@ index 10bc78954..58bf777e4 100644
          from sglang.srt.layers.attention.aiter_backend import AiterAttnBackend
  
 diff --git a/python/sglang/srt/speculative/eagle_utils.py b/python/sglang/srt/speculative/eagle_utils.py
-index 3bb3cec3a..49e3644c0 100644
+index 3bb3cec3ae3364a7f5e97dc1751ad3d1ad5b9fb0..49e3644c03789b4e9a36afe01a549a0720328831 100644
 --- a/python/sglang/srt/speculative/eagle_utils.py
 +++ b/python/sglang/srt/speculative/eagle_utils.py
 @@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, List, Optional
@@ -13771,7 +13877,7 @@ index 3bb3cec3a..49e3644c0 100644
  
  
 diff --git a/python/sglang/srt/speculative/spec_utils.py b/python/sglang/srt/speculative/spec_utils.py
-index 48d07334a..c00eb1e98 100644
+index 48d07334af78dfc7ddcf74288ce327fd18357ec4..c00eb1e982d03521f9d6d4d912b1542a8054ad4d 100644
 --- a/python/sglang/srt/speculative/spec_utils.py
 +++ b/python/sglang/srt/speculative/spec_utils.py
 @@ -39,12 +39,13 @@ from sglang.srt.speculative.triton_ops.cache_locs import (
@@ -13808,7 +13914,7 @@ index 48d07334a..c00eb1e98 100644
      i: int,
      topk_p: torch.Tensor,
 diff --git a/python/sglang/srt/speculative/triton_ops/cache_locs.py b/python/sglang/srt/speculative/triton_ops/cache_locs.py
-index e16a15ad5..3ee300af8 100644
+index e16a15ad58ebb78cdd312693b5c919b09f9d643e..3ee300af8fa14b9a461eeac716c513241d455615 100644
 --- a/python/sglang/srt/speculative/triton_ops/cache_locs.py
 +++ b/python/sglang/srt/speculative/triton_ops/cache_locs.py
 @@ -4,12 +4,13 @@ import torch
@@ -13851,7 +13957,7 @@ index e16a15ad5..3ee300af8 100644
 +        "the result straight to batch.out_cache_loc)."
 +    )
 diff --git a/python/sglang/srt/utils/common.py b/python/sglang/srt/utils/common.py
-index 4556d06b1..c5e35caf9 100644
+index 4556d06b16f88c55e10d4703f2bdfdf1a4d3c92d..c5e35caf9ada0d0360ecfcf72650ac15b159e1df 100644
 --- a/python/sglang/srt/utils/common.py
 +++ b/python/sglang/srt/utils/common.py
 @@ -329,6 +329,7 @@ def xpu_has_xmx_support():
@@ -13863,7 +13969,7 @@ index 4556d06b1..c5e35caf9 100644
      return get_bool_env_var("SGLANG_USE_SGL_XPU") and is_xpu()
  
 diff --git a/python/sglang/srt/utils/hf_transformers/config.py b/python/sglang/srt/utils/hf_transformers/config.py
-index f66ea9a67..8e5f7beda 100644
+index f66ea9a672e55dfd7b44f40feece4592dfc4c960..8e5f7beda725af2662f2e24ae8a6064c76437b29 100644
 --- a/python/sglang/srt/utils/hf_transformers/config.py
 +++ b/python/sglang/srt/utils/hf_transformers/config.py
 @@ -13,6 +13,7 @@
@@ -13938,7 +14044,7 @@ index f66ea9a67..8e5f7beda 100644
          _set_architectures(config, MODEL_FOR_CAUSAL_LM_MAPPING_NAMES[config.model_type])
 diff --git a/test/registered/unit/server_args/test_xpu_hicache_server_args.py b/test/registered/unit/server_args/test_xpu_hicache_server_args.py
 new file mode 100644
-index 000000000..47b4372a0
+index 0000000000000000000000000000000000000000..47b4372a0827a8dba1fd51caa65acd9fcd324e84
 --- /dev/null
 +++ b/test/registered/unit/server_args/test_xpu_hicache_server_args.py
 @@ -0,0 +1,100 @@
@@ -14044,7 +14150,7 @@ index 000000000..47b4372a0
 +    unittest.main()
 diff --git a/test/registered/xpu/test_xpu_hicache_storage_file.py b/test/registered/xpu/test_xpu_hicache_storage_file.py
 new file mode 100644
-index 000000000..42576c840
+index 0000000000000000000000000000000000000000..42576c8404f47a44c64b3a95b9a0e29de262201f
 --- /dev/null
 +++ b/test/registered/xpu/test_xpu_hicache_storage_file.py
 @@ -0,0 +1,209 @@
@@ -14259,7 +14365,7 @@ index 000000000..42576c840
 +    unittest.main()
 diff --git a/test/registered/xpu/test_xpu_hierarchical_cache.py b/test/registered/xpu/test_xpu_hierarchical_cache.py
 new file mode 100644
-index 000000000..d66b31f29
+index 0000000000000000000000000000000000000000..d66b31f29b27e978c46e22c3d8004c9264d3bce1
 --- /dev/null
 +++ b/test/registered/xpu/test_xpu_hierarchical_cache.py
 @@ -0,0 +1,238 @@

--- a/sglang/scripts/start_qwen3_6_service.sh
+++ b/sglang/scripts/start_qwen3_6_service.sh
@@ -105,6 +105,11 @@ if [[ "$MODEL_PATH" == *.gguf ]]; then
     # Folds GemmaRMSNorm(input_layernorm) + the q8_0 in_proj/qkv GEMV + the fp16
     # in_proj_ba GEMV into one op. Set to 0 for the unfused fallback.
     export SGL_XPU_GGUF_RESADD_NORM="${SGL_XPU_GGUF_RESADD_NORM:-1}"
+    # GGUF k-quant-only fusions. They default to off in SGLang so FP8 launches
+    # do not probe GGUF layouts; enable them explicitly for the GGUF path.
+    export SGL_XPU_GGUF_RESADD_NORM_KQ="${SGL_XPU_GGUF_RESADD_NORM_KQ:-1}"
+    export SGL_XPU_GGUF_MLP_SILU="${SGL_XPU_GGUF_MLP_SILU:-1}"
+    export SGL_XPU_GGUF_NORM_OUT_Q5K="${SGL_XPU_GGUF_NORM_OUT_Q5K:-1}"
     # Largest decode batch the fusions handle. Must cover the MTP verify batch
     # (concurrency x num_draft_tokens), so leave it at the default 64.
     export SGL_XPU_GGUF_FUSE_MAX_M="${SGL_XPU_GGUF_FUSE_MAX_M:-64}"


### PR DESCRIPTION
## Summary

- Refresh the SGLang BMG patch from `analytics-zoo/sglang:dev-bmg`.
- Disable the three GGUF k-quant kernel probes by default so FP8 services do not emit GGUF fallback warnings.
- Explicitly enable those GGUF fusions in the Qwen3.6 GGUF service launcher.

## Source revisions

- SGLang: `analytics-zoo/sglang:dev-bmg` plus commit `b4599c0ef` (`xpu: disable GGUF kernel probes by default`), based on `sgl-project/sglang:v0.5.13`.
- sgl-kernel-xpu: `analytics-zoo/sgl-kernel-xpu:dev-bmg`, based on `sgl-project/sgl-kernel-xpu:ea5c70f0909bcd55ceaf1803302651fc0593b64d`.

## Validation

- Generated both patches from the source branches.
- Ran `git apply --check --whitespace=nowarn` against each pinned upstream base.
- Ran `git diff --check` on the non-generated files.
- Ran `bash -n sglang/scripts/start_qwen3_6_service.sh`.
