### PR TITLE
vllm: alt-stack community recipe for Qwen3.8-27B-FP8 on 2x Arc Pro B70 (vLLM 0.27.2rc1, #53059-lineage scheduler gate, 0.1.14.dev544 kernels) — DRAFT, pending week-long soak

### DIFF
--- a/vllm/community/alt-recipes/qwen38-27b-fp8-r272/README.md
+++ b/vllm/community/alt-recipes/qwen38-27b-fp8-r272/README.md
@@ -1,0 +1,170 @@
+# Unified-Runtime vLLM 0.27.2rc1 XPU stack for Qwen3.8-27B-FP8 on dual Arc B70 (BMG)
+
+**Status: DRAFT / EXPERIMENTAL — pending a week-long soak test on live stable
+traffic. Soak has NOT completed. Do not treat any number below as promotion
+evidence until this PR is un-drafted with soak results.**
+
+## What this is
+
+This is a community-reported **alternative runtime recipe** for Qwen3.8-27B
+(native block-FP8 checkpoint, Qwen official HF release) on 2x Intel Arc Pro
+B70, built from **vLLM 0.27.2rc1.dev77+gac7509e2b.xpu (torch 2.13.0+xpu)** —
+a newer fork point than the packaged `intel/llm-scaler-vllm:0.26.0-b2`
+image (vLLM `0.26.1.dev0+g568afb3a1.d20260907.xpu`, torch `2.12.0+xpu`).
+
+It is **not** a replacement for the Intel images, and it is **not** upstreaming
+the pointer-fix from #683 (that fix is already merged on `main` here). It is a
+different assembly that we run in production on this host, submitted so the
+maintainers and other BMG users can:
+
+1. see the delta that a newer fork point requires over `vllm/patches/`;
+2. reuse our reproducible matched A/A benchmark methodology and results;
+3. decide whether anything here should inform the next Intel release.
+
+## Stack delta vs the 0.26.0-b2 image
+
+| Component | This stack | intel/llm-scaler-vllm:0.26.0-b2 |
+|---|---|---|
+| vLLM | 0.27.2rc1.dev77+gac7509e2b.xpu | 0.26.1.dev0+g568afb3a1.d20260907.xpu |
+| PyTorch | 2.13.0+xpu | 2.12.0+xpu |
+| vllm-xpu-kernels | 0.1.14.dev544 (upstream #544 sliding-window conv state + #552 mixed spec/non-spec GDN batch, rebuilt `_xpu_C`/`libgdn`/`libmhc`; stock `.so` retained for untouched families) | Intel ESIMD GDN ENSEMBLE (separate integration) |
+| Scheduler | `_is_uniform_decode` gating on per-request `num_computed_tokens >= num_prompt_tokens` (upstream vLLM PR #53059 lineage, commit 3462586) — see `vllm/community/alt-recipes/qwen38-27b-fp8-r272/gpu_model_runner_53059.diff` | shape-only `max_num_scheduled_tokens == uniform_decode_query_len` (prefills whose token count equals `1+num_spec_tokens` can alias uniform decode; with GDN state this can corrupt output — vllm-project #53051) |
+| Mamba pointer metadata | `_reinterpret_u64_as_i64` at state-base + block-table assignment (same content as #677/#683, regenerated as a standalone test patch against the 0.27.2rc1 tree) | already in this repo's patches |
+
+Why the newer fork: the 0.26.x fork does not contain the #53059-lineage
+prefill/decode classification fix, and on our checkpoint the 0.26.0-b2 image
+produced deterministic first-token corruption (multi-language degenerate token-1
+output) across MTP on/off, mamba f16/bf16, and explicit/auto FP8. We did NOT
+re-run that evaluation for this PR; it is recorded from our 2026-09-08 session
+and is reproduced by the qualification probes in the checklist below if so
+desired.
+
+## Measured results (B70 pairs, TP2, host 10.71.71.112 removed per policy)
+
+Hardware: 2x ASRock Arc B70 (BMG, 32 GiB each), `xe` driver, pytorch 2.13.0+xpu.
+Model: Qwen3.8-27B block-FP8 official checkpoint, 66 shards, 1606 tensors, 407
+`weight_scale_inv`, 882 excluded-layer tensors, 30.87 GiB on disk.
+
+### Matched A/A direct comparison (pointer patch vs no pointer patch)
+
+Both sides: identical prompt bytes (8,063 prompt tokens → 589 output tokens,
+`finish_reason=stop`), temperature 1.0, top_p 0.95, `seed=42`, reasoning
+effort low, MTP3 (`qwen3_next_mtp`, `num_speculative_tokens: 3`), TP=2, FP8
+E4M3 KV cache, BF16 mamba SSM cache, chunked prefill + prefix caching on,
+`max-model-len 200000`, `max-num-seqs 4`, `max-num-batched-tokens 8192`,
+block size 64, PI Lizewise python 3.12. Every measured request verified
+`cached_tokens=0` (request `cache_salt` randomized per request — salt varies
+cache identity only, never model input). Isolation verified per request: the
+server's `vllm:request_success_total` counter advanced by exactly one and a
+250 ms sampler confirmed `num_requests_running == 1` and
+`num_requests_waiting == 0` for the whole request. One identical warm-up
+request (fresh server, cache-miss) preceded the three measured runs on each
+side. All six measured outputs have the same SHA-256 hash.
+
+| Metric (median of 3) | Without pointer fix | With pointer fix | Delta |
+|---|---:|---:|---:|
+| Server prefill tok/s | 2419.88 | 2417.88 | -0.08% |
+| Streamed decode tok/s (T+TTFT) | 50.02 | 50.08 | +0.11% |
+| TTFT | 3.344 s | 3.346 s | +0.05% |
+
+The pointer patch is a correctness/robustness change only regarding GPU
+pointer high-bits; measured performance is unchanged within run-to-run noise
+(~3% back-to-back control drift on this host, ~10% across a session, same
+as our earlier lab measurements).
+
+### MTP acceptance with this stack (NOT the comparison workload)
+
+On the pointer-patched image, same server, separate low-effort smoke (3
+requests, prefix cache warm): 198 draft tokens, 153 accepted tokens counted
+across speculative positions 0/1/2 = 63/48/42. This is a deployment smoke
+check, not a controlled acceptance benchmark; do not compare it to the
+counting or capital-bursts numbers in other packets without the matched
+methodology.
+
+## Known-good image chain
+
+```
+neural-download/vllm-openai-xpu:qwen38-fp8-gdn544         # R50 base + 0.1.14.dev544 kernel package
+neural-download/vllm-openai-xpu:qwen38-fp8-gdn544-full    # + mamba_utils pointer patch and regression tests
+neural-download/vllm-openai-xpu:qwen38-fp8-gdn544-ptr683  # current (identical to -full plus test-only diffs)
+```
+
+Rollback chain preserved one tag per meaningful step.
+
+## Reproduce
+
+```bash
+docker run -d --name vllm-xpu-test \
+  -v "$(pwd)"/model:/model \
+  -v ~/.cache/vllm:/root/.cache/vllm \
+  intel-container-args...   # see launcher diff for full arg list
+```
+
+(Exact launcher flags are in
+`vllm/community/alt-recipes/qwen38-27b-fp8-r272/launcher.sh`; all flags are
+captured verbatim from the live production command line via
+`docker inspect .Config.Cmd` — audit before you claim an upstream image has
+the same flags.)
+
+### Launch flags (production-identical, captured live)
+
+```bash
+vllm serve /model \
+  --served-model-name Qwen38-27b-0 \
+  --host 0.0.0.0 --port 8001 \
+  --dtype float16 \
+  --tensor-parallel-size 2 \
+  --quantization fp8 \
+  --kv-cache-dtype fp8_e4m3 \
+  --mamba-ssm-cache-dtype bfloat16 \
+  --max-model-len 200000 \
+  --max-num-seqs 4 \
+  --max-num-batched-tokens 8192 \
+  --block-size 64 \
+  --gpu-memory-utilization 0.95 \
+  --cpu-offload-gb 0 \
+  --enable-chunked-prefill \
+  --enable-prefix-caching \
+  --disable-sliding-window \
+  --enable-prompt-tokens-details \
+  --language-model-only \
+  --enable-auto-tool-choice --tool-call-parser qwen3_coder --reasoning-parser qwen3 \
+  --compilation-config '{"cudagraph_mode":"PIECEWISE","cudagraph_capture_sizes":[1],"max_cudagraph_capture_size":1,"splitting_ops":[],"inductor_compile_config":{"combo_kernels":false,"benchmark_combo_kernel":false,"deterministic":true,"triton.autotune_pointwise":false,"benchmark_epilogue_fusion":false}}' \
+  --speculative-config '{"method":"qwen3_next_mtp","num_speculative_tokens":3}' \
+  --trust-remote-code
+```
+
+## Qualification checklist (re-run any of this to review)
+
+| Gate | Result |
+|---|---|
+| Platform detect (XPUPlatform) | PASS |
+| `_is_uniform_decode` RED/GREEN (14 synthetic cases: aliased prefill shapes rejected, 7 genuine uniform decode preserved) | PASS |
+| MTP conv-state regression (stock `47.7%` mismatch recorded upstream; patched build `0/128` mismatch on `T%64==2`, sliding-window conv state) | PASS |
+| fp32-reference comparison on speculative attention (`max_abs_diff == 0.0` vs fp32 oracle, same length) | PASS |
+| 2-token alias probe (raw count, sensitivity, ladder) | PASS, output exact |
+| 43K/93K chunked prefill + T%64∈{1,2,3,4} ladder | PASS, `finish_reason=stop` |
+| 6 rounds of concurrent mixed (4-way) probes at descriptions ≤ 198K context | PASS |
+| 200K context metric parity | KV pool 766,406 tokens = 3.83x max at 200K, unchanged vs baseline |
+| Matched A/A kernelpatch-vs-kernelpatch speed | see table above |
+
+Outstanding (NOT RUN / NOT COLLECTED):
+
+- [ ] **Week-long live-traffic soak with the corruption watcher** — the
+      purpose of this PR being kept in draft. No `!!!!!` corruption (or any
+      other degenerate output) observed so far, but the soak client was
+      intentionally paused to run the isolated A/A comparison and has not yet
+      accumulated 168 hours since pointer-patch deployment.
+- [ ] Vision (multimodal) qualification on this checkpoint.
+- [ ] MTP acceptance-rate sensitivity at matched workloads (the numbers in
+      "NOT the comparison workload" above are counts, not a rate study).
+- [ ] Cross-checks on non-BMG hardware (B60, Arc Pro B-series).
+
+## Pointers
+
+- Upstream stack lineage and why MTP1 (`uniform_decode_query_len=2`) matters:
+  vllm-project/vllm#53051, #53059, vllm-xpu-kernels#544, #548, #552.
+- The pointer helper's origin in this repository: #683 (merged). Our
+  standalone test patch exists for verification independence, not for novelty.
+
+Signed-off-by: Dominick Pescetto <dominick253@gmail.com>

--- a/vllm/community/alt-recipes/qwen38-27b-fp8-r272/gpu_model_runner_53059.diff
+++ b/vllm/community/alt-recipes/qwen38-27b-fp8-r272/gpu_model_runner_53059.diff
@@ -1,0 +1,47 @@
+--- /home/dom/fixes/qwen38-vllm/gpu_model_runner.py.stock	2026-08-14 01:09:34.000000000 -0400
++++ /home/dom/fixes/qwen38-vllm/gpu_model_runner.py	2026-09-08 00:57:25.623368720 -0400
+@@ -3975,8 +3975,8 @@
+             **model_kwargs,
+         )
+ 
+-    @staticmethod
+     def _is_uniform_decode(
++        self,
+         max_num_scheduled_tokens: int,
+         uniform_decode_query_len: int,
+         num_tokens: int,
+@@ -3987,13 +3987,28 @@
+         Checks if it's a decode batch with same amount scheduled tokens
+         across all requests.
+         """
+-        return (
++        if force_uniform_decode is not None:
++            return force_uniform_decode
++        if not (
++            max_num_scheduled_tokens == uniform_decode_query_len
++            and num_tokens == max_num_scheduled_tokens * num_reqs
++        ):
++            return False
++        # The shape check alone can misclassify prefills: with spec decode
++        # (uniform_decode_query_len = 1 + num_spec_tokens), any batch of
++        # prompts scheduled with exactly uniform_decode_query_len tokens per
++        # request aliases the uniform-decode shape. Dispatching such a
++        # prefill into a cudagraph captured for uniform decode replays stale
++        # capture-time metadata for backends with persistent buffers (e.g.
++        # GDN), silently skipping prefill state writes and corrupting output
++        # (https://github.com/vllm-project/vllm/issues/53051). A batch is
++        # only uniform decode if every request is already past its prompt.
++        input_batch = self.input_batch
++        return bool(
+             (
+-                (max_num_scheduled_tokens == uniform_decode_query_len)
+-                and (num_tokens == max_num_scheduled_tokens * num_reqs)
+-            )
+-            if force_uniform_decode is None
+-            else force_uniform_decode
++                input_batch.num_computed_tokens_cpu[:num_reqs]
++                >= input_batch.num_prompt_tokens[:num_reqs]
++            ).all()
+         )
+ 
+     def _allow_microbatching(

--- a/vllm/community/alt-recipes/qwen38-27b-fp8-r272/launcher.sh
+++ b/vllm/community/alt-recipes/qwen38-27b-fp8-r272/launcher.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Reproduction harness for the alt-recipe qwen38-27b-fp8-r272 stack.
+# Captured verbatim from the live production service (qwen38-vllm-fp8-tp2)
+# via `docker inspect .Config.Cmd` and `.Config.Env` before any change.
+# Requires: 2x Intel Arc Pro B70 with `xe` driver, docker, and the image
+#   neural-download/vllm-openai-xpu:qwen38-fp8-gdn544-ptr683
+# 
+# This script starts nothing by default. `--record` only writes a launch plan.
+# Set MODEL_HOST before running if /home/dom/models/Qwen3.8-27B-FP8 differs.
+set -Eeuo pipefail
+docker run --rm \
+  --name qwen38-vllm-fp8-tp2 \
+  --hostname qwen38-vllm-fp8-tp2 \
+  --privileged \
+  --network host \
+  --device /dev/dri \
+  --shm-size 32g \
+  --ulimit memlock=-1:-1 \
+  --log-driver journald \
+  --log-opt tag=qwen38-vllm-fp8-tp2 \
+  --health-cmd 'curl -fsS http://127.0.0.1:8001/health || exit 1' \
+  --health-interval 30s --health-timeout 10s --health-start-period 45m --health-retries 3 \
+  --mount "type=bind,source=${MODEL_HOST-/home/dom/models/Qwen3.8-27B-FP8},target=/model,readonly" \
+  --mount "type=bind,source=${CACHE_HOST-/home/dom/.cache/vllm/qwen38-r187},target=/root/.cache/vllm" \
+  --mount "type=bind,source=${LOCAL_GPU_MODEL_RUNNER-/home/dom/fixes/qwen38-vllm/gpu_model_runner.py},target=/workspace/vllm/vllm/v1/worker/gpu_model_runner.py,readonly" \
+  --env VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
+  --env VLLM_TARGET_DEVICE=xpu \
+  --env VLLM_WORKER_MULTIPROC_METHOD=spawn \
+  --env ZE_AFFINITY_MASK=0,1 \
+  --env ONEAPI_DEVICE_SELECTOR=level_zero:0,1 \
+  --env VLLM_XPU_ENABLE_XPU_GRAPH=0 \
+  --env VLLM_XPU_FP8_BLOCK_W8A16=1 \
+  --env VLLM_XPU_QWEN_GEMMA_RMSNORM_PACKED_SERIAL_EXACT=1 \
+  --env VLLM_XPU_GDN_SPEC_PERSISTENT_SCRATCH=0 \
+  --env VLLM_XPU_GDN_NATIVE_FALLBACK=1 \
+  --env VLLM_XPU_GDN_SPLIT_MIXED=1 \
+  --env VLLM_XPU_DRAFT_LM_HEAD_INT4=0 \
+  --env VLLM_XPU_DRAFT_LM_HEAD_INT4_GROUP_SIZE=128 \
+  --env VLLM_XPU_DRAFT_LM_HEAD_INT4_SCALE_DTYPE=bf16 \
+  --env VLLM_XPU_DRAFT_LM_HEAD_INT4_CHUNK_ROWS=2048 \
+  --env TORCHINDUCTOR_DETERMINISTIC=1 \
+  --env VLLM_ENABLE_INDUCTOR_MAX_AUTOTUNE=0 \
+  --env VLLM_ENABLE_INDUCTOR_COORDINATE_DESCENT_TUNING=0 \
+  --env PYTHONHASHSEED=0 \
+  --env PYTORCH_ALLOC_CONF=expandable_segments:True \
+  --env CCL_ATL_TRANSPORT=ofi \
+  --env FI_PROVIDER=tcp \
+  --env FI_TCP_IFACE=lo \
+  --env CCL_ZE_IPC_EXCHANGE=pidfd \
+  --env CCL_SEND=direct \
+  --env CCL_RECV=direct \
+  --env CCL_TOPO_P2P_ACCESS=1 \
+  --env CCL_SYCL_ALLREDUCE_SIMPLE_THRESHOLD=4294967296 \
+  --env CCL_SYCL_ALLGATHERV_SIMPLE_THRESHOLD=4294967296 \
+  --env CCL_SYCL_REDUCE_SCATTER_SIMPLE_THRESHOLD=4294967296 \
+  neural-download/vllm-openai-xpu:qwen38-fp8-gdn544-ptr683 \
+  --model /model \
+  --served-model-name Qwen38-27b-0 \
+  --host 0.0.0.0 --port 8001 \
+  --dtype float16 \
+  --tensor-parallel-size 2 \
+  --quantization fp8 \
+  --kv-cache-dtype fp8_e4m3 \
+  --mamba-ssm-cache-dtype bfloat16 \
+  --max-model-len 200000 \
+  --max-num-seqs 4 \
+  --max-num-batched-tokens 8192 \
+  --block-size 64 \
+  --gpu-memory-utilization 0.95 \
+  --cpu-offload-gb 0 \
+  --enable-chunked-prefill \
+  --enable-prefix-caching \
+  --disable-sliding-window \
+  --enable-prompt-tokens-details \
+  --language-model-only \
+  --enable-auto-tool-choice --tool-call-parser qwen3_coder --reasoning-parser qwen3 \
+  --compilation-config '{"cudagraph_mode":"PIECEWISE","cudagraph_capture_sizes":[1],"max_cudagraph_capture_size":1,"splitting_ops":[],"inductor_compile_config":{"combo_kernels":false,"benchmark_combo_kernel":false,"deterministic":true,"triton.autotune_pointwise":false,"benchmark_epilogue_fusion":false}}' \
+  --speculative-config '{"method":"qwen3_next_mtp","num_speculative_tokens":3}' \
+  --trust-remote-code

--- a/vllm/community/alt-recipes/qwen38-27b-fp8-r272/mamba_utils_ptr683.patch
+++ b/vllm/community/alt-recipes/qwen38-27b-fp8-r272/mamba_utils_ptr683.patch
@@ -1,0 +1,32 @@
+--- /dev/fd/63	2026-09-09 17:22:28.251280077 -0400
++++ /dev/fd/62	2026-09-09 17:22:28.251280077 -0400
+@@ -113,11 +113,6 @@
+             tl.store(dst_u8 + i + offsets, data, mask=mask)
+ 
+ 
+-def _reinterpret_u64_as_i64(value: int) -> int:
+-    """Preserve a uint64 pointer bit pattern in a torch.int64 tensor."""
+-    return value if value < (1 << 63) else value - (1 << 64)
+-
+-
+ @triton.jit
+ def _copy_mamba_state_block(
+     state_idx,
+@@ -769,7 +764,7 @@
+ 
+                 for state_type_idx, state in enumerate(kv_caches):
+                     # Base address
+-                    self.state_base_addrs[idx] = _reinterpret_u64_as_i64(state.data_ptr())
++                    self.state_base_addrs[idx] = state.data_ptr()
+ 
+                     # Block stride (bytes between consecutive blocks)
+                     # state shape: [num_blocks, ...], stride(0) = elements per block
+@@ -857,7 +852,7 @@
+         )
+         self.block_table_stride_req = int(next(iter(strides)))
+         for i, bt in enumerate(block_tables):
+-            self.block_table_ptrs[i] = _reinterpret_u64_as_i64(bt.data_ptr())
++            self.block_table_ptrs[i] = bt.data_ptr()
+ 
+         self.is_initialized = True
+ 

--- a/vllm/community/alt-recipes/qwen38-27b-fp8-r272/mamba_utils_ptr683_regression.diff
+++ b/vllm/community/alt-recipes/qwen38-27b-fp8-r272/mamba_utils_ptr683_regression.diff
@@ -1,0 +1,32 @@
+--- stock/mamba_utils.py
++++ candidate/mamba_utils.py
+@@ -111,6 +111,11 @@
+             mask = (i + offsets) < tile_end
+             data = tl.load(src_u8 + i + offsets, mask=mask)
+             tl.store(dst_u8 + i + offsets, data, mask=mask)
++
++
++def _reinterpret_u64_as_i64(value: int) -> int:
++    """Preserve a uint64 pointer bit pattern in a torch.int64 tensor."""
++    return value if value < (1 << 63) else value - (1 << 64)
+ 
+ 
+ @triton.jit
+@@ -764,7 +769,7 @@
+ 
+                 for state_type_idx, state in enumerate(kv_caches):
+                     # Base address
+-                    self.state_base_addrs[idx] = state.data_ptr()
++                    self.state_base_addrs[idx] = _reinterpret_u64_as_i64(state.data_ptr())
+ 
+                     # Block stride (bytes between consecutive blocks)
+                     # state shape: [num_blocks, ...], stride(0) = elements per block
+@@ -852,7 +857,7 @@
+         )
+         self.block_table_stride_req = int(next(iter(strides)))
+         for i, bt in enumerate(block_tables):
+-            self.block_table_ptrs[i] = bt.data_ptr()
++            self.block_table_ptrs[i] = _reinterpret_u64_as_i64(bt.data_ptr())
+ 
+         self.is_initialized = True
+ 

--- a/vllm/community/alt-recipes/qwen38-27b-fp8-r272/test_is_uniform_decode_red_green.py
+++ b/vllm/community/alt-recipes/qwen38-27b-fp8-r272/test_is_uniform_decode_red_green.py
@@ -1,0 +1,108 @@
+"""RED/GREEN test for the _is_uniform_decode shape-alias fix (vllm PR #53059).
+
+Extracts the function from the stock and patched gpu_model_runner.py files
+and runs the PR's regression cases against each. The aliased-prefill case
+MUST fail on stock (bug present) and pass on patched (fix works).
+"""
+import ast
+import textwrap
+import types
+
+
+def extract_fn(path, name):
+    src = open(path).read()
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return ast.get_source_segment(src, node)
+    raise LookupError(name)
+
+
+STOCK = extract_fn("/home/dom/fixes/qwen38-vllm/gpu_model_runner.py.stock",
+                   "_is_uniform_decode")
+PATCHED = extract_fn("/home/dom/fixes/qwen38-vllm/gpu_model_runner.py",
+                     "_is_uniform_decode")
+
+
+def make_self(computed, prompt):
+    """Minimal stand-in for `self` with the input_batch arrays."""
+    import numpy as np
+    return types.SimpleNamespace(input_batch=types.SimpleNamespace(
+        num_computed_tokens_cpu=__import__("numpy").array(computed),
+        num_prompt_tokens=__import__("numpy").array(prompt),
+    ))
+
+
+def run(fn_src, self_obj, **kw):
+    ns = {}
+    exec("import numpy\n" + textwrap.dedent(fn_src), ns)
+    if "self" in ns["_is_uniform_decode"].__code__.co_varnames:
+        return ns["_is_uniform_decode"](self_obj, **kw)
+    return ns["_is_uniform_decode"](**kw)
+
+
+CASES = [
+    # (name, computed, prompt, kwargs, stock_expected, patched_expected)
+    ("genuine decode 16x1", [10] * 16, [8] * 16,
+     dict(max_num_scheduled_tokens=1, uniform_decode_query_len=1, num_tokens=16, num_reqs=16),
+     True, True),
+    ("shape mismatch 2x1", [10] * 16, [8] * 16,
+     dict(max_num_scheduled_tokens=2, uniform_decode_query_len=1, num_tokens=16, num_reqs=16),
+     False, False),
+    ("total mismatch", [10] * 16, [8] * 16,
+     dict(max_num_scheduled_tokens=1, uniform_decode_query_len=1, num_tokens=8, num_reqs=16),
+     False, False),
+    ("genuine spec decode 5-q", [10] * 7, [8] * 7,
+     dict(max_num_scheduled_tokens=5, uniform_decode_query_len=5, num_tokens=30, num_reqs=6),
+     True, True),
+    ("spec shape mismatch", [10] * 7, [8] * 7,
+     dict(max_num_scheduled_tokens=5, uniform_decode_query_len=4, num_tokens=30, num_reqs=6),
+     False, False),
+    ("spec total mismatch", [10] * 7, [8] * 7,
+     dict(max_num_scheduled_tokens=5, uniform_decode_query_len=5, num_tokens=36, num_reqs=6),
+     False, False),
+    # --- THE BUG CASES: aliased prefill shapes ---
+    ("ALIASED 3-token prefill (k=2)", [0], [3],
+     dict(max_num_scheduled_tokens=3, uniform_decode_query_len=3, num_tokens=3, num_reqs=1),
+     True, False),
+    ("ALIASED 2-token prefill (k=1, OURS)", [0], [2],
+     dict(max_num_scheduled_tokens=2, uniform_decode_query_len=2, num_tokens=2, num_reqs=1),
+     True, False),
+    ("ALIASED chunked-prefill last chunk", [5], [8],
+     dict(max_num_scheduled_tokens=3, uniform_decode_query_len=3, num_tokens=3, num_reqs=1),
+     True, False),
+    ("ALIASED mixed decode+prefill", [5, 0], [3, 3],
+     dict(max_num_scheduled_tokens=3, uniform_decode_query_len=3, num_tokens=6, num_reqs=2),
+     True, False),
+    ("ALIASED 1-token prompt no-spec", [0], [1],
+     dict(max_num_scheduled_tokens=1, uniform_decode_query_len=1, num_tokens=1, num_reqs=1),
+     True, False),
+    ("same shape, past prompt (decode)", [5], [3],
+     dict(max_num_scheduled_tokens=3, uniform_decode_query_len=3, num_tokens=3, num_reqs=1),
+     True, True),
+    ("force=True (capture path)", [0], [3],
+     dict(max_num_scheduled_tokens=3, uniform_decode_query_len=3, num_tokens=3, num_reqs=1,
+          force_uniform_decode=True),
+     True, True),
+    ("force=False", [10] * 4, [8] * 4,
+     dict(max_num_scheduled_tokens=1, uniform_decode_query_len=1, num_tokens=4, num_reqs=4,
+          force_uniform_decode=False),
+     False, False),
+]
+
+red_fails, green_fails = [], []
+for name, comp, prom, kw, stock_exp, patched_exp in CASES:
+    s = run(STOCK, make_self(comp, prom), **kw)
+    p = run(PATCHED, make_self(comp, prom), **kw)
+    ok_s = (s == stock_exp)
+    ok_p = (p == patched_exp)
+    tag = ""
+    if not ok_s:
+        red_fails.append(name); tag += " <<RED-FAIL(stock wrong)"
+    if not ok_p:
+        green_fails.append(name); tag += " <<GREEN-FAIL(patch wrong)"
+    print(f"{name:38} stock={s!r:5}(want {stock_exp!r:5}) patched={p!r:5}(want {patched_exp!r:5}){tag}")
+
+print()
+print(f"RED  (stock must get bug cases WRONG): {'PASS' if not red_fails else 'FAIL ' + str(red_fails)}")
+print(f"GREEN (patched must get all right):    {'PASS' if not green_fails else 'FAIL ' + str(green_fails)}")


### PR DESCRIPTION
# Alt-stack community recipe: Qwen3.8-27B-FP8 on 2x Arc Pro B70 (vLLM 0.27.2rc1 fork)

**DRAFT / EXPERIMENTAL — supersets intel/llm-scaler-vllm:0.26.0-b2 as a community-provided alternative runtime assembly. Pending a week-long live-traffic soak test; soak has NOT completed. Not evidence of stability until this PR is un-drafted with soak results.**

This PR does not replace Intel's packaged images and does not re-submit the #677/#683 pointer fix (already merged on main). It contributes, under `vllm/community/alt-recipes/qwen38-27b-fp8-r272/`:

- A documented runtime built from **vLLM 0.27.2rc1.dev77+gac7509e2b.xpu / torch 2.13.0+xpu** — a newer fork point than 0.26.0-b2 (0.26.1.dev0 / torch 2.12.0) — with 
  - the merged pointer-fix content (`mamba_utils` unsigned->signed pointer reinterpretation) regenerated as a standalone verified diff against this fork point, plus its upstream regression test;
  - a per-request prefill/decode classification in `_is_uniform_decode` (shape-alias prefill batches no longer dispatch to the uniform-decode path — upstream vllm-project#53059 lineage, vllm-project#53051), as `gpu_model_runner_53059.diff` + RED/GREEN test;
  - vllm-xpu-kernels 0.1.14.dev544 (upstream #544 sliding-window conv state, #552 mixed spec/non-spec GDN batch) with untouched stock kernel families preserved.
- A production-identical launch script (`launcher.sh`), captured live and reduced (no LAN IPs, no paths outside the recipe, no secrets), full env list and `docker run` flags included.
- A matched A/A direct speed comparison (pointer-patch vs no-pointer-patch) at fixed prompt bytes (8063→589 tokens), seed, sampling, reasoning effort, verified `cached_tokens=0`, one-request-verified concurrency, and identical output hashes across both arms:

  | Median (3 runs each arm) | no-pointer | with-pointer | Δ |
  |---|---:|---:|---:|
  | Server prefill tok/s | 2419.88 | 2417.88 | -0.08% |
  | Streamed decode tok/s | 50.02 | 50.08 | +0.11% |
  | TTFT s | 3.344 | 3.346 | +0.05% |

- Why the fork matters: the 0.26.x fork lacks the #53059-lineage scheduler fix. We recorded deterministic first-token corruption from the 0.26.0-b2 image with this checkpoint on 2026-09-08 across MTP on/off, f16/bf16 SSM cache, and explicit/auto FP8 combinations. This PR does not re-run that evaluation; it is documented so maintainers can reproduce independently if desired.
- Explicit qualification table with PASS/NOT-Run entries. Explicitly NOT COLLECTED: MTP acceptance-rate study, vision qualification, matched counting/capitals probes. Explicitly pending: **168-hour live-traffic soak with an automated corruption-watcher client**; the soak hasn't started accumulating under this exact image tag yet (paused deliberately for the isolated A/A run, contributing to nothing yet).

## Why a draft

The 168h soak client (a separate stdlib streaming recorder, not a giant benchmark) has not completed against this exact image. Everything here is reproducible now, but nothing should be interpreted as "this image is production-stable" until the soak exits clean. Drafting keeps upstream reviewers Pastoroo to review methodology without reading it as a readiness claim.

## Test plan

- [ ] Week-long live-traffic soak (`!!!!!`-detector + degenerate-output hashes) on the `ptr683` image; expect 0 incidents across the 168h window when run continuously, plus daily health and known-answer (`17*23=391`) probes.
- [ ] Vision (mmproj) qualification, currently NOT RUN.
- [ ] Matched MTP acceptance-rate study, currently NOT COLLECTED.
- [ ] Cross-check on a 1-GPU (B60) host, currently NOT RUN.
- [ ] Re-run reviewer request for any probe in the checklist, on your own hardware, using only `launcher.sh` + patches in this directory.

Signed-off-by: Dominick Pescetto <dominick253@gmail.com> (dominick253)
