### PR TITLE
Guard `info_once()` in `SymInt4LinearMethod.apply()` so sym_int4 can start under torch.compile / XPU graph

### DIFF
--- a/vllm/patches/vllm_for_multi_arc.patch
+++ b/vllm/patches/vllm_for_multi_arc.patch
@@ -11415,10 +11415,10 @@ index 000000000..a5465c7d1
 +    )
 diff --git a/vllm/model_executor/layers/quantization/sym_int4.py b/vllm/model_executor/layers/quantization/sym_int4.py
 new file mode 100644
-index 000000000..94a6222b6
+index 000000000..9cf2279c1
 --- /dev/null
 +++ b/vllm/model_executor/layers/quantization/sym_int4.py
-@@ -0,0 +1,722 @@
+@@ -0,0 +1,724 @@
 +# SPDX-License-Identifier: Apache-2.0
 +# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 +"""Runtime symmetric INT4 weight-only quantization for Intel XPU.
@@ -11814,16 +11814,18 @@ index 000000000..94a6222b6
 +            allow_batch=allow_batch_esimd,
 +        )
 +        if output is not None:
-+            logger.info_once(
-+                "sym_int4 linear execution is using the guarded ESIMD path.",
-+                scope="local",
-+            )
++            if not torch.compiler.is_compiling():
++                logger.info_once(
++                    "sym_int4 linear execution is using the guarded ESIMD path.",
++                    scope="local",
++                )
 +            return output.reshape(x.shape[:-1] + (output.shape[-1],))
 +
-+        logger.info_once(
-+            "sym_int4 linear execution is using the XPU W4A16 kernel.",
-+            scope="local",
-+        )
++        if not torch.compiler.is_compiling():
++            logger.info_once(
++                "sym_int4 linear execution is using the XPU W4A16 kernel.",
++                scope="local",
++            )
 +        output = torch.ops._xpu_C.int4_gemm_w4a16(
 +            x_2d,
 +            layer.qweight,


### PR DESCRIPTION
## Summary
On `intel/llm-scaler-vllm:0.26.0-b2`, serving any `sym_int4` model with a compiled mode
(`VLLM_XPU_ENABLE_XPU_GRAPH=1`, or compile-only) fails at engine init:

```
torch._dynamo.exc.Unsupported: logging.Logger method not supported for non-export cases
  Developer debug context: <Logger ...quantization.sym_int4>.info_once
```

`sym_int4.py` calls `logger.info_once()` twice inside the traced `SymInt4LinearMethod.apply()`
forward path; Dynamo refuses to trace a `logging.Logger` method and aborts startup. Only
`--enforce-eager` starts. (Full isolation in #699.)

## Change
Guard the two traced calls with `torch.compiler.is_compiling()`:

```diff
             if output is not None:
+                if not torch.compiler.is_compiling():
                     logger.info_once("sym_int4 ... guarded ESIMD path.", scope="local")
                 return output.reshape(x.shape[:-1] + (output.shape[-1],))

+            if not torch.compiler.is_compiling():
                 logger.info_once("sym_int4 ... XPU W4A16 kernel.", scope="local")
```

The two load-time calls in `_runtime_quantize_q4_0()` are **untouched** — they are never traced
and work correctly.

## Why this form
- The branch is runtime-dependent, so the log cannot move to `__init__` /
  `process_weights_after_loading`.
- `torch.compiler.is_compiling()` is True **only during tracing**, so the diagnostics still emit
  under normal execution (verified: 2 occurrences in a patched run) — **no diagnostic is lost.**
  Strictly better than `torch._dynamo.config.ignore_logging_functions`, which suppresses these
  process-wide.

## Validation (same image/config, only the mounted file varies — B70, 0.26.0-b2, sym_int4, XPU graph, tp=1)
| | dynamo-blocker lines | startup complete | graph capture |
|---|---|---|---|
| unpatched | 2 | no | dies in tracing |
| patched | 0 | yes | **41 s, 5.34 GiB** |

Patched generations coherent. This is the first XPU-graph capture we've achieved on `0.26.0-b2`.

## Important — necessary but not sufficient (please don't misread a later error as failure)
After this patch, startup advances to a stage that was previously unreachable and may surface a
**separate, pre-existing** config incompatibility:

```
ValueError: max_num_seqs (256) exceeds available Mamba cache blocks (164) ...
CUDA graph capture cannot proceed.
```

This is raised at `resolve_cudagraph_mode_and_sizes`, **after** Dynamo tracing — the unpatched
image never reaches it (masked by the earlier crash). Re-running with `--max-num-seqs 128`
captures cleanly. This error is evidence the patch works: it moved startup past the
previously-fatal tracing stage.

## Evidence base
Reproduced across **2 Arc generations** (B60/B70), **4 model architectures** (GDN and non-GDN),
TP=1 and TP=2. Version bisect: **0** `logger` calls in `sym_int4.py` on `0.21.0-b1`/`0.21.0-b3.1`,
**4** on `0.26.0-b2` — a b2 regression. Clean controls: same model on `0.21.0-b3.1` captures in
42 s; `--enforce-eager` on `0.26.0-b2` starts fine. Patch verified `git apply --check` clean
against upstream `vllm-project/vllm` v0.26.0 (`568afb3`), and its only delta vs the repo's current
`vllm_for_multi_arc.patch` is the regenerated hunk header + these two guards.
