### PR TITLE
sglang: enable Qwen GGUF MTP verification in launcher

### DIFF
--- a/sglang/README.md
+++ b/sglang/README.md
@@ -141,10 +141,16 @@ ZE_AFFINITY_MASK=6,7 TP_SIZE=2 PORT=30001 \
 Defaults are `SPEC_NUM_STEPS=3`, `SPEC_TOPK=1`, `SPEC_NUM_DRAFT_TOKENS=4`.
 Use steps `1` and draft tokens `2` for a smaller initial trial. Keep
 `SPEC_TOPK=1`: the XPU GDN verify kernels support a linear chain only.
-The launcher enables `SGL_XPU_GDN_VERIFY_ESIMD` when MTP is requested and
+The launcher enables `SGLANG_XPU_MTP_GDN_VERIFY` when MTP is requested and
 defaults GGUF MTP to `MEM_FRACTION_STATIC=0.65` to leave room for draft weights,
 KV cache and GDN snapshots. Explicit environment overrides are preserved.
 The ordinary GGUF memory default remains `0.8`.
+Here, "verify" means the target-model forward that checks MTP draft tokens
+and saves GDN state snapshots for the accepted prefix. This selects the XPU
+kernels for that inference stage; it is not a test mode or the MTP enable switch.
+`SGL_XPU_GDN_VERIFY_ESIMD` is accepted as a legacy name; the new name takes
+precedence when both are set. The launcher also forwards the resolved value
+under the legacy name for compatibility with older SGLang revisions.
 
 The local `Qwen3.6-27B-Q4_K_M.gguf` does not include an MTP branch; it needs
 a separate matching GGUF draft with those tensors. Do not use another model

--- a/sglang/README.md
+++ b/sglang/README.md
@@ -128,10 +128,32 @@ SPEC_DRAFT_PATH=$MODEL_PATH ZE_AFFINITY_MASK=6,7 \
   bash scripts/start_qwen3_6_service.sh
 ```
 
-Defaults are `SPEC_NUM_STEPS=3`, `SPEC_TOPK=1`, `SPEC_NUM_DRAFT_TOKENS=4`;
-override them to change the tree width. Each verify step runs the target model
+For Qwen3.8-27B, the GGUF includes its MTP branch:
+
+```bash
+MODEL_PATH=/models/Qwen3.8-27B-GGUF/Qwen3.8-27B-UD-Q4_K_M.gguf \
+GGUF_CFG_DIR=/models/Qwen3.8-27B \
+SPEC_DRAFT_PATH=/models/Qwen3.8-27B-GGUF/Qwen3.8-27B-UD-Q4_K_M.gguf \
+ZE_AFFINITY_MASK=6,7 TP_SIZE=2 PORT=30001 \
+  bash scripts/start_qwen3_6_service.sh
+```
+
+Defaults are `SPEC_NUM_STEPS=3`, `SPEC_TOPK=1`, `SPEC_NUM_DRAFT_TOKENS=4`.
+Use steps `1` and draft tokens `2` for a smaller initial trial. Keep
+`SPEC_TOPK=1`: the XPU GDN verify kernels support a linear chain only.
+The launcher enables `SGL_XPU_GDN_VERIFY_ESIMD` when MTP is requested and
+defaults GGUF MTP to `MEM_FRACTION_STATIC=0.65` to leave room for draft weights,
+KV cache and GDN snapshots. Explicit environment overrides are preserved.
+The ordinary GGUF memory default remains `0.8`.
+
+The local `Qwen3.6-27B-Q4_K_M.gguf` does not include an MTP branch; it needs
+a separate matching GGUF draft with those tensors. Do not use another model
+version's MTP weights as its draft.
+
+Each verify step runs the target model
 on `num_draft_tokens x concurrency` rows at once, which is the batch the
-M-tiled ESIMD GEMVs are tuned for, so the gain grows with concurrency. XPU
+M-tiled ESIMD GEMVs are tuned for. Measure acceptance and throughput at the
+intended concurrency; extra draft work does not guarantee a speedup. XPU
 graph capture cannot express the speculative control flow, so decode stays
 eager (`--disable-cuda-graph`) as it already does for the non-MTP paths.
 

--- a/sglang/custom-esimd-kernels/tests/test_gdn_mtp_verify.py
+++ b/sglang/custom-esimd-kernels/tests/test_gdn_mtp_verify.py
@@ -1,0 +1,133 @@
+"""MTP verify snapshots and accepted-prefix commit, at 27B TP-local shapes."""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+if not torch.xpu.is_available():
+    pytest.skip("requires an Intel XPU", allow_module_level=True)
+
+import custom_esimd_kernels_sglang  # noqa: F401,E402
+
+
+@pytest.mark.parametrize("batch,steps", [(1, 2), (4, 2), (1, 4), (4, 4)])
+@pytest.mark.parametrize("state_dtype", [torch.float16, torch.float32])
+def test_verify_snapshots_and_rejected_suffix(batch, steps, state_dtype):
+    torch.set_num_threads(4)
+    g = torch.Generator().manual_seed(20260911)
+    hk, hv, dim = 8, 24, 128
+    width = (2 * hk + hv) * dim
+    slots = batch + 2
+
+    def rand(shape, scale=0.2, dtype=torch.float16):
+        return (torch.randn(shape, generator=g) * scale).to(dtype)
+
+    # Match the real row-strided packed QKV and BA projections.
+    backing = rand((batch * steps, width + hv * dim))
+    packed = backing[:, :width]
+    ba = rand((batch * steps, 2 * hv))
+    a, b = ba[:, hv:], ba[:, :hv]
+    alog, bias = rand((hv,), dtype=torch.float32), rand((hv,), dtype=torch.float32)
+    state = rand((slots, hv, dim, dim), 0.02, state_dtype)
+    cache_ids = torch.arange(batch, 0, -1, dtype=torch.int32)
+    inter_ids = torch.arange(batch, dtype=torch.int32)
+    starts = torch.arange(batch + 1, dtype=torch.int32) * steps
+    xstate = state.xpu()
+    inter = torch.full(
+        (slots, steps, hv, dim, dim), -7, dtype=state_dtype, device="xpu"
+    )
+    output = torch.empty(
+        (1, batch * steps, hv, dim), dtype=torch.float16, device="xpu"
+    )
+    xb = backing.xpu()
+    xba = ba.xpu()
+    torch.ops.eagle_ops.gdn_target_verify_packed(
+        output, xb[:, :width], xba[:, hv:], xba[:, :hv], alog.xpu(), bias.xpu(),
+        xstate, inter, starts.xpu(), cache_ids.xpu(), inter_ids.xpu(),
+        steps, hk, dim, hv, dim,
+    )
+    q, k, v = packed.float().split([hk * dim, hk * dim, hv * dim], -1)
+    # Kernel normalizes using sqrt(sum(x*x) + 1e-6), not clamp(norm, eps).
+    qr = packed[:, : hk * dim].float().reshape(batch, steps, hk, dim)
+    kr = k.reshape(batch, steps, hk, dim)
+    q = qr / (qr.square().sum(-1, keepdim=True) + 1e-6).sqrt() / dim**0.5
+    k = kr / (kr.square().sum(-1, keepdim=True) + 1e-6).sqrt()
+    q, k = q.repeat_interleave(3, 2), k.repeat_interleave(3, 2)
+    v = v.reshape(batch, steps, hv, dim)
+    aa, bb = a.float().reshape(batch, steps, hv), b.float().reshape(batch, steps, hv)
+    decay = torch.exp(-alog.exp() * F.softplus(aa + bias))
+    beta = bb.sigmoid()
+    current = state[cache_ids.long()].float()
+    snapshots, expected_out = [], []
+    for t in range(steps):
+        current = current * decay[:, t, :, None, None]
+        memory = (current * k[:, t, :, None, :]).sum(-1)
+        delta = (v[:, t] - memory) * beta[:, t, :, None]
+        current = current + delta.unsqueeze(-1) * k[:, t, :, None, :]
+        expected_out.append((current * q[:, t, :, None, :]).sum(-1))
+        snapshots.append(current.to(state_dtype))
+    expected_out = torch.stack(expected_out, 1).reshape_as(output).half()
+    expected_inter = torch.stack(snapshots, 1)
+    torch.testing.assert_close(output.cpu(), expected_out, atol=1e-4, rtol=2e-3)
+    torch.testing.assert_close(inter[:batch].cpu(), expected_inter, atol=1e-4, rtol=2e-3)
+    assert torch.equal(xstate.cpu(), state), "verify must leave the main state untouched"
+    assert (inter[batch:] == -7).all(), "verify wrote an unused intermediate slot"
+
+    # Commit first, middle, or last verified state; negative index means no commit.
+    accepted = torch.tensor([0, steps - 1, -1, steps // 2][:batch], dtype=torch.int32)
+    expected_state = state.clone()
+    for r, step in enumerate(accepted.tolist()):
+        if step >= 0:
+            expected_state[cache_ids[r]] = inter[r, step].cpu()
+    torch.ops.eagle_ops.mamba_state_scatter(
+        xstate.unsqueeze(0), inter.unsqueeze(0), cache_ids.xpu(), accepted.xpu()
+    )
+    assert torch.equal(xstate.cpu(), expected_state), "commit selected a rejected suffix"
+
+
+@pytest.mark.parametrize("batch,steps", [(1, 2), (4, 2), (1, 4), (4, 4)])
+def test_conv_verify_snapshots_and_commit(batch, steps):
+    g = torch.Generator().manual_seed(20260912)
+    channels, window = 5120, 4
+    slots = batch + 2
+
+    def rand(shape):
+        return (torch.randn(shape, generator=g) * 0.2).half()
+
+    backing = rand((batch, steps, channels + 3072))
+    x = backing[:, :, :channels]
+    weight, bias = rand((channels, window)), rand((channels,))
+    state = rand((slots, channels, window - 1))
+    ids = torch.arange(batch, 0, -1, dtype=torch.int32)
+    out = torch.empty((batch, steps, channels), dtype=torch.float16, device="xpu")
+    inter = torch.full(
+        (slots, steps, channels, window - 1),
+        -7, dtype=torch.float16, device="xpu",
+    )
+    xs = state.xpu()
+    torch.ops.eagle_ops.causal_conv1d_verify_tm(
+        out, backing.xpu()[:, :, :channels], weight.xpu(), bias.xpu(), xs, inter,
+        ids.xpu(), torch.arange(batch, dtype=torch.int32, device="xpu"), 1,
+    )
+    history = state[ids.long()]
+    outputs, snapshots = [], []
+    for t in range(steps):
+        full = torch.cat([history, x[:, t].unsqueeze(-1)], -1)
+        outputs.append(
+            F.silu((full.float() * weight.float()).sum(-1) + bias.float()).half()
+        )
+        history = full[:, :, 1:]
+        snapshots.append(history)
+    torch.testing.assert_close(out.cpu(), torch.stack(outputs, 1), atol=1e-4, rtol=2e-3)
+    assert torch.equal(inter[:batch].cpu(), torch.stack(snapshots, 1))
+    assert torch.equal(xs.cpu(), state)
+    assert (inter[batch:] == -7).all()
+    accepted = torch.tensor([0, steps - 1, -1, steps // 2][:batch], dtype=torch.int32)
+    expected = state.clone()
+    for r, step in enumerate(accepted.tolist()):
+        if step >= 0:
+            expected[ids[r]] = inter[r, step].cpu()
+    torch.ops.eagle_ops.mamba_state_scatter(
+        xs.unsqueeze(0), inter.unsqueeze(0), ids.xpu(), accepted.xpu()
+    )
+    assert torch.equal(xs.cpu(), expected)

--- a/sglang/scripts/start_qwen3_6_service.sh
+++ b/sglang/scripts/start_qwen3_6_service.sh
@@ -71,7 +71,9 @@ if [[ -n "${SPEC_DRAFT_PATH:-}" ]]; then
     # Use the existing XPU kernels for verification and rollback snapshots,
     # just as decode/extend use their XPU kernels. Ordinary launches leave
     # this MTP-only switch unset; an explicit override is preserved.
-    export SGL_XPU_GDN_VERIFY_ESIMD="${SGL_XPU_GDN_VERIFY_ESIMD:-1}"
+    export SGLANG_XPU_MTP_GDN_VERIFY="${SGLANG_XPU_MTP_GDN_VERIFY:-${SGL_XPU_GDN_VERIFY_ESIMD:-1}}"
+    # Forward the resolved value for SGLang revisions that read the old name.
+    export SGL_XPU_GDN_VERIFY_ESIMD="$SGLANG_XPU_MTP_GDN_VERIFY"
     SPEC_ARGS=(
         --speculative-algorithm NEXTN
         --speculative-draft-model-path "$SPEC_DRAFT_PATH"

--- a/sglang/scripts/start_qwen3_6_service.sh
+++ b/sglang/scripts/start_qwen3_6_service.sh
@@ -36,6 +36,7 @@
 # misleading oneCCL "unknown memory type" during warmup.
 # HOST defaults to 0.0.0.0; use 127.0.0.1 for local-only access.
 # Optional MTP tuning: SPEC_NUM_STEPS=3 SPEC_TOPK=1 SPEC_NUM_DRAFT_TOKENS=4.
+# The XPU GDN verify kernels support linear chains only (SPEC_TOPK=1).
 # For GGUF the served model id defaults to GGUF_CFG_DIR so that OpenAI-style
 # clients can use it as a tokenizer id; override with SERVED_MODEL_NAME.
 # Long-context runs (e.g. BFCL multi-turn) also need
@@ -63,6 +64,14 @@ SPEC_ARGS=()
 SPEC_ON=0
 if [[ -n "${SPEC_DRAFT_PATH:-}" ]]; then
     SPEC_ON=1
+    if [[ "${SPEC_TOPK:-1}" != 1 ]]; then
+        echo "XPU GDN MTP verification requires SPEC_TOPK=1." >&2
+        exit 2
+    fi
+    # Use the existing XPU kernels for verification and rollback snapshots,
+    # just as decode/extend use their XPU kernels. Ordinary launches leave
+    # this MTP-only switch unset; an explicit override is preserved.
+    export SGL_XPU_GDN_VERIFY_ESIMD="${SGL_XPU_GDN_VERIFY_ESIMD:-1}"
     SPEC_ARGS=(
         --speculative-algorithm NEXTN
         --speculative-draft-model-path "$SPEC_DRAFT_PATH"
@@ -84,6 +93,15 @@ if [[ "$MODEL_PATH" == *.gguf ]]; then
         exit 2
     fi
     export SGLANG_GGUF_HF_CONFIG_DIR="$GGUF_CFG_DIR"
+    # The draft weights, KV cache and per-token GDN snapshots need headroom
+    # beyond the target's static allocation. Preserve user memory settings.
+    if [[ -z "${MEM_FRACTION_STATIC:-}" ]]; then
+        if [[ $SPEC_ON == 1 ]]; then
+            MEM_FRACTION_STATIC=0.65
+        else
+            MEM_FRACTION_STATIC=0.8
+        fi
+    fi
     export SGLANG_MAMBA_CONV_DTYPE=float16
     export SGLANG_MAMBA_SSM_DTYPE=float16
     export SGL_XPU_ESIMD_DECODE=1


### PR DESCRIPTION
Setting `SPEC_DRAFT_PATH` enabled NEXTN in the Qwen launcher but did not select the existing XPU GDN verification kernels. The GGUF path also kept the ordinary 0.8 static-memory default despite the additional draft weights, KV cache and state snapshots.

Enable `SGL_XPU_MTP_GDN_VERIFY` when MTP is requested, default GGUF MTP static memory to 0.65, and reject `SPEC_TOPK` values other than 1 because these kernels support linear chains. Explicit environment overrides are preserved. The legacy `SGL_XPU_GDN_VERIFY_ESIMD` name remains accepted; the new name wins on conflicts, and the launcher forwards the resolved value under both names for older SGLang revisions. Here, verify denotes target-model inference over draft tokens and GDN state snapshots, not a test mode. Add a Qwen3.8-27B launch example and regression tests for verify snapshots and accepted-prefix state commits. This reuses the kernels already present after #701. The runtime-side canonical name and legacy alias are added in https://github.com/analytics-zoo/sglang/pull/7; dual-name forwarding keeps the launcher compatible with the preceding runtime.

Validation:

- 12 XPU kernel tests passed: CPU recurrence oracle, strided packed inputs, batch sizes 1/4, 2/4 verify positions, FP16/FP32 SSM state, convolution snapshots, and first/middle/last accepted prefixes plus masked requests.
- Eight initial launch-default checks and 28 additional captured GGUF/HF ordinary/MTP configurations passed, including old/new-name precedence and legacy forwarding. Seven runtime environment cases passed at both GDN call sites, plus seven fresh-import checks for the downstream `SGL_XPU_` namespace; topk=2 rejects before launch. Shell syntax and diff checks passed.
- Qwen3.6/3.8 27B GGUF: TP=2 on XPU 6/7, eager execution, identical static-memory fraction 0.65 for ordinary/MTP comparisons. JSON, marker and generated-prefix cache checks passed. Ordinary and 3-step MTP each scored 31/32 on the same five-shot GSM8K subset, with identical final answers within each model and no transport errors or truncations.

Short performance comparison, median of three repetitions with 128 output tokens per request and a cache flush before each wave. C1 is one request; C4 is aggregate throughput over four concurrent requests. Rates include prefill and first-token waiting.

| Configuration | C1 tok/s | C4 total tok/s | GSM32 elapsed s |
|---|---:|---:|---:|
| Qwen3.6 ordinary | 30.10 | 73.99 | 82.65 |
| Qwen3.6 MTP, 3 steps | 49.00 | 94.50 | 58.65 |
| Qwen3.8 ordinary | 22.35 | 66.51 | 95.42 |
| Qwen3.8 MTP, 3 steps | 40.80 | 80.36 | 66.75 |

Qwen3.8 uses its embedded Q6_K/Q8_0 MTP branch. The tested Qwen3.6 main GGUF omits MTP, so its matching local HF MTP tensors were exported to a separate Q8_0 draft for this comparison. Main GGUF files were unchanged. Cross-version figures therefore describe different quantization mixes; each model's comparison with its own ordinary baseline is the relevant MTP speedup. The number-sequence performance prompt has high acceptance, and GSM timings are single bounded passes. The existing Qwen3.8 non-thinking `17*23-19` response of 362 remains reproducible with and without MTP.

Runtime smoke check after the namespace update (2026-09-14): Qwen3.8-27B GGUF, XPU 6/7, TP=2, 3-step MTP launched with `SGL_XPU_MTP_GDN_VERIFY=1`. All 8 requests passed (1+1, strict JSON, marker, and 128-token number sequences at C1/C4). Both TP ranks logged entry into the ESIMD GDN target-verification path. One short wave measured 39.76 tok/s at C1 and 78.84 aggregate tok/s at C4, including prefill/TTFT; this is a smoke test, not a repeated performance benchmark. The test service was stopped and port 30000 was unchanged.
